### PR TITLE
Add typed error hierarchy and run/sweep specs

### DIFF
--- a/src/gmat_sweep/__init__.py
+++ b/src/gmat_sweep/__init__.py
@@ -2,9 +2,28 @@
 
 from importlib.metadata import PackageNotFoundError, version
 
+from gmat_sweep.errors import (
+    BackendError,
+    GmatSweepError,
+    ManifestCorruptError,
+    RunFailed,
+    SweepConfigError,
+)
+from gmat_sweep.spec import RunOutcome, RunSpec, SweepSpec
+
 try:
     __version__ = version("gmat-sweep")
 except PackageNotFoundError:
     __version__ = "0.0.0"
 
-__all__ = ["__version__"]
+__all__ = [
+    "BackendError",
+    "GmatSweepError",
+    "ManifestCorruptError",
+    "RunFailed",
+    "RunOutcome",
+    "RunSpec",
+    "SweepConfigError",
+    "SweepSpec",
+    "__version__",
+]

--- a/src/gmat_sweep/errors.py
+++ b/src/gmat_sweep/errors.py
@@ -1,3 +1,76 @@
-"""Typed exception hierarchy so downstream code can branch on failure mode."""
+"""Typed exception hierarchy so downstream code can branch on failure mode.
+
+Every exception gmat-sweep raises inherits from :class:`GmatSweepError`. Leaf
+classes carry payload relevant to their failure mode as named attributes
+(:attr:`RunFailed.run_id`, :attr:`ManifestCorruptError.path`) rather than
+only as the formatted message — pattern-matching downstream code can read
+the attribute without re-parsing the string.
+
+:class:`RunFailed` is mostly a typed sentinel for tests and for callers
+that opt into raise-on-failure behaviour. The default worker contract
+(see issue #6) converts per-run failures into a
+:class:`gmat_sweep.spec.RunOutcome` with ``status="failed"`` so a single
+bad run does not abort the parent sweep.
+"""
 
 from __future__ import annotations
+
+from pathlib import Path
+
+__all__ = [
+    "BackendError",
+    "GmatSweepError",
+    "ManifestCorruptError",
+    "RunFailed",
+    "SweepConfigError",
+]
+
+
+class GmatSweepError(Exception):
+    """Base class for every exception raised by gmat-sweep."""
+
+
+class SweepConfigError(GmatSweepError):
+    """Raised when a sweep configuration is invalid before any run starts.
+
+    Covers contradictory arguments, malformed grid specs, and dotted-path
+    overrides that fail validation at sweep-construction time. The message
+    is the only payload.
+    """
+
+
+class RunFailed(GmatSweepError):
+    """Raised when a single run fails inside a worker (raise-on-failure mode).
+
+    Per the gmat-sweep contract a failed run normally lands as a labelled
+    row in the parent DataFrame rather than an exception, so this class
+    is a typed sentinel for tests and for callers that opt into eager
+    failure. The ``run_id`` attribute identifies the offending run;
+    ``stderr`` carries the captured worker stderr or Python traceback.
+    """
+
+    def __init__(self, message: str, run_id: int, stderr: str | None = None) -> None:
+        self.run_id = run_id
+        self.stderr = stderr
+        super().__init__(message)
+
+
+class BackendError(GmatSweepError):
+    """Raised when an execution backend itself fails.
+
+    Covers worker-pool initialisation failures, lost workers, and backend
+    implementations that violate the subprocess-isolation contract
+    enforced by the :class:`Pool` ABC.
+    """
+
+
+class ManifestCorruptError(GmatSweepError):
+    """Raised when a sweep manifest cannot be parsed.
+
+    The ``path`` attribute points at the offending file so callers can
+    surface it in error messages without re-deriving the path.
+    """
+
+    def __init__(self, message: str, path: Path) -> None:
+        self.path = path
+        super().__init__(message)

--- a/src/gmat_sweep/spec.py
+++ b/src/gmat_sweep/spec.py
@@ -1,3 +1,197 @@
-"""Run/sweep specs and outcomes — JSON-serialisable units of work crossing the worker boundary."""
+"""Run/sweep specs and outcomes — JSON-serialisable units of work crossing the worker boundary.
+
+These three dataclasses are the only objects that travel between the
+driver process and worker subprocesses. They are
+:func:`dataclasses.dataclass` ``frozen=True, slots=True`` so they cannot
+accidentally mutate after handoff; ``frozen`` does not deep-freeze the
+dict-typed fields, but it pins the field references and the serialised
+shape.
+
+Each class exposes a paired :meth:`to_dict` / :meth:`from_dict` for JSON
+encoding. :class:`pathlib.Path` is coerced to ``str``; :class:`datetime`
+to ISO-8601 via :meth:`datetime.isoformat`. Values inside ``overrides``,
+``run_options``, ``backend_kwargs``, and ``output_paths`` must already be
+JSON-encodable (no numpy scalars) — gmat-run handles numpy on the
+:meth:`Mission.__setitem__` write side, but the spec is the
+serialisation boundary.
+
+``json.dumps(spec.to_dict(), sort_keys=True)`` is the canonical
+"bit-equal" comparator across a serialise → deserialise → serialise
+cycle.
+"""
 
 from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Literal, cast
+
+__all__ = ["RunOutcome", "RunSpec", "RunStatus", "SweepSpec"]
+
+
+RunStatus = Literal["ok", "failed", "skipped"]
+
+
+@dataclass(frozen=True, slots=True)
+class RunSpec:
+    """A single run's worth of work — script + overrides + run_id + seed.
+
+    A worker reconstructs the full run from this record alone:
+    instantiate :class:`gmat_run.Mission` from ``script_path``, apply
+    ``overrides`` via the dotted-path setter, run with ``run_options``,
+    write outputs under ``output_dir``.
+    """
+
+    script_path: Path
+    overrides: dict[str, Any]
+    output_dir: Path
+    run_id: int
+    seed: int | None
+    run_options: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "script_path": str(self.script_path),
+            "overrides": dict(self.overrides),
+            "output_dir": str(self.output_dir),
+            "run_id": self.run_id,
+            "seed": self.seed,
+            "run_options": dict(self.run_options),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RunSpec:
+        return cls(
+            script_path=Path(data["script_path"]),
+            overrides=dict(data["overrides"]),
+            output_dir=Path(data["output_dir"]),
+            run_id=int(data["run_id"]),
+            seed=None if data["seed"] is None else int(data["seed"]),
+            run_options=dict(data["run_options"]),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SweepSpec:
+    """A whole sweep's metadata — script, runs, backend, outputs.
+
+    ``runs`` is a materialised :class:`tuple` of :class:`RunSpec` so the
+    spec round-trips through JSON cleanly. ``run_id`` ordering is the
+    contract the manifest and resume flow depend on: ``runs[i].run_id ==
+    i`` for every well-formed sweep.
+    """
+
+    mission_script_path: Path
+    runs: tuple[RunSpec, ...]
+    backend: str
+    backend_kwargs: dict[str, Any]
+    output_dir: Path
+    manifest_path: Path
+    sweep_seed: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "mission_script_path": str(self.mission_script_path),
+            "runs": [r.to_dict() for r in self.runs],
+            "backend": self.backend,
+            "backend_kwargs": dict(self.backend_kwargs),
+            "output_dir": str(self.output_dir),
+            "manifest_path": str(self.manifest_path),
+            "sweep_seed": self.sweep_seed,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SweepSpec:
+        return cls(
+            mission_script_path=Path(data["mission_script_path"]),
+            runs=tuple(RunSpec.from_dict(r) for r in data["runs"]),
+            backend=str(data["backend"]),
+            backend_kwargs=dict(data["backend_kwargs"]),
+            output_dir=Path(data["output_dir"]),
+            manifest_path=Path(data["manifest_path"]),
+            sweep_seed=None if data["sweep_seed"] is None else int(data["sweep_seed"]),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RunOutcome:
+    """The result of one run after the worker returns.
+
+    ``output_paths`` maps a worker-chosen key (e.g. the parsed
+    ReportFile resource name) to the on-disk Parquet artefact written
+    under :attr:`RunSpec.output_dir`. Empty for failed and skipped runs.
+    ``stderr`` is ``None`` for successful runs and the captured worker
+    stderr / traceback string for failed runs. ``duration_s`` is computed
+    by the :meth:`ok` / :meth:`failed` helpers from the bookend timestamps
+    so the three values cannot disagree.
+    """
+
+    run_id: int
+    status: RunStatus
+    output_paths: dict[str, Path]
+    duration_s: float
+    stderr: str | None
+    started_at: datetime
+    ended_at: datetime
+
+    @classmethod
+    def ok(
+        cls,
+        *,
+        run_id: int,
+        output_paths: dict[str, Path],
+        started_at: datetime,
+        ended_at: datetime,
+    ) -> RunOutcome:
+        return cls(
+            run_id=run_id,
+            status="ok",
+            output_paths=dict(output_paths),
+            duration_s=(ended_at - started_at).total_seconds(),
+            stderr=None,
+            started_at=started_at,
+            ended_at=ended_at,
+        )
+
+    @classmethod
+    def failed(
+        cls,
+        *,
+        run_id: int,
+        stderr: str,
+        started_at: datetime,
+        ended_at: datetime,
+    ) -> RunOutcome:
+        return cls(
+            run_id=run_id,
+            status="failed",
+            output_paths={},
+            duration_s=(ended_at - started_at).total_seconds(),
+            stderr=stderr,
+            started_at=started_at,
+            ended_at=ended_at,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "status": self.status,
+            "output_paths": {k: str(v) for k, v in self.output_paths.items()},
+            "duration_s": self.duration_s,
+            "stderr": self.stderr,
+            "started_at": self.started_at.isoformat(),
+            "ended_at": self.ended_at.isoformat(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RunOutcome:
+        return cls(
+            run_id=int(data["run_id"]),
+            status=cast(RunStatus, data["status"]),
+            output_paths={k: Path(v) for k, v in data["output_paths"].items()},
+            duration_s=float(data["duration_s"]),
+            stderr=None if data["stderr"] is None else str(data["stderr"]),
+            started_at=datetime.fromisoformat(data["started_at"]),
+            ended_at=datetime.fromisoformat(data["ended_at"]),
+        )

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,53 @@
+"""Tests for gmat_sweep.errors — typed exception hierarchy."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gmat_sweep.errors import (
+    BackendError,
+    GmatSweepError,
+    ManifestCorruptError,
+    RunFailed,
+    SweepConfigError,
+)
+
+
+def test_root_class_subclasses_exception() -> None:
+    assert issubclass(GmatSweepError, Exception)
+
+
+@pytest.mark.parametrize(
+    "cls",
+    [SweepConfigError, RunFailed, BackendError, ManifestCorruptError],
+)
+def test_every_leaf_is_a_gmat_sweep_error(cls: type[GmatSweepError]) -> None:
+    assert issubclass(cls, GmatSweepError)
+
+
+@pytest.mark.parametrize("cls", [SweepConfigError, BackendError])
+def test_plain_message_classes_carry_only_a_message(cls: type[GmatSweepError]) -> None:
+    exc = cls("nope")
+    assert isinstance(exc, GmatSweepError)
+    assert str(exc) == "nope"
+
+
+def test_run_failed_carries_run_id_and_stderr() -> None:
+    exc = RunFailed("worker died", run_id=7, stderr="Traceback (most recent call last)…")
+    assert exc.run_id == 7
+    assert exc.stderr == "Traceback (most recent call last)…"
+    assert str(exc) == "worker died"
+
+
+def test_run_failed_stderr_defaults_to_none() -> None:
+    exc = RunFailed("worker died", run_id=0)
+    assert exc.stderr is None
+
+
+def test_manifest_corrupt_carries_path() -> None:
+    p = Path("/tmp/manifest.json")
+    exc = ManifestCorruptError("invalid json at byte 42", p)
+    assert exc.path == p
+    assert str(exc) == "invalid json at byte 42"

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -1,0 +1,171 @@
+"""Tests for gmat_sweep.spec — RunSpec / SweepSpec / RunOutcome and JSON round-trip."""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from gmat_sweep.spec import RunOutcome, RunSpec, SweepSpec
+
+
+def _utc(year: int, month: int, day: int, h: int = 0, m: int = 0, s: int = 0) -> datetime:
+    return datetime(year, month, day, h, m, s, tzinfo=timezone.utc)
+
+
+def _make_run_spec(run_id: int = 0) -> RunSpec:
+    return RunSpec(
+        script_path=Path("/missions/flyby.script"),
+        overrides={"Sat.SMA": 7000.0, "Sat.ECC": 0.001},
+        output_dir=Path(f"/sweep-out/run-{run_id}"),
+        run_id=run_id,
+        seed=42,
+        run_options={"overwrite": True},
+    )
+
+
+def _make_sweep_spec(n: int = 3) -> SweepSpec:
+    return SweepSpec(
+        mission_script_path=Path("/missions/flyby.script"),
+        runs=tuple(_make_run_spec(i) for i in range(n)),
+        backend="joblib",
+        backend_kwargs={"n_jobs": 4},
+        output_dir=Path("/sweep-out"),
+        manifest_path=Path("/sweep-out/manifest.json"),
+        sweep_seed=1729,
+    )
+
+
+# ---- RunSpec --------------------------------------------------------------
+
+
+def test_run_spec_is_frozen() -> None:
+    spec = _make_run_spec()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        spec.run_id = 99  # type: ignore[misc]
+
+
+def test_run_spec_round_trips_through_json() -> None:
+    original = _make_run_spec(run_id=5)
+    serialised = json.dumps(original.to_dict(), sort_keys=True)
+    restored = RunSpec.from_dict(json.loads(serialised))
+    assert restored == original
+    # Bit-equal across a re-serialise.
+    assert json.dumps(restored.to_dict(), sort_keys=True) == serialised
+
+
+def test_run_spec_seed_none_round_trips() -> None:
+    spec = dataclasses.replace(_make_run_spec(), seed=None)
+    restored = RunSpec.from_dict(json.loads(json.dumps(spec.to_dict())))
+    assert restored.seed is None
+    assert restored == spec
+
+
+# ---- SweepSpec ------------------------------------------------------------
+
+
+def test_sweep_spec_round_trips_with_runs() -> None:
+    original = _make_sweep_spec(n=5)
+    serialised = json.dumps(original.to_dict(), sort_keys=True)
+    restored = SweepSpec.from_dict(json.loads(serialised))
+    assert restored == original
+    assert json.dumps(restored.to_dict(), sort_keys=True) == serialised
+    # The contract the manifest and resume flow depend on: run_id == index.
+    assert tuple(r.run_id for r in restored.runs) == tuple(range(5))
+
+
+def test_sweep_spec_default_seed_is_none_and_round_trips() -> None:
+    spec = SweepSpec(
+        mission_script_path=Path("/m.script"),
+        runs=(),
+        backend="joblib",
+        backend_kwargs={},
+        output_dir=Path("/o"),
+        manifest_path=Path("/o/manifest.json"),
+    )
+    assert spec.sweep_seed is None
+    restored = SweepSpec.from_dict(json.loads(json.dumps(spec.to_dict())))
+    assert restored == spec
+
+
+# ---- RunOutcome -----------------------------------------------------------
+
+
+def test_run_outcome_ok_helper_sets_status_and_clears_stderr() -> None:
+    started = _utc(2026, 5, 4, 0, 0, 0)
+    ended = _utc(2026, 5, 4, 0, 0, 12)
+    out = RunOutcome.ok(
+        run_id=2,
+        output_paths={"ReportFile1": Path("/o/run-2/r1.parquet")},
+        started_at=started,
+        ended_at=ended,
+    )
+    assert out.status == "ok"
+    assert out.stderr is None
+    assert out.duration_s == 12.0
+    assert out.output_paths == {"ReportFile1": Path("/o/run-2/r1.parquet")}
+
+
+def test_run_outcome_failed_helper_captures_stderr_and_empty_outputs() -> None:
+    started = _utc(2026, 5, 4, 0, 0, 0)
+    ended = _utc(2026, 5, 4, 0, 0, 5)
+    out = RunOutcome.failed(
+        run_id=4,
+        stderr="GMAT exploded",
+        started_at=started,
+        ended_at=ended,
+    )
+    assert out.status == "failed"
+    assert out.stderr == "GMAT exploded"
+    assert out.duration_s == 5.0
+    assert out.output_paths == {}
+
+
+def test_run_outcome_ok_round_trips_paths_and_timestamps() -> None:
+    started = _utc(2026, 5, 4, 0, 0, 0)
+    ended = _utc(2026, 5, 4, 0, 1, 30)
+    original = RunOutcome.ok(
+        run_id=11,
+        output_paths={
+            "ReportFile1": Path("/o/r1.parquet"),
+            "EphemerisFile1": Path("/o/eph.parquet"),
+        },
+        started_at=started,
+        ended_at=ended,
+    )
+    restored = RunOutcome.from_dict(json.loads(json.dumps(original.to_dict())))
+    assert restored == original
+    assert restored.duration_s == 90.0
+
+
+def test_run_outcome_failed_round_trips_with_stderr() -> None:
+    started = _utc(2026, 5, 4, 0, 0, 0)
+    ended = _utc(2026, 5, 4, 0, 0, 5)
+    original = RunOutcome.failed(
+        run_id=4,
+        stderr="GMAT exploded",
+        started_at=started,
+        ended_at=ended,
+    )
+    restored = RunOutcome.from_dict(json.loads(json.dumps(original.to_dict())))
+    assert restored == original
+    assert restored.stderr == "GMAT exploded"
+
+
+def test_run_outcome_skipped_constructed_directly_round_trips() -> None:
+    moment = _utc(2026, 5, 4, 0, 0, 0)
+    skipped = RunOutcome(
+        run_id=8,
+        status="skipped",
+        output_paths={},
+        duration_s=0.0,
+        stderr=None,
+        started_at=moment,
+        ended_at=moment,
+    )
+    restored = RunOutcome.from_dict(json.loads(json.dumps(skipped.to_dict())))
+    assert restored == skipped
+    assert restored.status == "skipped"


### PR DESCRIPTION
## Summary

- `gmat_sweep/errors.py`: `GmatSweepError` root + `SweepConfigError`, `RunFailed(run_id, stderr)`, `BackendError`, `ManifestCorruptError(path)`.
- `gmat_sweep/spec.py`: `RunSpec`, `SweepSpec`, `RunOutcome` — all `frozen=True, slots=True`. Paired `to_dict` / `from_dict` give a JSON-encodable representation: `Path` ⇄ `str`, `datetime` ⇄ `isoformat`. `RunOutcome.ok(...)` / `RunOutcome.failed(...)` classmethod helpers compute `duration_s` from the bookend timestamps so the three values cannot disagree.
- `SweepSpec.runs` is a materialised `tuple[RunSpec, ...]` for v0.1 (full-factorial grids are finite); the `run_id == index` contract is asserted in tests and is what the manifest / resume flow in #5 will depend on.
- `__init__.py` re-exports the eight new public names so users can `from gmat_sweep import RunSpec, RunOutcome, SweepConfigError`.

## Test plan

- [x] `uv run pytest --cov` — 21 passing.
- [x] `uv run coverage report --include='src/gmat_sweep/errors.py' --fail-under=100` — 100%.
- [x] `uv run coverage report --include='src/gmat_sweep/spec.py' --fail-under=100` — 100%.
- [x] `uv run ruff check` — clean.
- [x] `uv run ruff format --check` — clean.
- [x] `uv run mypy` — clean across 19 source files.
- [ ] CI matches the local results across the 12-cell matrix.

Closes #3