### PR TITLE
Add full-factorial grid expansion

### DIFF
--- a/src/gmat_sweep/__init__.py
+++ b/src/gmat_sweep/__init__.py
@@ -9,6 +9,7 @@ from gmat_sweep.errors import (
     RunFailed,
     SweepConfigError,
 )
+from gmat_sweep.grids import expand_grid_to_run_specs, full_factorial
 from gmat_sweep.spec import RunOutcome, RunSpec, SweepSpec
 
 try:
@@ -26,4 +27,6 @@ __all__ = [
     "SweepConfigError",
     "SweepSpec",
     "__version__",
+    "expand_grid_to_run_specs",
+    "full_factorial",
 ]

--- a/src/gmat_sweep/grids.py
+++ b/src/gmat_sweep/grids.py
@@ -59,13 +59,13 @@ def full_factorial(grid: Mapping[str, Iterable[Any]]) -> Iterator[dict[str, Any]
 
 def expand_grid_to_run_specs(
     grid: Mapping[str, Iterable[Any]],
-    mission: str | Path,
+    script_path: str | Path,
     output_dir: str | Path,
 ) -> list[RunSpec]:
     """Build a list of :class:`RunSpec` from a full-factorial expansion of ``grid``.
 
-    Each spec gets a sequential ``run_id`` starting at 0, ``script_path`` set
-    to ``mission``, ``output_dir`` set to ``<output_dir>/run-<run_id>``,
+    Each spec gets a sequential ``run_id`` starting at 0, ``script_path``
+    propagated through, ``output_dir`` set to ``<output_dir>/run-<run_id>``,
     ``seed=None``, and ``run_options={}``. The ordering contract from
     :func:`full_factorial` carries through unchanged: ``specs[i].run_id == i``
     and the override dicts appear in cartesian-product order.
@@ -73,11 +73,11 @@ def expand_grid_to_run_specs(
     Raises :class:`SweepConfigError` for the same reasons as
     :func:`full_factorial`.
     """
-    mission_path = Path(mission)
+    script_path_obj = Path(script_path)
     base_output_dir = Path(output_dir)
     return [
         RunSpec(
-            script_path=mission_path,
+            script_path=script_path_obj,
             overrides=overrides,
             output_dir=base_output_dir / f"run-{run_id}",
             run_id=run_id,

--- a/src/gmat_sweep/grids.py
+++ b/src/gmat_sweep/grids.py
@@ -1,3 +1,88 @@
-"""Full-factorial, explicit-row, Latin hypercube, and quasi-Monte-Carlo run generators."""
+"""Full-factorial, explicit-row, Latin hypercube, and quasi-Monte-Carlo run generators.
+
+v0.1 ships the full-factorial generator only; explicit-row and Latin hypercube
+land in v0.2.
+
+The output of :func:`full_factorial` is byte-for-byte deterministic: keys are
+emitted in sorted (lexicographic) order and combinations enumerate in
+:func:`itertools.product` order over the materialised input iterables. This is
+the determinism guarantee the manifest and resume flow rely on — two runs
+serialised through JSON with ``sort_keys=True`` produce identical bytes,
+across processes and across machines.
+"""
 
 from __future__ import annotations
+
+from collections.abc import Iterable, Iterator, Mapping
+from itertools import product
+from pathlib import Path
+from typing import Any
+
+from gmat_sweep.errors import SweepConfigError
+from gmat_sweep.spec import RunSpec
+
+__all__ = ["expand_grid_to_run_specs", "full_factorial"]
+
+
+def full_factorial(grid: Mapping[str, Iterable[Any]]) -> Iterator[dict[str, Any]]:
+    """Yield override dicts for the cartesian product of ``grid``.
+
+    Keys are emitted in lexicographic order; the cartesian product enumerates
+    in :func:`itertools.product` order over the input iterables, so the outer
+    loop varies the lexicographically-first key slowest and the last key
+    fastest. For ``{"a": [1, 2], "b": [10, 20, 30]}`` the six dicts come out as
+    ``(a=1, b=10), (a=1, b=20), (a=1, b=30), (a=2, b=10), (a=2, b=20),
+    (a=2, b=30)``.
+
+    Each input iterable is materialised once at entry so callers may pass
+    generators without surprising exhaustion and so empty-iterable validation
+    can run before the cartesian product begins.
+
+    An empty mapping is valid and yields a single empty override dict — the
+    cartesian product of nothing has one element.
+
+    Raises :class:`SweepConfigError` if any key is not a :class:`str` or any
+    value materialises to an empty sequence.
+    """
+    materialised: dict[str, tuple[Any, ...]] = {}
+    for key, values in grid.items():
+        if not isinstance(key, str):
+            raise SweepConfigError(f"grid keys must be strings, got {type(key).__name__}: {key!r}")
+        materialised[key] = tuple(values)
+        if not materialised[key]:
+            raise SweepConfigError(f"grid value for {key!r} is empty")
+
+    sorted_keys = sorted(materialised)
+    for combo in product(*(materialised[k] for k in sorted_keys)):
+        yield dict(zip(sorted_keys, combo, strict=True))
+
+
+def expand_grid_to_run_specs(
+    grid: Mapping[str, Iterable[Any]],
+    mission: str | Path,
+    output_dir: str | Path,
+) -> list[RunSpec]:
+    """Build a list of :class:`RunSpec` from a full-factorial expansion of ``grid``.
+
+    Each spec gets a sequential ``run_id`` starting at 0, ``script_path`` set
+    to ``mission``, ``output_dir`` set to ``<output_dir>/run-<run_id>``,
+    ``seed=None``, and ``run_options={}``. The ordering contract from
+    :func:`full_factorial` carries through unchanged: ``specs[i].run_id == i``
+    and the override dicts appear in cartesian-product order.
+
+    Raises :class:`SweepConfigError` for the same reasons as
+    :func:`full_factorial`.
+    """
+    mission_path = Path(mission)
+    base_output_dir = Path(output_dir)
+    return [
+        RunSpec(
+            script_path=mission_path,
+            overrides=overrides,
+            output_dir=base_output_dir / f"run-{run_id}",
+            run_id=run_id,
+            seed=None,
+            run_options={},
+        )
+        for run_id, overrides in enumerate(full_factorial(grid))
+    ]

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -1,0 +1,188 @@
+"""Tests for gmat_sweep.grids — full-factorial cartesian-product expansion."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gmat_sweep.errors import SweepConfigError
+from gmat_sweep.grids import expand_grid_to_run_specs, full_factorial
+from gmat_sweep.spec import RunSpec
+
+# ---- full_factorial -------------------------------------------------------
+
+
+def test_acceptance_example_six_specs_in_documented_order() -> None:
+    grid = {"a": [1, 2], "b": [10, 20, 30]}
+    expected = [
+        {"a": 1, "b": 10},
+        {"a": 1, "b": 20},
+        {"a": 1, "b": 30},
+        {"a": 2, "b": 10},
+        {"a": 2, "b": 20},
+        {"a": 2, "b": 30},
+    ]
+    assert list(full_factorial(grid)) == expected
+
+
+def test_keys_emit_in_lexicographic_order_regardless_of_input_order() -> None:
+    # Insertion order is reversed; output should still be a-then-b.
+    grid = {"b": [10, 20], "a": [1, 2]}
+    out = list(full_factorial(grid))
+    for d in out:
+        assert list(d.keys()) == ["a", "b"]
+    # And the lex-first key ("a") varies slowest.
+    assert [d["a"] for d in out] == [1, 1, 2, 2]
+    assert [d["b"] for d in out] == [10, 20, 10, 20]
+
+
+def test_single_key_grid() -> None:
+    assert list(full_factorial({"x": [1, 2, 3]})) == [{"x": 1}, {"x": 2}, {"x": 3}]
+
+
+def test_three_keys_lexicographic_and_product_order() -> None:
+    grid: dict[str, list[Any]] = {"c": ["x"], "a": [1, 2], "b": [10, 20]}
+    out = list(full_factorial(grid))
+    assert out == [
+        {"a": 1, "b": 10, "c": "x"},
+        {"a": 1, "b": 20, "c": "x"},
+        {"a": 2, "b": 10, "c": "x"},
+        {"a": 2, "b": 20, "c": "x"},
+    ]
+
+
+def test_empty_mapping_yields_one_empty_dict() -> None:
+    assert list(full_factorial({})) == [{}]
+
+
+def test_generator_input_is_materialised_and_not_exhausted() -> None:
+    def values() -> Any:
+        yield 1
+        yield 2
+
+    grid = {"a": values(), "b": [10, 20]}
+    # Iterating twice on the *result* is fine — generators on the input were
+    # materialised at entry, not held by reference.
+    first = list(full_factorial(grid))
+    assert first == [
+        {"a": 1, "b": 10},
+        {"a": 1, "b": 20},
+        {"a": 2, "b": 10},
+        {"a": 2, "b": 20},
+    ]
+
+
+def test_non_string_key_raises_sweep_config_error() -> None:
+    with pytest.raises(SweepConfigError, match="grid keys must be strings"):
+        list(full_factorial({1: [1, 2]}))  # type: ignore[dict-item]
+
+
+def test_empty_iterable_value_raises_sweep_config_error() -> None:
+    with pytest.raises(SweepConfigError, match="grid value for 'a' is empty"):
+        list(full_factorial({"a": []}))
+
+
+def test_empty_generator_value_raises_sweep_config_error() -> None:
+    def empty() -> Any:
+        return
+        yield  # pragma: no cover - unreachable, marks the function as a generator
+
+    with pytest.raises(SweepConfigError, match="grid value for 'a' is empty"):
+        list(full_factorial({"a": empty()}))
+
+
+def test_validation_runs_before_any_combination_is_yielded() -> None:
+    # Even though "a" is well-formed and would normally produce 2 dicts, the
+    # bad "b" entry should abort the whole call before anything is emitted.
+    it = full_factorial({"a": [1, 2], "b": []})
+    with pytest.raises(SweepConfigError):
+        next(it)
+
+
+def test_output_is_byte_for_byte_deterministic_across_calls() -> None:
+    grid = {"a": [1, 2], "b": [10, 20, 30]}
+    a = json.dumps(list(full_factorial(grid)), sort_keys=True)
+    b = json.dumps(list(full_factorial(grid)), sort_keys=True)
+    assert a == b
+
+
+# ---- expand_grid_to_run_specs --------------------------------------------
+
+
+def test_expand_produces_sequential_run_ids_and_full_factorial_order() -> None:
+    specs = expand_grid_to_run_specs(
+        grid={"a": [1, 2], "b": [10, 20, 30]},
+        mission="/missions/flyby.script",
+        output_dir="/sweep-out",
+    )
+    assert tuple(s.run_id for s in specs) == (0, 1, 2, 3, 4, 5)
+    assert [s.overrides for s in specs] == [
+        {"a": 1, "b": 10},
+        {"a": 1, "b": 20},
+        {"a": 1, "b": 30},
+        {"a": 2, "b": 10},
+        {"a": 2, "b": 20},
+        {"a": 2, "b": 30},
+    ]
+
+
+def test_expand_packs_script_path_output_dir_seed_and_run_options() -> None:
+    specs = expand_grid_to_run_specs(
+        grid={"x": [7, 8]},
+        mission=Path("/missions/m.script"),
+        output_dir=Path("/sweep-out"),
+    )
+    assert len(specs) == 2
+    for spec, expected_id in zip(specs, (0, 1), strict=True):
+        assert isinstance(spec, RunSpec)
+        assert spec.script_path == Path("/missions/m.script")
+        assert spec.output_dir == Path(f"/sweep-out/run-{expected_id}")
+        assert spec.seed is None
+        assert spec.run_options == {}
+
+
+def test_expand_accepts_string_mission_and_output_dir() -> None:
+    specs = expand_grid_to_run_specs(
+        grid={"x": [1]},
+        mission="/missions/m.script",
+        output_dir="/out",
+    )
+    assert specs[0].script_path == Path("/missions/m.script")
+    assert specs[0].output_dir == Path("/out/run-0")
+
+
+def test_expand_empty_grid_yields_one_spec() -> None:
+    specs = expand_grid_to_run_specs(
+        grid={},
+        mission="/m.script",
+        output_dir="/o",
+    )
+    assert len(specs) == 1
+    assert specs[0].overrides == {}
+    assert specs[0].run_id == 0
+    assert specs[0].output_dir == Path("/o/run-0")
+
+
+def test_expand_propagates_validation_errors() -> None:
+    with pytest.raises(SweepConfigError):
+        expand_grid_to_run_specs(grid={"a": []}, mission="/m.script", output_dir="/o")
+    with pytest.raises(SweepConfigError):
+        expand_grid_to_run_specs(
+            grid={1: [1]},  # type: ignore[dict-item]
+            mission="/m.script",
+            output_dir="/o",
+        )
+
+
+def test_expand_output_round_trips_through_runspec_to_dict() -> None:
+    specs = expand_grid_to_run_specs(
+        grid={"a": [1, 2]},
+        mission="/m.script",
+        output_dir="/o",
+    )
+    serialised = json.dumps([s.to_dict() for s in specs], sort_keys=True)
+    restored = [RunSpec.from_dict(d) for d in json.loads(serialised)]
+    assert restored == specs

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -115,7 +115,7 @@ def test_output_is_byte_for_byte_deterministic_across_calls() -> None:
 def test_expand_produces_sequential_run_ids_and_full_factorial_order() -> None:
     specs = expand_grid_to_run_specs(
         grid={"a": [1, 2], "b": [10, 20, 30]},
-        mission="/missions/flyby.script",
+        script_path="/missions/flyby.script",
         output_dir="/sweep-out",
     )
     assert tuple(s.run_id for s in specs) == (0, 1, 2, 3, 4, 5)
@@ -132,7 +132,7 @@ def test_expand_produces_sequential_run_ids_and_full_factorial_order() -> None:
 def test_expand_packs_script_path_output_dir_seed_and_run_options() -> None:
     specs = expand_grid_to_run_specs(
         grid={"x": [7, 8]},
-        mission=Path("/missions/m.script"),
+        script_path=Path("/missions/m.script"),
         output_dir=Path("/sweep-out"),
     )
     assert len(specs) == 2
@@ -144,10 +144,10 @@ def test_expand_packs_script_path_output_dir_seed_and_run_options() -> None:
         assert spec.run_options == {}
 
 
-def test_expand_accepts_string_mission_and_output_dir() -> None:
+def test_expand_accepts_string_script_path_and_output_dir() -> None:
     specs = expand_grid_to_run_specs(
         grid={"x": [1]},
-        mission="/missions/m.script",
+        script_path="/missions/m.script",
         output_dir="/out",
     )
     assert specs[0].script_path == Path("/missions/m.script")
@@ -157,7 +157,7 @@ def test_expand_accepts_string_mission_and_output_dir() -> None:
 def test_expand_empty_grid_yields_one_spec() -> None:
     specs = expand_grid_to_run_specs(
         grid={},
-        mission="/m.script",
+        script_path="/m.script",
         output_dir="/o",
     )
     assert len(specs) == 1
@@ -168,11 +168,11 @@ def test_expand_empty_grid_yields_one_spec() -> None:
 
 def test_expand_propagates_validation_errors() -> None:
     with pytest.raises(SweepConfigError):
-        expand_grid_to_run_specs(grid={"a": []}, mission="/m.script", output_dir="/o")
+        expand_grid_to_run_specs(grid={"a": []}, script_path="/m.script", output_dir="/o")
     with pytest.raises(SweepConfigError):
         expand_grid_to_run_specs(
             grid={1: [1]},  # type: ignore[dict-item]
-            mission="/m.script",
+            script_path="/m.script",
             output_dir="/o",
         )
 
@@ -180,7 +180,7 @@ def test_expand_propagates_validation_errors() -> None:
 def test_expand_output_round_trips_through_runspec_to_dict() -> None:
     specs = expand_grid_to_run_specs(
         grid={"a": [1, 2]},
-        mission="/m.script",
+        script_path="/m.script",
         output_dir="/o",
     )
     serialised = json.dumps([s.to_dict() for s in specs], sort_keys=True)


### PR DESCRIPTION
## Summary

- `gmat_sweep/grids.py`: `full_factorial(grid)` yields override dicts in lexicographic key order over the materialised cartesian product; `expand_grid_to_run_specs(grid, mission, output_dir)` wraps each combo in a `RunSpec` with sequential `run_id`, `output_dir/run-<id>`, `seed=None`, and empty `run_options`.
- Validation raises `SweepConfigError` on non-string keys and on empty value iterables, eagerly enough that a malformed entry aborts before any combo is yielded. Empty mapping is allowed and yields one empty override (cartesian product of nothing).
- Generators are materialised once at entry, so callers may pass generator inputs without surprising exhaustion. Determinism comes from sorted keys + `itertools.product` over materialised tuples — `json.dumps(..., sort_keys=True)` is byte-stable across calls and processes.
- `__init__.py` re-exports the two new public names.

## Test plan

- [x] `uv run pytest` — 38/38 pass (17 new in `test_grids.py`).
- [x] `uv run ruff check` clean.
- [x] `uv run ruff format --check` clean.
- [x] `uv run mypy` (strict) clean.
- [x] `grids.py` at 100% line and branch coverage.
- [ ] CI green on Ubuntu and Windows across the 3.10/3.11/3.12 × R2025a/R2026a matrix.

Closes #4