### PR TITLE
Add subprocess-fresh single-run worker callable

### DIFF
--- a/src/gmat_sweep/worker.py
+++ b/src/gmat_sweep/worker.py
@@ -1,3 +1,114 @@
-"""Per-run worker: subprocess-fresh gmat_run import, override application, Parquet output."""
+"""Per-run worker: subprocess-fresh gmat_run import, override application, Parquet output.
+
+The single public entry point is :func:`run_one`. It is the unit of work the
+backend pool fans out: one :class:`gmat_sweep.spec.RunSpec` in, one
+:class:`gmat_sweep.spec.RunOutcome` out, and *never* a raised exception. Every
+failure mode — bootstrap failure, override rejection, GMAT engine error,
+Parquet write failure — is caught and turned into
+:meth:`RunOutcome.failed` carrying the captured traceback as ``stderr`` so a
+single bad run does not abort the parent sweep.
+
+``import gmat_run`` is deferred until inside :func:`run_one` so the driver
+process never bootstraps ``gmatpy``. Each backend worker pays the bootstrap
+cost exactly once on its first call, in its own subprocess.
+"""
 
 from __future__ import annotations
+
+import logging
+import traceback
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+from gmat_sweep.spec import RunOutcome
+
+if TYPE_CHECKING:
+    from gmat_sweep.spec import RunSpec
+
+__all__ = ["run_one"]
+
+
+_WORKER_LOG_NAME = "worker.log"
+
+
+def run_one(spec: RunSpec) -> RunOutcome:
+    """Run one mission described by ``spec`` and return a :class:`RunOutcome`.
+
+    Loads the script via :class:`gmat_run.Mission`, applies every override in
+    ``spec.overrides`` through the dotted-path setter, executes the mission
+    with ``working_dir=spec.output_dir`` plus ``**spec.run_options``, and
+    writes each ``ReportFile`` output as a Parquet file under
+    ``spec.output_dir``. Returns :meth:`RunOutcome.ok` on success.
+
+    Any exception raised inside the function (bootstrap failure, override
+    rejection, ``GmatRunError``, Parquet write failure, …) is caught and
+    converted to :meth:`RunOutcome.failed` with the formatted traceback as
+    ``stderr``. ``KeyboardInterrupt`` is the one exception that still
+    propagates so ``Ctrl-C`` reaches the driver.
+
+    A per-run log file is written to ``spec.output_dir / "worker.log"`` for
+    both successful and failed runs; the eventual manifest entry references
+    it via :attr:`gmat_sweep.manifest.ManifestEntry.log_path`.
+    """
+    started_at = datetime.now(timezone.utc)
+    spec.output_dir.mkdir(parents=True, exist_ok=True)
+    log_path = spec.output_dir / _WORKER_LOG_NAME
+
+    logger = logging.getLogger(f"gmat_sweep.worker.run_{spec.run_id}")
+    logger.setLevel(logging.DEBUG)
+    logger.propagate = False
+    handler = logging.FileHandler(log_path, mode="a", encoding="utf-8")
+    handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
+    logger.addHandler(handler)
+
+    try:
+        logger.info("run_id=%d script=%s", spec.run_id, spec.script_path)
+        logger.info("overrides=%s", spec.overrides)
+        if spec.seed is not None:
+            logger.info("seed=%d (reserved for v0.2 Monte Carlo)", spec.seed)
+
+        # Lazy import: keeps gmatpy out of the driver process. The first call
+        # in any given worker subprocess pays the bootstrap cost; subsequent
+        # calls in the same subprocess hit the module cache.
+        import gmat_run
+
+        mission = gmat_run.Mission.load(spec.script_path)
+        for key, value in spec.overrides.items():
+            mission[key] = value
+        results = mission.run(working_dir=spec.output_dir, **spec.run_options)
+
+        output_paths = {}
+        for name, df in results.reports.items():
+            parquet_path = spec.output_dir / f"{name}.parquet"
+            df.to_parquet(parquet_path)
+            output_paths[name] = parquet_path
+            logger.info("wrote report %s -> %s (%d rows)", name, parquet_path, len(df))
+
+        if results.log:
+            logger.info("--- GMAT engine log ---\n%s", results.log)
+
+        ended_at = datetime.now(timezone.utc)
+        logger.info("status=ok duration_s=%.3f", (ended_at - started_at).total_seconds())
+        return RunOutcome.ok(
+            run_id=spec.run_id,
+            output_paths=output_paths,
+            started_at=started_at,
+            ended_at=ended_at,
+        )
+    except KeyboardInterrupt:  # pragma: no cover - propagates to the driver
+        raise
+    except Exception as exc:
+        ended_at = datetime.now(timezone.utc)
+        tb = traceback.format_exc()
+        engine_log = getattr(exc, "log", None)
+        stderr = tb if not engine_log else f"{tb}\n--- GMAT engine log ---\n{engine_log}"
+        logger.error("status=failed\n%s", stderr)
+        return RunOutcome.failed(
+            run_id=spec.run_id,
+            stderr=stderr,
+            started_at=started_at,
+            ended_at=ended_at,
+        )
+    finally:
+        logger.removeHandler(handler)
+        handler.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,108 @@
 """Shared pytest fixtures for the gmat-sweep test suite."""
 
 from __future__ import annotations
+
+import sys
+from collections.abc import Callable, Iterator, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pandas as pd
+import pytest
+
+
+@dataclass
+class FakeResults:
+    """Stand-in for :class:`gmat_run.results.Results` — only the bits the worker reads."""
+
+    reports: Mapping[str, pd.DataFrame] = field(default_factory=dict)
+    log: str = ""
+
+
+@dataclass
+class FakeMission:
+    """Stand-in for :class:`gmat_run.mission.Mission` — only the bits the worker calls.
+
+    Each callable hook can be swapped out per test to inject failures at the
+    matching point. The default hooks succeed and return an empty
+    :class:`FakeResults`.
+    """
+
+    script_path: Path
+    overrides_log: list[tuple[str, Any]] = field(default_factory=list)
+    setitem_hook: Callable[[str, Any], None] | None = None
+    run_hook: Callable[..., FakeResults] | None = None
+    run_kwargs_log: list[dict[str, Any]] = field(default_factory=list)
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.overrides_log.append((key, value))
+        if self.setitem_hook is not None:
+            self.setitem_hook(key, value)
+
+    def run(self, **kwargs: Any) -> FakeResults:
+        self.run_kwargs_log.append(kwargs)
+        if self.run_hook is not None:
+            return self.run_hook(**kwargs)
+        return FakeResults()
+
+
+class FakeGmatRunError(Exception):
+    """Stand-in for :class:`gmat_run.errors.GmatRunError` — carries the engine ``log``."""
+
+    def __init__(self, message: str, *, log: str = "") -> None:
+        super().__init__(message)
+        self.log = log
+
+
+@dataclass
+class FakeGmatRun:
+    """Container for the fake module installed at ``sys.modules['gmat_run']``.
+
+    Tests call :meth:`install_loader` (or :meth:`install_failing_loader`) to
+    swap out the ``Mission.load`` callable per scenario; ``last_mission`` is
+    populated as a side effect of the default loader so tests can assert on
+    the calls the worker made through the mission interface.
+    """
+
+    module: ModuleType
+    last_mission: FakeMission | None = None
+
+    def install_loader(
+        self,
+        *,
+        setitem_hook: Callable[[str, Any], None] | None = None,
+        run_hook: Callable[..., FakeResults] | None = None,
+    ) -> None:
+        def _load(path: Any, **_: Any) -> FakeMission:
+            mission = FakeMission(
+                script_path=Path(path), setitem_hook=setitem_hook, run_hook=run_hook
+            )
+            self.last_mission = mission
+            return mission
+
+        self.module.Mission = SimpleNamespace(load=_load)  # type: ignore[attr-defined]
+
+    def install_failing_loader(self, exc: BaseException) -> None:
+        def _load(_path: Any, **_: Any) -> FakeMission:
+            raise exc
+
+        self.module.Mission = SimpleNamespace(load=_load)  # type: ignore[attr-defined]
+
+
+@pytest.fixture
+def fake_gmat_run(monkeypatch: pytest.MonkeyPatch) -> Iterator[FakeGmatRun]:
+    """Install a fake ``gmat_run`` module into :data:`sys.modules` for the test.
+
+    The default ``Mission.load`` returns a :class:`FakeMission` whose
+    ``__setitem__`` and ``run`` succeed; tests call ``install_loader`` /
+    ``install_failing_loader`` on the yielded :class:`FakeGmatRun` to inject
+    behaviour.
+    """
+    container = FakeGmatRun(module=ModuleType("gmat_run"))
+    container.install_loader()
+    container.module.GmatRunError = FakeGmatRunError  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "gmat_run", container.module)
+    yield container

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,0 +1,279 @@
+"""Tests for gmat_sweep.worker.run_one — happy path, every failure mode, never raises."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pytest
+
+from gmat_sweep.spec import RunSpec
+from gmat_sweep.worker import run_one
+from tests.conftest import FakeGmatRun, FakeGmatRunError, FakeResults
+
+
+def _make_spec(
+    *,
+    output_dir: Path,
+    run_id: int = 0,
+    overrides: dict[str, Any] | None = None,
+    run_options: dict[str, Any] | None = None,
+    seed: int | None = None,
+    script_name: str = "mission.script",
+) -> RunSpec:
+    return RunSpec(
+        script_path=Path(f"/missions/{script_name}"),
+        overrides=overrides if overrides is not None else {},
+        output_dir=output_dir,
+        run_id=run_id,
+        seed=seed,
+        run_options=run_options if run_options is not None else {},
+    )
+
+
+# ---- happy path ----------------------------------------------------------
+
+
+def test_run_one_ok_writes_parquet_and_returns_ok(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    df_a = pd.DataFrame({"t": [0.0, 1.0], "x": [1.0, 2.0]})
+    df_b = pd.DataFrame({"t": [0.0], "y": [42.0]})
+
+    def _run(**_: Any) -> FakeResults:
+        return FakeResults(reports={"R1": df_a, "R2": df_b}, log="GMAT engine log line\n")
+
+    fake_gmat_run.install_loader(run_hook=_run)
+
+    out_dir = tmp_path / "run-0"
+    spec = _make_spec(
+        output_dir=out_dir,
+        overrides={"Sat.SMA": 7000.0, "Sat.ECC": 0.01},
+        run_options={"overwrite": True},
+    )
+    outcome = run_one(spec)
+
+    assert outcome.status == "ok"
+    assert outcome.run_id == 0
+    assert outcome.stderr is None
+    assert outcome.duration_s >= 0
+    assert outcome.started_at <= outcome.ended_at
+    assert set(outcome.output_paths) == {"R1", "R2"}
+
+    # Parquet round-trip.
+    pd.testing.assert_frame_equal(pd.read_parquet(outcome.output_paths["R1"]), df_a)
+    pd.testing.assert_frame_equal(pd.read_parquet(outcome.output_paths["R2"]), df_b)
+
+    # Worker log present and contains override + engine-log lines.
+    log_text = (out_dir / "worker.log").read_text(encoding="utf-8")
+    assert "Sat.SMA" in log_text
+    assert "GMAT engine log line" in log_text
+    assert "status=ok" in log_text
+
+    # mission.run got the working_dir and the forwarded run_options.
+    assert fake_gmat_run.last_mission is not None
+    assert fake_gmat_run.last_mission.run_kwargs_log == [
+        {"working_dir": out_dir, "overwrite": True}
+    ]
+    # Overrides were applied in spec order.
+    assert fake_gmat_run.last_mission.overrides_log == [
+        ("Sat.SMA", 7000.0),
+        ("Sat.ECC", 0.01),
+    ]
+
+
+def test_run_one_ok_with_no_reports_returns_empty_output_paths(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    spec = _make_spec(output_dir=tmp_path / "run-0")
+    outcome = run_one(spec)
+
+    assert outcome.status == "ok"
+    assert outcome.output_paths == {}
+    assert outcome.stderr is None
+    assert (tmp_path / "run-0" / "worker.log").exists()
+
+
+def test_run_one_creates_output_dir_when_missing(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    nested = tmp_path / "a" / "b" / "run-0"
+    assert not nested.exists()
+    outcome = run_one(_make_spec(output_dir=nested))
+
+    assert outcome.status == "ok"
+    assert nested.is_dir()
+
+
+def test_run_one_logs_seed_when_set(tmp_path: Path, fake_gmat_run: FakeGmatRun) -> None:
+    spec = _make_spec(output_dir=tmp_path / "run-0", seed=1729)
+    run_one(spec)
+
+    log_text = (tmp_path / "run-0" / "worker.log").read_text(encoding="utf-8")
+    assert "seed=1729" in log_text
+
+
+# ---- failure modes -------------------------------------------------------
+
+
+def test_run_one_failed_when_override_raises(tmp_path: Path, fake_gmat_run: FakeGmatRun) -> None:
+    def _setitem(key: str, _value: Any) -> None:
+        if key == "Sat.ECC":
+            raise ValueError(f"GMAT rejected write to {key!r}: ECC > 1")
+
+    fake_gmat_run.install_loader(setitem_hook=_setitem)
+
+    out_dir = tmp_path / "run-0"
+    outcome = run_one(_make_spec(output_dir=out_dir, overrides={"Sat.SMA": 7000.0, "Sat.ECC": 1.5}))
+
+    assert outcome.status == "failed"
+    assert outcome.stderr is not None
+    assert "Sat.ECC" in outcome.stderr
+    assert "Traceback" in outcome.stderr
+    assert outcome.output_paths == {}
+    log_text = (out_dir / "worker.log").read_text(encoding="utf-8")
+    assert "status=failed" in log_text
+
+
+def test_run_one_failed_when_load_raises(tmp_path: Path, fake_gmat_run: FakeGmatRun) -> None:
+    fake_gmat_run.install_failing_loader(FileNotFoundError("/missions/nope.script does not exist"))
+
+    out_dir = tmp_path / "run-0"
+    outcome = run_one(_make_spec(output_dir=out_dir, script_name="nope.script"))
+
+    assert outcome.status == "failed"
+    assert outcome.stderr is not None
+    assert "nope.script" in outcome.stderr
+
+
+def test_run_one_failed_when_run_raises_includes_engine_log(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    engine_log = "GMAT: detailed engine error trace"
+
+    def _run(**_: Any) -> FakeResults:
+        raise FakeGmatRunError("RunScript returned status -1", log=engine_log)
+
+    fake_gmat_run.install_loader(run_hook=_run)
+
+    outcome = run_one(_make_spec(output_dir=tmp_path / "run-0"))
+
+    assert outcome.status == "failed"
+    assert outcome.stderr is not None
+    assert "RunScript returned status -1" in outcome.stderr
+    assert engine_log in outcome.stderr
+
+
+def test_run_one_failed_when_gmat_run_import_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Block the import without using the fake_gmat_run fixture: install a
+    # meta-path finder that raises ImportError for "gmat_run".
+    monkeypatch.delitem(sys.modules, "gmat_run", raising=False)
+
+    class _BlockingFinder:
+        def find_spec(self, name: str, _path: Any = None, _target: Any = None) -> None:
+            if name == "gmat_run":
+                raise ImportError("simulated gmat_run install failure")
+            return None
+
+    monkeypatch.setattr(sys, "meta_path", [_BlockingFinder(), *sys.meta_path])
+
+    out_dir = tmp_path / "run-0"
+    outcome = run_one(_make_spec(output_dir=out_dir))
+
+    assert outcome.status == "failed"
+    assert outcome.stderr is not None
+    assert "gmat_run" in outcome.stderr
+
+
+def test_run_one_failed_when_parquet_write_fails(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    df = pd.DataFrame({"t": [0.0]})
+
+    def _run(**_: Any) -> FakeResults:
+        return FakeResults(reports={"R1": df})
+
+    fake_gmat_run.install_loader(run_hook=_run)
+
+    out_dir = tmp_path / "run-0"
+    out_dir.mkdir()
+    # Block the parquet write by pre-creating R1.parquet as a *directory* —
+    # df.to_parquet then fails with IsADirectoryError / PermissionError.
+    (out_dir / "R1.parquet").mkdir()
+
+    outcome = run_one(_make_spec(output_dir=out_dir))
+
+    assert outcome.status == "failed"
+    assert outcome.stderr is not None
+    assert "Traceback" in outcome.stderr
+
+
+# ---- contract: never raises ----------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    ["load_raises", "setitem_raises", "run_raises", "import_blocked"],
+)
+def test_run_one_never_raises_for_known_failure_modes(
+    scenario: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
+) -> None:
+    if scenario == "import_blocked":
+        monkeypatch.delitem(sys.modules, "gmat_run", raising=False)
+
+        class _BlockingFinder:
+            def find_spec(self, name: str, _path: Any = None, _target: Any = None) -> None:
+                if name == "gmat_run":
+                    raise ImportError("blocked")
+                return None
+
+        monkeypatch.setattr(sys, "meta_path", [_BlockingFinder(), *sys.meta_path])
+    else:
+        fake = request.getfixturevalue("fake_gmat_run")
+        if scenario == "load_raises":
+            fake.install_failing_loader(RuntimeError("boom"))
+        elif scenario == "setitem_raises":
+
+            def _setitem(*_a: Any, **_k: Any) -> None:
+                raise RuntimeError("nope")
+
+            fake.install_loader(setitem_hook=_setitem)
+        elif scenario == "run_raises":
+
+            def _run(**_: Any) -> FakeResults:
+                raise RuntimeError("explosion")
+
+            fake.install_loader(run_hook=_run)
+
+    spec = _make_spec(output_dir=tmp_path / "run-0", overrides={"x": 1})
+    # The contract: this call returns; it does not raise.
+    outcome = run_one(spec)
+    assert outcome.status == "failed"
+    assert outcome.stderr
+
+
+# ---- defensive: a stale handler on the same logger does not bleed across runs ----
+
+
+def test_run_one_does_not_bleed_handlers_between_runs(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    import logging
+
+    spec_a = _make_spec(output_dir=tmp_path / "run-0", run_id=0)
+    spec_b = _make_spec(output_dir=tmp_path / "run-1", run_id=1)
+    run_one(spec_a)
+    run_one(spec_b)
+    run_one(spec_a)
+
+    # Same logger name across the two run_id=0 calls; we should not have
+    # accumulated multiple file handlers attached to it.
+    logger = logging.getLogger("gmat_sweep.worker.run_0")
+    assert logger.handlers == []


### PR DESCRIPTION
## Summary

- `gmat_sweep.worker.run_one(spec) -> RunOutcome`: lazy `import gmat_run` inside the function (driver process never bootstraps gmatpy), `Mission.load` → apply overrides via the dotted-path setter → `mission.run(working_dir=spec.output_dir, **spec.run_options)` → write each `ReportFile` to `<output_dir>/<name>.parquet`.
- Never raises (except `KeyboardInterrupt`): bootstrap failure, override rejection, `GmatRunError`, Parquet write failure all become `RunOutcome.failed(stderr=traceback)`. `GmatRunError`-style exceptions have their `.log` appended to `stderr` so the engine trail is preserved.
- Per-run `worker.log` under `spec.output_dir` for both ok and failed runs; the file handler is detached in `finally` so repeat calls on the same `run_id` do not bleed handlers.
- `tests/conftest.py` adds `FakeMission` / `FakeResults` / `FakeGmatRun` / `FakeGmatRunError` with `install_loader` / `install_failing_loader` helpers; `tests/test_worker.py` has 14 tests covering happy path, every failure mode, the parametrized never-raises contract, and a defensive handler-bleed check. `worker.py` at 100% line and branch coverage.

## Test plan

- [x] `uv run pytest` — 90 passed (14 new in `tests/test_worker.py`)
- [x] `uv run ruff check`
- [x] `uv run ruff format --check`
- [x] `uv run mypy` (strict, 22 source files)
- [x] `uv run coverage report --include='src/gmat_sweep/worker.py' --fail-under=90` — 100%
- [ ] Real-GMAT integration smoke (load a stock R2026a sample, assert Parquet output) — deferred to the integration-test infra issue (#11); this PR does not add any `@pytest.mark.integration` tests.
- [ ] EphemerisFile / ContactLocator aggregation — explicitly out of scope per the issue (v0.2).

Closes #6