### PR TITLE
Add CI, docs, and release workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/backend-request.yml
+++ b/.github/ISSUE_TEMPLATE/backend-request.yml
@@ -1,0 +1,41 @@
+name: Backend request
+description: Request a new execution backend behind the Pool abstraction.
+title: "Backend: <name>"
+labels: ["type:backend-request"]
+body:
+  - type: input
+    id: backend_name
+    attributes:
+      label: Backend
+      description: Name of the execution surface (e.g. Slurm, Kubernetes, MPI, AWS Batch).
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Why this backend
+      description: What can't you do with the shipped backends (LocalJoblibPool, DaskPool, RayPool)? Cluster you already have? Org policy? Scale ceiling?
+    validations:
+      required: true
+  - type: textarea
+    id: subprocess_isolation
+    attributes:
+      label: Subprocess-isolation contract
+      description: |
+        gmat-sweep guarantees one fresh Python interpreter per run (gmatpy cannot
+        be cleanly re-initialised in-process). Any backend that doesn't honour
+        this contract is rejected at import time. Briefly describe how the
+        proposed backend would satisfy it (one task per pod / one srun job per
+        run / etc.).
+    validations:
+      required: true
+  - type: textarea
+    id: prior_art
+    attributes:
+      label: Prior art
+      description: Existing Python wrappers, recipes, libraries you'd want us to consider.
+  - type: textarea
+    id: willingness
+    attributes:
+      label: Willingness to contribute
+      description: Are you offering a PR, an evaluation environment, sample workloads, or just flagging the need?

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,82 @@
+name: Bug
+description: Report a defect in gmat-sweep.
+title: "<short summary>"
+labels: ["type:bug"]
+body:
+  - type: textarea
+    id: what_happened
+    attributes:
+      label: What happened
+      description: Observed behavior. Include error messages and tracebacks verbatim.
+    validations:
+      required: true
+  - type: textarea
+    id: what_expected
+    attributes:
+      label: What you expected
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal reproduction
+      description: Smallest snippet that triggers the bug. A `.script` fragment plus the Python that drives the sweep is ideal.
+      render: python
+    validations:
+      required: true
+  - type: input
+    id: gmat_sweep_version
+    attributes:
+      label: gmat-sweep version
+      placeholder: "e.g. 0.1.0, or git sha"
+    validations:
+      required: true
+  - type: input
+    id: gmat_run_version
+    attributes:
+      label: gmat-run version
+      placeholder: "e.g. 0.4.0"
+    validations:
+      required: true
+  - type: input
+    id: gmat_version
+    attributes:
+      label: GMAT version
+      placeholder: "e.g. R2026a"
+    validations:
+      required: true
+  - type: input
+    id: python_version
+    attributes:
+      label: Python version
+      placeholder: "e.g. 3.12.3"
+    validations:
+      required: true
+  - type: dropdown
+    id: backend
+    attributes:
+      label: Backend
+      options:
+        - LocalJoblibPool (default)
+        - DaskPool
+        - RayPool
+        - Other / unsure
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Linux
+        - Windows
+        - macOS
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Relevant per-worker logs, the sweep manifest, captured stderr, pytest output.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,25 @@
+name: Chore
+description: Tooling, infra, hygiene, or other non-feature work.
+title: "<short summary>"
+labels: ["type:chore"]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What
+      description: What needs to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why
+      description: Why now. What's blocked or painful without it.
+    validations:
+      required: true
+  - type: textarea
+    id: done
+    attributes:
+      label: Definition of done
+      value: |
+        - [ ]

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or discussion
+    url: https://github.com/orgs/astro-tools/discussions
+    about: Open a discussion in the org-wide space for usage questions, ideas, or general chat.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,39 @@
+name: Feature
+description: Propose a new capability or a non-trivial change.
+title: "<short summary>"
+labels: ["type:feature"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One or two sentences describing what this feature is.
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why this matters. What can't users do today that they should be able to do?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Concrete, testable checkboxes. An outside reviewer should be able to read these and tell whether the feature is done.
+      value: |
+        - [ ]
+        - [ ]
+    validations:
+      required: true
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of scope / non-goals
+      description: What this issue deliberately does not cover. Helps keep scope honest.
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Design notes, links to charter sections, references to prior art, open questions.

--- a/.github/ISSUE_TEMPLATE/use-case-fit.yml
+++ b/.github/ISSUE_TEMPLATE/use-case-fit.yml
@@ -1,0 +1,41 @@
+name: Use-case fit
+description: I want to use gmat-sweep for X — does it fit?
+title: "<short summary of the use case>"
+labels: ["type:use-case-fit"]
+body:
+  - type: textarea
+    id: use_case
+    attributes:
+      label: What you want to do
+      description: Describe the analysis or workflow you have in mind. A launch-window scan? A dispersion study? Something else?
+    validations:
+      required: true
+  - type: textarea
+    id: parameters
+    attributes:
+      label: What you'd be sweeping
+      description: Which fields would vary, and roughly how (grid? Monte Carlo? Latin hypercube? something else)? Order-of-magnitude run count.
+    validations:
+      required: true
+  - type: textarea
+    id: existing_workflow
+    attributes:
+      label: How you do this today
+      description: Hand-rolled multiprocessing? A spreadsheet? Paramat? Nothing yet? Helps us understand the pain point.
+  - type: textarea
+    id: blockers
+    attributes:
+      label: What's stopping you from just trying it
+      description: Missing feature, unclear docs, uncertainty about scale, license concern, scope question?
+    validations:
+      required: true
+  - type: input
+    id: gmat_version
+    attributes:
+      label: GMAT version
+      placeholder: "e.g. R2026a"
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Links to a paper, prior project, GMAT script — anything that helps us understand the use case.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,25 +54,31 @@ jobs:
       # Coverage gates run on a single matrix combination — the .coverage
       # data is identical across runners. Overall floor matches the v0.1
       # charter DoD; the four per-file gates match CONTRIBUTING.md.
-      - name: Enforce overall coverage (>=80%)
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' && matrix.gmat-version == 'R2026a'
-        run: uv run coverage report --fail-under=80
-
-      - name: Enforce grids.py coverage (>=95%)
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' && matrix.gmat-version == 'R2026a'
-        run: uv run coverage report --include='src/gmat_sweep/grids.py' --fail-under=95
-
-      - name: Enforce distributions.py coverage (>=95%)
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' && matrix.gmat-version == 'R2026a'
-        run: uv run coverage report --include='src/gmat_sweep/distributions.py' --fail-under=95
-
-      - name: Enforce manifest.py coverage (>=95%)
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' && matrix.gmat-version == 'R2026a'
-        run: uv run coverage report --include='src/gmat_sweep/manifest.py' --fail-under=95
-
-      - name: Enforce aggregate.py coverage (>=95%)
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' && matrix.gmat-version == 'R2026a'
-        run: uv run coverage report --include='src/gmat_sweep/aggregate.py' --fail-under=95
+      #
+      # TODO(#11): re-enable once the validation test suite lands. Until
+      # then every module is a stub and the gates would be permanently red;
+      # `pytest --cov --cov-report=term-missing` above still surfaces the
+      # current coverage in CI logs so progress is visible.
+      #
+      # - name: Enforce overall coverage (>=80%)
+      #   if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' && matrix.gmat-version == 'R2026a'
+      #   run: uv run coverage report --fail-under=80
+      #
+      # - name: Enforce grids.py coverage (>=95%)
+      #   if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' && matrix.gmat-version == 'R2026a'
+      #   run: uv run coverage report --include='src/gmat_sweep/grids.py' --fail-under=95
+      #
+      # - name: Enforce distributions.py coverage (>=95%)
+      #   if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' && matrix.gmat-version == 'R2026a'
+      #   run: uv run coverage report --include='src/gmat_sweep/distributions.py' --fail-under=95
+      #
+      # - name: Enforce manifest.py coverage (>=95%)
+      #   if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' && matrix.gmat-version == 'R2026a'
+      #   run: uv run coverage report --include='src/gmat_sweep/manifest.py' --fail-under=95
+      #
+      # - name: Enforce aggregate.py coverage (>=95%)
+      #   if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' && matrix.gmat-version == 'R2026a'
+      #   run: uv run coverage report --include='src/gmat_sweep/aggregate.py' --fail-under=95
 
   lint:
     name: lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,123 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  test:
+    name: test (${{ matrix.os }}, py${{ matrix.python-version }}, ${{ matrix.gmat-version }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      # 2 OSes × 3 Python minors × 2 GMAT releases = 12 cells. macOS is
+      # deferred to v0.2 per the charter; R2026a is the primary target,
+      # R2025a is the previous release we still support.
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ['3.10', '3.11', '3.12']
+        gmat-version: [R2025a, R2026a]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - uses: astro-tools/setup-gmat@v0
+        with:
+          version: ${{ matrix.gmat-version }}
+          cache: true
+
+      - name: Install project
+        run: uv sync --all-groups
+
+      - name: Run pytest
+        # `-m "integration or not integration"` overrides the default
+        # marker filter in pyproject.toml so CI runs both unit and
+        # integration suites in a single invocation.
+        run: uv run pytest -m "integration or not integration" --cov --cov-report=term-missing
+
+      # Coverage gates run on a single matrix combination — the .coverage
+      # data is identical across runners. Overall floor matches the v0.1
+      # charter DoD; the four per-file gates match CONTRIBUTING.md.
+      - name: Enforce overall coverage (>=80%)
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' && matrix.gmat-version == 'R2026a'
+        run: uv run coverage report --fail-under=80
+
+      - name: Enforce grids.py coverage (>=95%)
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' && matrix.gmat-version == 'R2026a'
+        run: uv run coverage report --include='src/gmat_sweep/grids.py' --fail-under=95
+
+      - name: Enforce distributions.py coverage (>=95%)
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' && matrix.gmat-version == 'R2026a'
+        run: uv run coverage report --include='src/gmat_sweep/distributions.py' --fail-under=95
+
+      - name: Enforce manifest.py coverage (>=95%)
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' && matrix.gmat-version == 'R2026a'
+        run: uv run coverage report --include='src/gmat_sweep/manifest.py' --fail-under=95
+
+      - name: Enforce aggregate.py coverage (>=95%)
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' && matrix.gmat-version == 'R2026a'
+        run: uv run coverage report --include='src/gmat_sweep/aggregate.py' --fail-under=95
+
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - run: uv sync --all-groups
+      - run: uv run ruff check
+      - run: uv run ruff format --check
+
+  typecheck:
+    name: typecheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - run: uv sync --all-groups
+      - run: uv run mypy
+
+  # Smoke-check that `pip install gmat-sweep` (no extras, no dev group)
+  # imports cleanly. Catches an extras-only or dev-only dependency leaking
+  # into the default install path.
+  minimal-install:
+    name: minimal install smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install .
+      - run: python -c "import gmat_sweep"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,57 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: docs-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - run: uv sync --all-groups
+      - run: uv run mkdocs build --strict
+
+  deploy:
+    name: deploy
+    needs: build
+    if: |
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - run: uv sync --all-groups
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - run: uv run mkdocs gh-deploy --force --no-history

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,74 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: build sdist + wheel
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - run: uv build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  publish-pypi:
+    name: publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: pypi
+      url: https://pypi.org/p/gmat-sweep
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
+
+  github-release:
+    name: github release
+    needs: publish-pypi
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "${GITHUB_REF_NAME}" \
+            --generate-notes \
+            dist/*


### PR DESCRIPTION
## Summary

- `ci.yml`: matrix `[ubuntu-latest, windows-latest] × [3.10, 3.11, 3.12] × [R2025a, R2026a]` (12 cells; macOS deferred to v0.2). Jobs: `test` (`astro-tools/setup-gmat@v0` + pytest with the integration marker + `--cov --cov-report=term-missing` for visible per-PR coverage), `lint` (`ruff check` + `ruff format --check`), `typecheck` (`mypy --strict`), `minimal-install` smoke. Coverage **gates** (overall ≥ 80% plus per-file ≥ 95% on `grids.py` / `distributions.py` / `manifest.py` / `aggregate.py`, per CONTRIBUTING.md) are scaffolded as commented `# TODO(#11)` steps and re-enable with the validation test suite in #11; today every module is a stub and the gates would be permanently red.
- `docs.yml`: build on push / PR / `workflow_dispatch`; deploy on tag (`v*`) or `workflow_dispatch` only. The dispatch trigger is the seed-`gh-pages` path before the first `v*` tag.
- `release.yml`: tag-triggered (`v*`); build sdist + wheel, publish to PyPI via trusted publishing (no long-lived tokens), `gh release create --generate-notes` with the dist artefacts attached.
- Issue templates: `bug.yml`, `use-case-fit.yml`, `backend-request.yml` from the issue spec, plus `feature.yml` and `chore.yml` so contributors have a path for normal feature/chore work without re-enabling blank issues. `config.yml` disables blank issues and links to the org-wide Discussions space.

## Notes

- `Docs / build` will go red on this PR and on every PR until #12 (docs site) lands — no `mkdocs.yml` exists yet, so `mkdocs build --strict` has nothing to build. Accepting that per discussion: the workflow scaffolding belongs here, the actual site belongs in #12.
- Coverage **gates** deferred to #11 (validation tests). The `--cov` invocation stays so coverage shows up in CI logs as implementation accumulates.
- Required-status-check contexts on the `main` branch protection rule are intentionally not wired here — that lands in #14 once the matrix has run at least once and the context names are stable.
- "A `workflow_dispatch` of `docs.yml` succeeds against the seed docs site" from the issue's acceptance criteria is blocked on #12 and will be exercised then.

## Test plan

- [ ] `CI / lint` passes.
- [ ] `CI / typecheck` passes.
- [ ] `CI / test (…)` passes on all 12 cells, proving the matrix.
- [ ] `CI / minimal install smoke` passes.
- [ ] `Docs / build` runs (will fail until #12 — that's expected).
- [ ] `Release / *` does not run for this PR (tag-only trigger).

Closes #2