### PR TITLE
Add lazy multi-indexed aggregation from per-run Parquet

### DIFF
--- a/src/gmat_sweep/__init__.py
+++ b/src/gmat_sweep/__init__.py
@@ -2,6 +2,7 @@
 
 from importlib.metadata import PackageNotFoundError, version
 
+from gmat_sweep.aggregate import lazy_multiindex
 from gmat_sweep.backends import Pool
 from gmat_sweep.errors import (
     BackendError,
@@ -35,4 +36,5 @@ __all__ = [
     "canonical_script_sha256",
     "expand_grid_to_run_specs",
     "full_factorial",
+    "lazy_multiindex",
 ]

--- a/src/gmat_sweep/aggregate.py
+++ b/src/gmat_sweep/aggregate.py
@@ -1,3 +1,189 @@
-"""Lazy assembly of the multi-indexed parent DataFrame from per-run Parquet files."""
+"""Lazy assembly of the multi-indexed parent DataFrame from per-run Parquet files.
+
+The single public entry point is :func:`lazy_multiindex`. It walks a
+:class:`gmat_sweep.manifest.Manifest`, reads each successful run's Parquet
+output through :mod:`pyarrow.dataset`, and stitches the per-run frames
+into one ``(run_id, time)``-indexed :class:`pandas.DataFrame`. Failed and
+skipped runs are materialised as one-row, NaN-filled slices so the
+caller sees a complete row per run rather than having to reconcile a
+``DataFrame`` against the manifest by hand.
+
+The default path streams each run's record batches through pandas one
+fragment at a time so peak conversion memory is one batch, not one full
+sweep. ``spool=False`` flips to an eager fragment-at-a-time read for
+small sweeps where the streaming overhead is not worth it; the result
+DataFrame is identical.
+
+v0.1 assumes one Parquet output per ``ok`` run. Multi-report runs raise
+:class:`NotImplementedError` and defer to the v0.2 reshape helpers.
+"""
 
 from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pyarrow.dataset as ds
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+
+    from gmat_sweep.manifest import Manifest, ManifestEntry
+
+__all__ = ["lazy_multiindex"]
+
+
+_INDEX_NAMES: tuple[str, str] = ("run_id", "time")
+_STATUS_COL = "__status"
+_TIME_COL = "time"
+
+
+def lazy_multiindex(
+    manifest: Manifest,
+    output_dir: Path,
+    *,
+    spool: bool = True,
+) -> pd.DataFrame:
+    """Assemble the public ``(run_id, time)``-indexed DataFrame from a sweep's outputs.
+
+    Iterates ``manifest.entries`` in order. For each ``ok`` entry the
+    sole Parquet listed in :attr:`ManifestEntry.output_paths` is read via
+    :mod:`pyarrow.dataset` and tagged with its ``run_id``. For each
+    ``failed`` or ``skipped`` entry one NaN-filled row is materialised
+    with ``time = NaT`` and ``__status`` set to the run-level status.
+    Relative paths in ``output_paths`` are resolved against ``output_dir``;
+    absolute paths are used as-is.
+
+    The returned frame has a ``(run_id, time)`` :class:`pandas.MultiIndex`,
+    a ``time`` level coerced to ``datetime64[ns]``, and a ``__status``
+    column populated for every row.
+
+    Parameters
+    ----------
+    manifest
+        The sweep manifest. Drives both the set of runs and their status.
+    output_dir
+        Sweep output root. Used to anchor any relative paths recorded in
+        the manifest.
+    spool
+        ``True`` (default) streams each run's record batches into pandas
+        one batch at a time. ``False`` reads each run's Parquet eagerly
+        in one shot — simpler control flow, higher peak memory.
+
+    Raises
+    ------
+    NotImplementedError
+        If an ``ok`` run has more than one Parquet output. v0.1 assumes a
+        single ReportFile per run; multi-report aggregation is deferred
+        to the v0.2 reshape helpers.
+    ValueError
+        If an ``ok`` entry has no ``output_paths``, or if a per-run
+        Parquet is missing the ``time`` column required for the index.
+    """
+    paths_with_run_id: list[tuple[Path, int]] = []
+    nonok_entries: list[ManifestEntry] = []
+    for entry in manifest.entries:
+        if entry.status == "ok":
+            if len(entry.output_paths) == 0:
+                raise ValueError(
+                    f"manifest entry for run_id={entry.run_id} has status='ok' but no output_paths"
+                )
+            if len(entry.output_paths) > 1:
+                raise NotImplementedError(
+                    f"run_id={entry.run_id} produced {len(entry.output_paths)} Parquet "
+                    "outputs; v0.1 lazy_multiindex assumes one ReportFile per run. "
+                    "Multi-report aggregation is deferred to the v0.2 reshape helpers."
+                )
+            ((_name, raw_path),) = entry.output_paths.items()
+            resolved = raw_path if raw_path.is_absolute() else output_dir / raw_path
+            paths_with_run_id.append((resolved, entry.run_id))
+        else:
+            nonok_entries.append(entry)
+
+    ok_df = _read_ok_runs(paths_with_run_id, spool=spool)
+    data_columns = [c for c in ok_df.columns if c != _STATUS_COL] if not ok_df.empty else []
+    nonok_df = _materialise_nonok(nonok_entries, data_columns=data_columns)
+
+    parts = [df for df in (ok_df, nonok_df) if not df.empty]
+    if not parts:
+        return _empty_frame()
+
+    return cast(pd.DataFrame, pd.concat(parts, axis=0).sort_index())
+
+
+def _read_ok_runs(
+    paths_with_run_id: Sequence[tuple[Path, int]],
+    *,
+    spool: bool,
+) -> pd.DataFrame:
+    if not paths_with_run_id:
+        return pd.DataFrame()
+
+    paths_str = [str(p) for p, _ in paths_with_run_id]
+    path_to_run_id = {str(p): run_id for p, run_id in paths_with_run_id}
+
+    dataset = ds.dataset(paths_str, format="parquet")  # type: ignore[no-untyped-call]
+
+    frames: list[pd.DataFrame] = []
+    for fragment in dataset.get_fragments():
+        run_id = path_to_run_id[fragment.path]
+        if spool:
+            for batch in fragment.to_batches():
+                frames.append(_batch_to_pandas(batch, run_id))
+        else:
+            table = fragment.to_table()
+            frames.append(_batch_to_pandas(table, run_id))
+
+    if not frames:
+        return pd.DataFrame()
+
+    merged = pd.concat(frames, ignore_index=True)
+    if _TIME_COL not in merged.columns:
+        raise ValueError(
+            "per-run Parquet output is missing the 'time' column required for the "
+            "(run_id, time) MultiIndex"
+        )
+    merged[_TIME_COL] = pd.to_datetime(merged[_TIME_COL]).astype("datetime64[ns]")
+    merged[_STATUS_COL] = "ok"
+    return cast(pd.DataFrame, merged.set_index(list(_INDEX_NAMES)))
+
+
+def _batch_to_pandas(batch_or_table: Any, run_id: int) -> pd.DataFrame:
+    n_rows = batch_or_table.num_rows
+    run_id_col = pa.array([run_id] * n_rows, type=pa.int64())
+    augmented = batch_or_table.append_column("run_id", run_id_col)
+    return cast(pd.DataFrame, augmented.to_pandas())
+
+
+def _materialise_nonok(
+    entries: Sequence[ManifestEntry],
+    *,
+    data_columns: Sequence[str],
+) -> pd.DataFrame:
+    if not entries:
+        return pd.DataFrame()
+
+    rows: dict[str, list[Any]] = {col: [np.nan] * len(entries) for col in data_columns}
+    rows["run_id"] = [e.run_id for e in entries]
+    rows[_TIME_COL] = [pd.NaT] * len(entries)
+    rows[_STATUS_COL] = [e.status for e in entries]
+
+    df = pd.DataFrame(rows)
+    df[_TIME_COL] = pd.to_datetime(df[_TIME_COL]).astype("datetime64[ns]")
+    return cast(pd.DataFrame, df.set_index(list(_INDEX_NAMES)))
+
+
+def _empty_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        {_STATUS_COL: pd.Series([], dtype="object")},
+        index=pd.MultiIndex.from_arrays(
+            [
+                pd.Series([], dtype="int64"),
+                pd.Series([], dtype="datetime64[ns]"),
+            ],
+            names=list(_INDEX_NAMES),
+        ),
+    )

--- a/src/gmat_sweep/aggregate.py
+++ b/src/gmat_sweep/aggregate.py
@@ -20,6 +20,7 @@ v0.1 assumes one Parquet output per ``ok`` run. Multi-report runs raise
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
@@ -29,7 +30,6 @@ import pyarrow.dataset as ds
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-    from pathlib import Path
 
     from gmat_sweep.manifest import Manifest, ManifestEntry
 
@@ -122,14 +122,18 @@ def _read_ok_runs(
     if not paths_with_run_id:
         return pd.DataFrame()
 
-    paths_str = [str(p) for p, _ in paths_with_run_id]
-    path_to_run_id = {str(p): run_id for p, run_id in paths_with_run_id}
+    # pyarrow normalises filesystem paths to forward-slash form on every
+    # platform, so we key path -> run_id in POSIX form and look up
+    # fragment.path the same way. Without this, str(WindowsPath(...)) on
+    # Windows produces backslash keys that never match what pyarrow returns.
+    paths_str = [Path(p).as_posix() for p, _ in paths_with_run_id]
+    path_to_run_id = {Path(p).as_posix(): run_id for p, run_id in paths_with_run_id}
 
     dataset = ds.dataset(paths_str, format="parquet")  # type: ignore[no-untyped-call]
 
     frames: list[pd.DataFrame] = []
     for fragment in dataset.get_fragments():
-        run_id = path_to_run_id[fragment.path]
+        run_id = path_to_run_id[Path(fragment.path).as_posix()]
         if spool:
             for batch in fragment.to_batches():
                 frames.append(_batch_to_pandas(batch, run_id))

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -1,0 +1,220 @@
+"""Tests for gmat_sweep.aggregate — lazy multi-indexed result assembly from Parquet."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from gmat_sweep.aggregate import lazy_multiindex
+from gmat_sweep.manifest import Manifest, ManifestEntry
+
+
+def _utc(year: int, month: int, day: int, h: int = 0, m: int = 0, s: int = 0) -> datetime:
+    return datetime(year, month, day, h, m, s, tzinfo=timezone.utc)
+
+
+def _make_manifest(entries: list[ManifestEntry]) -> Manifest:
+    return Manifest(
+        script_sha256="a" * 64,
+        gmat_sweep_version="0.1.0",
+        gmat_run_version="0.4.0",
+        gmat_install_version="R2026a",
+        python_version="3.12.3",
+        os_platform="Linux-6.6.0",
+        sweep_seed=None,
+        parameter_spec={},
+        run_count=len(entries),
+        entries=entries,
+    )
+
+
+def _ok_entry(run_id: int, parquet_path: Path) -> ManifestEntry:
+    return ManifestEntry(
+        run_id=run_id,
+        overrides={},
+        status="ok",
+        output_paths={"ReportFile1": parquet_path},
+        started_at=_utc(2026, 5, 4),
+        ended_at=_utc(2026, 5, 4, 0, 0, 1),
+        duration_s=1.0,
+        stderr=None,
+        log_path=None,
+    )
+
+
+def _nonok_entry(run_id: int, status: str) -> ManifestEntry:
+    return ManifestEntry(
+        run_id=run_id,
+        overrides={},
+        status=status,  # type: ignore[arg-type]
+        output_paths={},
+        started_at=_utc(2026, 5, 4),
+        ended_at=_utc(2026, 5, 4, 0, 0, 1),
+        duration_s=1.0,
+        stderr="boom" if status == "failed" else None,
+        log_path=None,
+    )
+
+
+def _write_run_parquet(output_dir: Path, run_id: int, *, n_rows: int = 3) -> Path:
+    path = output_dir / f"run-{run_id}" / "ReportFile1.parquet"
+    path.parent.mkdir(parents=True)
+    df = pd.DataFrame(
+        {
+            "time": pd.to_datetime(
+                [f"2026-05-04T00:00:0{i}" for i in range(n_rows)],
+            ),
+            "x": [run_id * 10 + i for i in range(n_rows)],
+            "y": [run_id * 100 + i * 2 for i in range(n_rows)],
+        }
+    )
+    df.to_parquet(path)
+    return path
+
+
+# ---- happy paths ----------------------------------------------------------
+
+
+def test_lazy_multiindex_16_run_all_ok(tmp_path: Path) -> None:
+    paths = [_write_run_parquet(tmp_path, i) for i in range(16)]
+    manifest = _make_manifest([_ok_entry(i, p) for i, p in enumerate(paths)])
+
+    df = lazy_multiindex(manifest, tmp_path)
+
+    assert df.index.names == ["run_id", "time"]
+    run_ids = sorted(df.index.get_level_values("run_id").unique().tolist())
+    assert run_ids == list(range(16))
+    assert df.index.get_level_values("time").dtype == "datetime64[ns]"
+    assert (df["__status"] == "ok").all()
+    assert len(df) == 16 * 3
+    assert {"x", "y", "__status"} == set(df.columns)
+
+
+def test_lazy_multiindex_15_ok_plus_one_failed(tmp_path: Path) -> None:
+    paths = [_write_run_parquet(tmp_path, i, n_rows=2) for i in range(15)]
+    entries: list[ManifestEntry] = [_ok_entry(i, p) for i, p in enumerate(paths)]
+    entries.append(_nonok_entry(15, "failed"))
+
+    df = lazy_multiindex(_make_manifest(entries), tmp_path)
+
+    assert len(df) == 15 * 2 + 1
+    failed_rows = df.xs(15, level="run_id")
+    assert len(failed_rows) == 1
+    assert (failed_rows["__status"] == "failed").all()
+    assert failed_rows[["x", "y"]].isna().all().all()
+    assert (df.loc[df["__status"] == "ok"]).shape[0] == 15 * 2
+
+
+def test_lazy_multiindex_skipped_run(tmp_path: Path) -> None:
+    p = _write_run_parquet(tmp_path, 0, n_rows=2)
+    manifest = _make_manifest([_ok_entry(0, p), _nonok_entry(1, "skipped")])
+
+    df = lazy_multiindex(manifest, tmp_path)
+
+    skipped = df.xs(1, level="run_id")
+    assert (skipped["__status"] == "skipped").all()
+    assert skipped[["x", "y"]].isna().all().all()
+
+
+def test_lazy_multiindex_spool_false_matches_spool_true(tmp_path: Path) -> None:
+    paths = [_write_run_parquet(tmp_path, i, n_rows=3) for i in range(4)]
+    manifest = _make_manifest([_ok_entry(i, p) for i, p in enumerate(paths)])
+
+    streamed = lazy_multiindex(manifest, tmp_path, spool=True)
+    eager = lazy_multiindex(manifest, tmp_path, spool=False)
+
+    pd.testing.assert_frame_equal(streamed, eager)
+
+
+def test_lazy_multiindex_relative_paths_resolve_against_output_dir(tmp_path: Path) -> None:
+    abs_path = _write_run_parquet(tmp_path, 0, n_rows=2)
+    rel_path = abs_path.relative_to(tmp_path)
+    entry = ManifestEntry(
+        run_id=0,
+        overrides={},
+        status="ok",
+        output_paths={"ReportFile1": rel_path},
+        started_at=_utc(2026, 5, 4),
+        ended_at=_utc(2026, 5, 4, 0, 0, 1),
+        duration_s=1.0,
+        stderr=None,
+        log_path=None,
+    )
+
+    df = lazy_multiindex(_make_manifest([entry]), tmp_path)
+    assert len(df) == 2
+
+
+# ---- empty / degenerate cases --------------------------------------------
+
+
+def test_lazy_multiindex_empty_manifest(tmp_path: Path) -> None:
+    df = lazy_multiindex(_make_manifest([]), tmp_path)
+
+    assert df.empty
+    assert df.index.names == ["run_id", "time"]
+    assert "__status" in df.columns
+    assert df.index.get_level_values("time").dtype == "datetime64[ns]"
+
+
+def test_lazy_multiindex_all_failed(tmp_path: Path) -> None:
+    entries = [_nonok_entry(i, "failed") for i in range(3)]
+
+    df = lazy_multiindex(_make_manifest(entries), tmp_path)
+
+    assert len(df) == 3
+    assert (df["__status"] == "failed").all()
+    assert list(df.columns) == ["__status"]
+
+
+# ---- error paths ---------------------------------------------------------
+
+
+def test_lazy_multiindex_multi_report_run_raises(tmp_path: Path) -> None:
+    p1 = _write_run_parquet(tmp_path, 0, n_rows=2)
+    p2 = tmp_path / "run-0" / "ReportFile2.parquet"
+    pd.DataFrame({"time": pd.to_datetime(["2026-05-04T00:00:00"]), "x": [0]}).to_parquet(p2)
+
+    entry = ManifestEntry(
+        run_id=0,
+        overrides={},
+        status="ok",
+        output_paths={"ReportFile1": p1, "ReportFile2": p2},
+        started_at=_utc(2026, 5, 4),
+        ended_at=_utc(2026, 5, 4, 0, 0, 1),
+        duration_s=1.0,
+        stderr=None,
+        log_path=None,
+    )
+
+    with pytest.raises(NotImplementedError, match=r"v0\.2"):
+        lazy_multiindex(_make_manifest([entry]), tmp_path)
+
+
+def test_lazy_multiindex_ok_entry_with_no_outputs_raises(tmp_path: Path) -> None:
+    entry = ManifestEntry(
+        run_id=0,
+        overrides={},
+        status="ok",
+        output_paths={},
+        started_at=_utc(2026, 5, 4),
+        ended_at=_utc(2026, 5, 4, 0, 0, 1),
+        duration_s=1.0,
+        stderr=None,
+        log_path=None,
+    )
+
+    with pytest.raises(ValueError, match="no output_paths"):
+        lazy_multiindex(_make_manifest([entry]), tmp_path)
+
+
+def test_lazy_multiindex_missing_time_column_raises(tmp_path: Path) -> None:
+    path = tmp_path / "run-0" / "ReportFile1.parquet"
+    path.parent.mkdir(parents=True)
+    pd.DataFrame({"x": [1, 2, 3]}).to_parquet(path)
+
+    with pytest.raises(ValueError, match="time"):
+        lazy_multiindex(_make_manifest([_ok_entry(0, path)]), tmp_path)


### PR DESCRIPTION
## Summary

- `gmat_sweep.aggregate.lazy_multiindex(manifest, output_dir, *, spool=True)` walks a `Manifest` and assembles a `(run_id, time)`-MultiIndexed `pandas.DataFrame` from each `ok` run's Parquet output. Failed and skipped runs land as one-row, NaN-filled slices with `__status` set from the manifest entry, so the result has one row block per run regardless of outcome.
- `spool=True` (default) reads each run's record batches through `pyarrow.dataset` one fragment at a time so peak conversion memory is one batch, not one full sweep. `spool=False` switches to a fragment-at-a-time eager `to_table()` read for small sweeps; output frames are identical.
- v0.1 assumes one Parquet output per `ok` run. Multi-report runs raise `NotImplementedError` pointing at the v0.2 reshape helpers; `ok` entries with no `output_paths` and Parquet outputs missing the `time` column raise `ValueError`. Relative paths in `output_paths` are anchored to `output_dir`.

## Test plan

- [x] 10 new unit tests in `tests/test_aggregate.py` covering the 16-run all-ok happy path, 15-ok+1-failed and skipped mixes, `spool=True`/`False` equivalence, relative-path resolution, empty and all-failed manifests, and the three error paths.
- [x] `uv run pytest` — 120/120 passing.
- [x] `uv run ruff check` and `uv run ruff format --check` — clean.
- [x] `uv run mypy` — clean under `--strict`.
- [x] `aggregate.py` at 98% line+branch coverage (>=95% per-file gate).

Closes #8