### PR TITLE
Add JSON Lines manifest with append/fsync and lookup helpers

### DIFF
--- a/src/gmat_sweep/__init__.py
+++ b/src/gmat_sweep/__init__.py
@@ -10,6 +10,7 @@ from gmat_sweep.errors import (
     SweepConfigError,
 )
 from gmat_sweep.grids import expand_grid_to_run_specs, full_factorial
+from gmat_sweep.manifest import Manifest, ManifestEntry, canonical_script_sha256
 from gmat_sweep.spec import RunOutcome, RunSpec, SweepSpec
 
 try:
@@ -20,13 +21,16 @@ except PackageNotFoundError:
 __all__ = [
     "BackendError",
     "GmatSweepError",
+    "Manifest",
     "ManifestCorruptError",
+    "ManifestEntry",
     "RunFailed",
     "RunOutcome",
     "RunSpec",
     "SweepConfigError",
     "SweepSpec",
     "__version__",
+    "canonical_script_sha256",
     "expand_grid_to_run_specs",
     "full_factorial",
 ]

--- a/src/gmat_sweep/manifest.py
+++ b/src/gmat_sweep/manifest.py
@@ -1,3 +1,238 @@
-"""Reproducibility manifest: load/save, canonical script-hash, find_failed/find_missing helpers."""
+"""Reproducibility manifest: load/save, canonical script-hash, find_failed/find_missing helpers.
+
+The on-disk format is JSON Lines with a single header object on line 1 and
+one :class:`ManifestEntry` per subsequent line. The header is written once
+by :meth:`Manifest.save` and is never rewritten — :meth:`Manifest.append_entry`
+only appends, and ``run_count`` on disk may therefore lag the entries below
+it. This is by design: a torn last line costs that one entry, the header
+stays valid, and a mid-sweep ``Ctrl-C`` leaves a parseable file.
+"""
 
 from __future__ import annotations
+
+import hashlib
+import json
+import os
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, cast
+
+from gmat_sweep.errors import ManifestCorruptError
+from gmat_sweep.spec import RunOutcome, RunStatus
+
+__all__ = ["Manifest", "ManifestEntry", "canonical_script_sha256"]
+
+
+def canonical_script_sha256(script_path: Path) -> str:
+    """SHA-256 of the script file after line-ending and trailing-newline normalisation.
+
+    Reads the file as bytes, decodes as UTF-8, replaces ``\\r\\n`` and
+    lone ``\\r`` with ``\\n``, and ensures exactly one trailing ``\\n``.
+    The hash is computed over the resulting UTF-8 bytes.
+    """
+    raw = script_path.read_bytes().decode("utf-8")
+    text = raw.replace("\r\n", "\n").replace("\r", "\n")
+    canonical = text.rstrip("\n") + "\n"
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+@dataclass(slots=True)
+class ManifestEntry:
+    """One run's record in the manifest — overrides, status, outputs, timing."""
+
+    run_id: int
+    overrides: dict[str, Any]
+    status: RunStatus
+    output_paths: dict[str, Path]
+    started_at: datetime
+    ended_at: datetime
+    duration_s: float
+    stderr: str | None
+    log_path: Path | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "overrides": dict(self.overrides),
+            "status": self.status,
+            "output_paths": {k: str(v) for k, v in self.output_paths.items()},
+            "started_at": self.started_at.isoformat(),
+            "ended_at": self.ended_at.isoformat(),
+            "duration_s": self.duration_s,
+            "stderr": self.stderr,
+            "log_path": None if self.log_path is None else str(self.log_path),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ManifestEntry:
+        return cls(
+            run_id=int(data["run_id"]),
+            overrides=dict(data["overrides"]),
+            status=cast(RunStatus, data["status"]),
+            output_paths={k: Path(v) for k, v in data["output_paths"].items()},
+            started_at=datetime.fromisoformat(data["started_at"]),
+            ended_at=datetime.fromisoformat(data["ended_at"]),
+            duration_s=float(data["duration_s"]),
+            stderr=None if data["stderr"] is None else str(data["stderr"]),
+            log_path=None if data["log_path"] is None else Path(data["log_path"]),
+        )
+
+    @classmethod
+    def from_outcome(
+        cls,
+        outcome: RunOutcome,
+        *,
+        overrides: dict[str, Any],
+        log_path: Path | None = None,
+    ) -> ManifestEntry:
+        """Build a manifest entry from a worker :class:`RunOutcome`."""
+        return cls(
+            run_id=outcome.run_id,
+            overrides=dict(overrides),
+            status=outcome.status,
+            output_paths=dict(outcome.output_paths),
+            started_at=outcome.started_at,
+            ended_at=outcome.ended_at,
+            duration_s=outcome.duration_s,
+            stderr=outcome.stderr,
+            log_path=log_path,
+        )
+
+
+@dataclass(slots=True)
+class Manifest:
+    """Sweep manifest — header fingerprint plus a growing list of per-run entries."""
+
+    script_sha256: str
+    gmat_sweep_version: str
+    gmat_run_version: str
+    gmat_install_version: str
+    python_version: str
+    os_platform: str
+    sweep_seed: int | None
+    parameter_spec: dict[str, Any]
+    run_count: int
+    entries: list[ManifestEntry] = field(default_factory=list)
+    _path: Path | None = field(default=None, init=False, repr=False, compare=False)
+
+    def _header_dict(self) -> dict[str, Any]:
+        return {
+            "script_sha256": self.script_sha256,
+            "gmat_sweep_version": self.gmat_sweep_version,
+            "gmat_run_version": self.gmat_run_version,
+            "gmat_install_version": self.gmat_install_version,
+            "python_version": self.python_version,
+            "os_platform": self.os_platform,
+            "sweep_seed": self.sweep_seed,
+            "parameter_spec": dict(self.parameter_spec),
+            "run_count": self.run_count,
+        }
+
+    @classmethod
+    def _header_from_dict(cls, data: dict[str, Any]) -> Manifest:
+        return cls(
+            script_sha256=str(data["script_sha256"]),
+            gmat_sweep_version=str(data["gmat_sweep_version"]),
+            gmat_run_version=str(data["gmat_run_version"]),
+            gmat_install_version=str(data["gmat_install_version"]),
+            python_version=str(data["python_version"]),
+            os_platform=str(data["os_platform"]),
+            sweep_seed=None if data["sweep_seed"] is None else int(data["sweep_seed"]),
+            parameter_spec=dict(data["parameter_spec"]),
+            run_count=int(data["run_count"]),
+            entries=[],
+        )
+
+    def save(self, path: Path) -> None:
+        """Write header + all current entries as JSON Lines, fsyncing file and parent dir."""
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        lines = [json.dumps(self._header_dict(), sort_keys=True)]
+        lines.extend(json.dumps(e.to_dict(), sort_keys=True) for e in self.entries)
+        payload = "\n".join(lines) + "\n"
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(payload)
+            f.flush()
+            os.fsync(f.fileno())
+        _fsync_dir(path.parent)
+        self._path = path
+
+    def append_entry(self, entry: ManifestEntry) -> None:
+        """Append one entry to the bound file with fsync, and to the in-memory list."""
+        if self._path is None:
+            raise RuntimeError(
+                "Manifest.append_entry requires a path — call save() or load() first."
+            )
+        line = json.dumps(entry.to_dict(), sort_keys=True) + "\n"
+        with open(self._path, "a", encoding="utf-8") as f:
+            f.write(line)
+            f.flush()
+            os.fsync(f.fileno())
+        self.entries.append(entry)
+
+    @classmethod
+    def load(cls, path: Path) -> Manifest:
+        """Load a manifest from disk, tolerating a single torn final line."""
+        path = Path(path)
+        with open(path, encoding="utf-8") as f:
+            raw = f.read()
+
+        if not raw:
+            raise ManifestCorruptError("manifest file is empty", path)
+
+        # Split on '\n' and drop the last element. For a clean
+        # newline-terminated file this drops the trailing empty string; for a
+        # torn write (missing trailing newline) it drops the partial line.
+        complete_lines = raw.split("\n")[:-1]
+
+        if not complete_lines:
+            raise ManifestCorruptError("manifest header line missing", path)
+
+        try:
+            header_data = json.loads(complete_lines[0])
+        except json.JSONDecodeError as exc:
+            raise ManifestCorruptError(f"manifest header is not valid JSON: {exc}", path) from exc
+
+        try:
+            manifest = cls._header_from_dict(header_data)
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ManifestCorruptError(f"manifest header is missing fields: {exc}", path) from exc
+
+        for i, line in enumerate(complete_lines[1:], start=2):
+            try:
+                entry_data = json.loads(line)
+                entry = ManifestEntry.from_dict(entry_data)
+            except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+                raise ManifestCorruptError(
+                    f"manifest entry on line {i} is malformed: {exc}", path
+                ) from exc
+            manifest.entries.append(entry)
+
+        manifest._path = path
+        return manifest
+
+    def find_failed(self) -> list[int]:
+        """Return run_ids of entries with status ``failed``, in arrival order."""
+        return [e.run_id for e in self.entries if e.status == "failed"]
+
+    def find_missing(self, expected_run_ids: Iterable[int]) -> list[int]:
+        """Return run_ids in ``expected_run_ids`` with no entry recorded, in input order."""
+        present = {e.run_id for e in self.entries}
+        return [rid for rid in expected_run_ids if rid not in present]
+
+
+def _fsync_dir(directory: Path) -> None:
+    # Directory fsync ensures the new file's metadata (existence, size) is
+    # durable across crash. Not supported on Windows; treat as a no-op there.
+    try:
+        fd = os.open(directory, os.O_RDONLY)
+    except (OSError, PermissionError):
+        return
+    try:
+        os.fsync(fd)
+    except OSError:
+        pass
+    finally:
+        os.close(fd)

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,511 @@
+"""Tests for gmat_sweep.manifest — JSON Lines manifest, append/fsync, lookup helpers."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gmat_sweep.errors import ManifestCorruptError
+from gmat_sweep.manifest import Manifest, ManifestEntry, canonical_script_sha256
+from gmat_sweep.spec import RunOutcome
+
+
+def _utc(year: int, month: int, day: int, h: int = 0, m: int = 0, s: int = 0) -> datetime:
+    return datetime(year, month, day, h, m, s, tzinfo=timezone.utc)
+
+
+def _make_entry(run_id: int = 0, status: str = "ok", *, log: bool = True) -> ManifestEntry:
+    return ManifestEntry(
+        run_id=run_id,
+        overrides={"Sat.SMA": 7000.0 + run_id, "Sat.ECC": 0.001},
+        status=status,  # type: ignore[arg-type]
+        output_paths={"ReportFile1": Path(f"/o/run-{run_id}/r1.parquet")} if status == "ok" else {},
+        started_at=_utc(2026, 5, 4, 0, 0, 0),
+        ended_at=_utc(2026, 5, 4, 0, 0, 12),
+        duration_s=12.0,
+        stderr=None if status == "ok" else "boom",
+        log_path=Path(f"/o/run-{run_id}/log.txt") if log else None,
+    )
+
+
+def _make_manifest(n_entries: int = 0) -> Manifest:
+    return Manifest(
+        script_sha256="a" * 64,
+        gmat_sweep_version="0.1.0",
+        gmat_run_version="0.4.0",
+        gmat_install_version="R2026a",
+        python_version="3.12.3",
+        os_platform="Linux-6.6.0",
+        sweep_seed=1729,
+        parameter_spec={"Sat.SMA": [7000.0, 7100.0], "Sat.ECC": [0.001, 0.002]},
+        run_count=4,
+        entries=[_make_entry(i) for i in range(n_entries)],
+    )
+
+
+# ---- ManifestEntry round-trip --------------------------------------------
+
+
+def test_manifest_entry_round_trips_through_json() -> None:
+    original = _make_entry(run_id=3)
+    serialised = json.dumps(original.to_dict(), sort_keys=True)
+    restored = ManifestEntry.from_dict(json.loads(serialised))
+    assert restored == original
+    assert json.dumps(restored.to_dict(), sort_keys=True) == serialised
+
+
+def test_manifest_entry_failed_round_trips_with_stderr_and_no_outputs() -> None:
+    original = _make_entry(run_id=2, status="failed")
+    restored = ManifestEntry.from_dict(json.loads(json.dumps(original.to_dict())))
+    assert restored == original
+    assert restored.status == "failed"
+    assert restored.stderr == "boom"
+    assert restored.output_paths == {}
+
+
+def test_manifest_entry_log_path_none_round_trips() -> None:
+    original = _make_entry(run_id=1, log=False)
+    restored = ManifestEntry.from_dict(json.loads(json.dumps(original.to_dict())))
+    assert restored == original
+    assert restored.log_path is None
+
+
+def test_manifest_entry_from_outcome_carries_overrides_and_log_path() -> None:
+    outcome = RunOutcome.ok(
+        run_id=7,
+        output_paths={"ReportFile1": Path("/o/run-7/r1.parquet")},
+        started_at=_utc(2026, 5, 4, 0, 0, 0),
+        ended_at=_utc(2026, 5, 4, 0, 0, 5),
+    )
+    entry = ManifestEntry.from_outcome(
+        outcome,
+        overrides={"Sat.SMA": 7050.0},
+        log_path=Path("/o/run-7/log.txt"),
+    )
+    assert entry.run_id == 7
+    assert entry.status == "ok"
+    assert entry.duration_s == 5.0
+    assert entry.overrides == {"Sat.SMA": 7050.0}
+    assert entry.log_path == Path("/o/run-7/log.txt")
+    assert entry.stderr is None
+
+
+def test_manifest_entry_from_outcome_log_path_defaults_to_none() -> None:
+    outcome = RunOutcome.failed(
+        run_id=4,
+        stderr="GMAT exploded",
+        started_at=_utc(2026, 5, 4, 0, 0, 0),
+        ended_at=_utc(2026, 5, 4, 0, 0, 1),
+    )
+    entry = ManifestEntry.from_outcome(outcome, overrides={"Sat.SMA": 7000.0})
+    assert entry.log_path is None
+    assert entry.status == "failed"
+    assert entry.stderr == "GMAT exploded"
+    assert entry.output_paths == {}
+
+
+# ---- Manifest save / load round-trip -------------------------------------
+
+
+def test_save_then_load_round_trips_bit_equal(tmp_path: Path) -> None:
+    original = _make_manifest(n_entries=3)
+    path = tmp_path / "manifest.jsonl"
+    original.save(path)
+
+    loaded = Manifest.load(path)
+    assert loaded == original
+    assert [e for e in loaded.entries] == original.entries
+
+    # Re-saving produces the same bytes (deterministic key ordering).
+    second = tmp_path / "second.jsonl"
+    loaded.save(second)
+    assert path.read_bytes() == second.read_bytes()
+
+
+def test_save_creates_parent_directory(tmp_path: Path) -> None:
+    m = _make_manifest()
+    path = tmp_path / "nested" / "dir" / "manifest.jsonl"
+    m.save(path)
+    assert path.exists()
+
+
+def test_save_writes_jsonl_with_header_first(tmp_path: Path) -> None:
+    m = _make_manifest(n_entries=2)
+    path = tmp_path / "manifest.jsonl"
+    m.save(path)
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 3
+    header = json.loads(lines[0])
+    assert header["script_sha256"] == m.script_sha256
+    assert "entries" not in header  # entries live on subsequent lines
+    for line in lines[1:]:
+        assert "run_id" in json.loads(line)
+
+
+def test_save_records_path_for_subsequent_append(tmp_path: Path) -> None:
+    m = _make_manifest()
+    path = tmp_path / "manifest.jsonl"
+    m.save(path)
+    # append_entry should now succeed without re-binding.
+    m.append_entry(_make_entry(run_id=99))
+    reloaded = Manifest.load(path)
+    assert reloaded.entries[-1].run_id == 99
+
+
+# ---- append_entry --------------------------------------------------------
+
+
+def test_append_entry_extends_file_and_in_memory_list(tmp_path: Path) -> None:
+    m = _make_manifest()
+    path = tmp_path / "manifest.jsonl"
+    m.save(path)
+
+    e0 = _make_entry(run_id=0)
+    e1 = _make_entry(run_id=1)
+    m.append_entry(e0)
+    m.append_entry(e1)
+
+    assert m.entries == [e0, e1]
+    reloaded = Manifest.load(path)
+    assert reloaded.entries == [e0, e1]
+
+
+def test_append_entry_without_save_or_load_raises() -> None:
+    m = _make_manifest()
+    with pytest.raises(RuntimeError, match="save\\(\\) or load\\(\\)"):
+        m.append_entry(_make_entry())
+
+
+def test_append_entry_after_load_writes_to_loaded_path(tmp_path: Path) -> None:
+    seed = _make_manifest(n_entries=1)
+    path = tmp_path / "manifest.jsonl"
+    seed.save(path)
+
+    loaded = Manifest.load(path)
+    loaded.append_entry(_make_entry(run_id=5))
+
+    final = Manifest.load(path)
+    assert [e.run_id for e in final.entries] == [0, 5]
+
+
+def test_append_entry_calls_fsync(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import os as os_module
+
+    fsynced: list[int] = []
+    real_fsync = os_module.fsync
+
+    def fake_fsync(fd: int) -> None:
+        fsynced.append(fd)
+        real_fsync(fd)
+
+    monkeypatch.setattr("gmat_sweep.manifest.os.fsync", fake_fsync)
+
+    m = _make_manifest()
+    path = tmp_path / "manifest.jsonl"
+    m.save(path)
+    fsynced.clear()
+    m.append_entry(_make_entry())
+    assert len(fsynced) >= 1
+
+
+def test_save_tolerates_dir_fsync_oserror(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Directory fsync is best-effort (Windows can't do it; some filesystems
+    # refuse). save() must not propagate the failure.
+    import os as os_module
+
+    real_open = os_module.open
+
+    def fake_open(path: Any, flags: int, *args: Any, **kwargs: Any) -> int:
+        # Fail only when opening a directory for fsync.
+        if Path(os_module.fsdecode(path)).is_dir():
+            raise PermissionError("simulated dir fsync open failure")
+        return real_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr("gmat_sweep.manifest.os.open", fake_open)
+
+    m = _make_manifest()
+    m.save(tmp_path / "manifest.jsonl")  # must not raise
+
+
+def test_save_tolerates_dir_fsync_call_oserror(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import os as os_module
+
+    real_fsync = os_module.fsync
+    real_fstat = os_module.fstat
+
+    def fake_fsync(fd: int) -> None:
+        # Fail fsync only on directory file descriptors; leave file fsyncs alone.
+        try:
+            mode = real_fstat(fd).st_mode
+        except OSError:
+            mode = 0
+        if (mode & 0o170000) == 0o040000:  # S_IFDIR
+            raise OSError("simulated dir fsync failure")
+        real_fsync(fd)
+
+    monkeypatch.setattr("gmat_sweep.manifest.os.fsync", fake_fsync)
+
+    m = _make_manifest()
+    m.save(tmp_path / "manifest.jsonl")  # must not raise
+
+
+def test_save_calls_fsync(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import os as os_module
+
+    fsynced: list[int] = []
+    real_fsync = os_module.fsync
+
+    def fake_fsync(fd: int) -> None:
+        fsynced.append(fd)
+        real_fsync(fd)
+
+    monkeypatch.setattr("gmat_sweep.manifest.os.fsync", fake_fsync)
+
+    m = _make_manifest()
+    m.save(tmp_path / "manifest.jsonl")
+    # At least the file fsync; parent dir fsync is best-effort.
+    assert len(fsynced) >= 1
+
+
+# ---- Truncation tolerance ------------------------------------------------
+
+
+def test_load_tolerates_torn_final_line(tmp_path: Path) -> None:
+    m = _make_manifest()
+    path = tmp_path / "manifest.jsonl"
+    m.save(path)
+    m.append_entry(_make_entry(run_id=0))
+    m.append_entry(_make_entry(run_id=1))
+
+    raw = path.read_bytes()
+    # Drop the trailing newline plus a few bytes from the last entry to simulate
+    # a Ctrl-C in the middle of a write.
+    truncated = raw.rstrip(b"\n")
+    truncated = truncated[: -len(b'"run_id": 1}') // 2]
+    path.write_bytes(truncated)
+
+    loaded = Manifest.load(path)
+    # The first entry survived; the partial second one was dropped.
+    assert [e.run_id for e in loaded.entries] == [0]
+
+
+def test_load_tolerates_truncation_at_line_boundary_after_header(tmp_path: Path) -> None:
+    m = _make_manifest()
+    path = tmp_path / "manifest.jsonl"
+    m.save(path)
+    m.append_entry(_make_entry(run_id=0))
+    m.append_entry(_make_entry(run_id=1))
+
+    raw = path.read_text(encoding="utf-8")
+    # Truncate to keep only the header line (with its trailing \n).
+    header_end = raw.index("\n") + 1
+    path.write_text(raw[:header_end], encoding="utf-8")
+
+    loaded = Manifest.load(path)
+    assert loaded.entries == []
+    assert loaded.script_sha256 == m.script_sha256
+
+
+def test_load_tolerates_truncation_mid_entry_no_trailing_newline(tmp_path: Path) -> None:
+    m = _make_manifest()
+    path = tmp_path / "manifest.jsonl"
+    m.save(path)
+    m.append_entry(_make_entry(run_id=0))
+
+    raw = path.read_text(encoding="utf-8")
+    # Cut the entry line in half, no trailing newline → torn write.
+    header_end = raw.index("\n") + 1
+    entry_line = raw[header_end:].rstrip("\n")
+    path.write_text(raw[:header_end] + entry_line[: len(entry_line) // 2], encoding="utf-8")
+
+    loaded = Manifest.load(path)
+    assert loaded.entries == []
+
+
+# ---- Corruption ----------------------------------------------------------
+
+
+def test_load_empty_file_raises_manifest_corrupt(tmp_path: Path) -> None:
+    path = tmp_path / "empty.jsonl"
+    path.write_text("", encoding="utf-8")
+    with pytest.raises(ManifestCorruptError) as excinfo:
+        Manifest.load(path)
+    assert excinfo.value.path == path
+
+
+def test_load_torn_header_with_no_newline_raises_manifest_corrupt(tmp_path: Path) -> None:
+    # File content has no '\n' at all — the header line itself was being written
+    # when the process died. Treated as corruption (no complete header).
+    path = tmp_path / "torn-header.jsonl"
+    path.write_text('{"script_sha256": "abc"', encoding="utf-8")
+    with pytest.raises(ManifestCorruptError) as excinfo:
+        Manifest.load(path)
+    assert excinfo.value.path == path
+    assert "header" in str(excinfo.value)
+
+
+def test_load_invalid_header_json_raises_manifest_corrupt(tmp_path: Path) -> None:
+    path = tmp_path / "bad.jsonl"
+    path.write_text("{not valid json\n", encoding="utf-8")
+    with pytest.raises(ManifestCorruptError) as excinfo:
+        Manifest.load(path)
+    assert excinfo.value.path == path
+    assert "header" in str(excinfo.value)
+
+
+def test_load_header_missing_fields_raises_manifest_corrupt(tmp_path: Path) -> None:
+    path = tmp_path / "incomplete.jsonl"
+    path.write_text(json.dumps({"script_sha256": "abc"}) + "\n", encoding="utf-8")
+    with pytest.raises(ManifestCorruptError) as excinfo:
+        Manifest.load(path)
+    assert excinfo.value.path == path
+
+
+def test_load_complete_but_malformed_entry_line_raises(tmp_path: Path) -> None:
+    m = _make_manifest()
+    path = tmp_path / "manifest.jsonl"
+    m.save(path)
+
+    with open(path, "a", encoding="utf-8") as f:
+        f.write("{this is not valid}\n")  # complete line, malformed JSON
+    with pytest.raises(ManifestCorruptError) as excinfo:
+        Manifest.load(path)
+    assert "line 2" in str(excinfo.value)
+
+
+def test_load_complete_entry_with_missing_field_raises(tmp_path: Path) -> None:
+    m = _make_manifest()
+    path = tmp_path / "manifest.jsonl"
+    m.save(path)
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(json.dumps({"run_id": 0}) + "\n")
+    with pytest.raises(ManifestCorruptError) as excinfo:
+        Manifest.load(path)
+    assert excinfo.value.path == path
+
+
+# ---- find_failed / find_missing -----------------------------------------
+
+
+def test_find_failed_returns_failed_run_ids_in_order() -> None:
+    m = _make_manifest()
+    m.entries = [
+        _make_entry(0, status="ok"),
+        _make_entry(1, status="failed"),
+        _make_entry(2, status="ok"),
+        _make_entry(3, status="failed"),
+        _make_entry(4, status="skipped"),
+    ]
+    assert m.find_failed() == [1, 3]
+
+
+def test_find_failed_empty_when_all_ok() -> None:
+    m = _make_manifest()
+    m.entries = [_make_entry(0), _make_entry(1)]
+    assert m.find_failed() == []
+
+
+def test_find_failed_returns_all_when_all_failed() -> None:
+    m = _make_manifest()
+    m.entries = [_make_entry(i, status="failed") for i in range(3)]
+    assert m.find_failed() == [0, 1, 2]
+
+
+def test_find_failed_skipped_runs_are_not_failed() -> None:
+    m = _make_manifest()
+    m.entries = [_make_entry(0, status="skipped")]
+    assert m.find_failed() == []
+
+
+def test_find_missing_preserves_input_order() -> None:
+    m = _make_manifest()
+    m.entries = [_make_entry(0), _make_entry(2), _make_entry(4)]
+    assert m.find_missing([4, 3, 2, 1, 0]) == [3, 1]
+
+
+def test_find_missing_empty_input_returns_empty() -> None:
+    m = _make_manifest()
+    m.entries = [_make_entry(0)]
+    assert m.find_missing([]) == []
+
+
+def test_find_missing_all_present_returns_empty() -> None:
+    m = _make_manifest()
+    m.entries = [_make_entry(0), _make_entry(1)]
+    assert m.find_missing([0, 1]) == []
+
+
+def test_find_missing_none_present_returns_all() -> None:
+    m = _make_manifest()
+    assert m.find_missing([0, 1, 2]) == [0, 1, 2]
+
+
+# ---- canonical_script_sha256 --------------------------------------------
+
+
+def _write_script(tmp_path: Path, name: str, payload: bytes) -> Path:
+    p = tmp_path / name
+    p.write_bytes(payload)
+    return p
+
+
+def test_canonical_hash_is_stable_across_line_endings(tmp_path: Path) -> None:
+    body = "Create Spacecraft Sat;\nSat.SMA = 7000;\nPropagate prop(Sat);\n"
+    lf = _write_script(tmp_path, "lf.script", body.encode("utf-8"))
+    crlf = _write_script(tmp_path, "crlf.script", body.replace("\n", "\r\n").encode("utf-8"))
+    cr = _write_script(tmp_path, "cr.script", body.replace("\n", "\r").encode("utf-8"))
+
+    h_lf = canonical_script_sha256(lf)
+    assert canonical_script_sha256(crlf) == h_lf
+    assert canonical_script_sha256(cr) == h_lf
+
+
+def test_canonical_hash_is_stable_across_trailing_newline_variants(tmp_path: Path) -> None:
+    base = "Create Spacecraft Sat;\nSat.SMA = 7000;"
+    no_nl = _write_script(tmp_path, "none.script", base.encode("utf-8"))
+    one_nl = _write_script(tmp_path, "one.script", (base + "\n").encode("utf-8"))
+    two_nl = _write_script(tmp_path, "two.script", (base + "\n\n").encode("utf-8"))
+
+    h = canonical_script_sha256(no_nl)
+    assert canonical_script_sha256(one_nl) == h
+    assert canonical_script_sha256(two_nl) == h
+
+
+def test_canonical_hash_changes_with_payload(tmp_path: Path) -> None:
+    a = _write_script(tmp_path, "a.script", b"Sat.SMA = 7000;\n")
+    b = _write_script(tmp_path, "b.script", b"Sat.SMA = 7100;\n")
+    assert canonical_script_sha256(a) != canonical_script_sha256(b)
+
+
+def test_canonical_hash_is_64_hex_chars(tmp_path: Path) -> None:
+    p = _write_script(tmp_path, "x.script", b"x\n")
+    h = canonical_script_sha256(p)
+    assert len(h) == 64
+    assert all(c in "0123456789abcdef" for c in h)
+
+
+# ---- Header field surface check ------------------------------------------
+
+
+def test_header_dict_carries_every_documented_field() -> None:
+    m = _make_manifest()
+    header: dict[str, Any] = m._header_dict()
+    expected = {
+        "script_sha256",
+        "gmat_sweep_version",
+        "gmat_run_version",
+        "gmat_install_version",
+        "python_version",
+        "os_platform",
+        "sweep_seed",
+        "parameter_spec",
+        "run_count",
+    }
+    assert set(header.keys()) == expected


### PR DESCRIPTION
## Summary

- New `gmat_sweep.manifest` module: `Manifest`, `ManifestEntry`, and `canonical_script_sha256()`.
- File format is JSON Lines — header on line 1, one entry per subsequent line. The header is never rewritten, so a torn last line costs only that one entry; `load()` drops a trailing partial line silently and treats a complete-but-malformed line as `ManifestCorruptError`.
- `Manifest.save()` writes header + entries with file and parent-directory `fsync` (best-effort on platforms that don't support directory `fsync`); `append_entry()` appends one line and `fsync`s.
- `find_failed()` returns failed run IDs in arrival order; `find_missing(expected)` returns expected IDs not present, in input order.
- Re-exported from `gmat_sweep.__init__`.

## Test plan

- [x] `uv run ruff check`
- [x] `uv run ruff format --check`
- [x] `uv run mypy`
- [x] `uv run pytest` — 76 passed
- [x] `manifest.py` coverage 100% (gate is ≥ 95%)

Covered: round-trip bit-equal, deterministic serialisation, torn-tail tolerance at three boundaries, header / mid-stream corruption, `append_entry` without prior bind, `from_outcome` adapter, canonical hash invariance across line endings and trailing-newline counts.

Closes #5.