### PR TITLE
Add Sweep orchestrator and public sweep() API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,12 @@ ignore_missing_imports = true
 module = ["pyarrow", "pyarrow.*"]
 ignore_missing_imports = true
 
+# tqdm ships no py.typed marker; sweep.py imports tqdm.auto and only uses the
+# .update / .close surface for the orchestrator's progress bar.
+[[tool.mypy.overrides]]
+module = ["tqdm", "tqdm.*"]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 minversion = "8.0"
 testpaths = ["tests"]

--- a/src/gmat_sweep/__init__.py
+++ b/src/gmat_sweep/__init__.py
@@ -1,8 +1,10 @@
 """gmat-sweep: parameter sweeps and Monte Carlo dispersions over GMAT missions in parallel."""
 
+import logging
 from importlib.metadata import PackageNotFoundError, version
 
 from gmat_sweep.aggregate import lazy_multiindex
+from gmat_sweep.api import sweep
 from gmat_sweep.backends import Pool
 from gmat_sweep.errors import (
     BackendError,
@@ -14,11 +16,21 @@ from gmat_sweep.errors import (
 from gmat_sweep.grids import expand_grid_to_run_specs, full_factorial
 from gmat_sweep.manifest import Manifest, ManifestEntry, canonical_script_sha256
 from gmat_sweep.spec import RunOutcome, RunSpec, SweepSpec
+from gmat_sweep.sweep import Sweep
 
 try:
     __version__ = version("gmat-sweep")
 except PackageNotFoundError:
     __version__ = "0.0.0"
+
+# Default the gmat-sweep logger to WARNING. Sweep orchestration emits
+# diagnostic INFO records on every per-run completion that would otherwise
+# spam the parent process. Only set the level if the user has not configured
+# it before importing gmat-sweep, so explicit `logging.getLogger("gmat_sweep")`
+# config wins.
+_logger = logging.getLogger(__name__)
+if _logger.level == logging.NOTSET:
+    _logger.setLevel(logging.WARNING)
 
 __all__ = [
     "BackendError",
@@ -30,6 +42,7 @@ __all__ = [
     "RunFailed",
     "RunOutcome",
     "RunSpec",
+    "Sweep",
     "SweepConfigError",
     "SweepSpec",
     "__version__",
@@ -37,4 +50,5 @@ __all__ = [
     "expand_grid_to_run_specs",
     "full_factorial",
     "lazy_multiindex",
+    "sweep",
 ]

--- a/src/gmat_sweep/api.py
+++ b/src/gmat_sweep/api.py
@@ -1,3 +1,124 @@
-"""Public entry points: sweep, monte_carlo, latin_hypercube."""
+"""Public entry points: sweep, monte_carlo, latin_hypercube.
+
+v0.1 ships :func:`sweep` only — the full-factorial parameter-grid path. The
+Monte Carlo and Latin hypercube wrappers land in v0.2 alongside
+:mod:`gmat_sweep.distributions`.
+"""
 
 from __future__ import annotations
+
+import tempfile
+import weakref
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from gmat_sweep.backends.joblib import LocalJoblibPool
+from gmat_sweep.grids import expand_grid_to_run_specs
+from gmat_sweep.sweep import Sweep
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+__all__ = ["sweep"]
+
+# Manifest filename inside the sweep's output directory. Picked to match the
+# JSON Lines format suffix for grep-friendliness; downstream consumers
+# (resume, CLI show) load it back with :meth:`Manifest.load`.
+_MANIFEST_FILENAME = "manifest.jsonl"
+
+
+def sweep(
+    mission: str | Path,
+    *,
+    grid: Mapping[str, Iterable[Any]],
+    workers: int = -1,
+    out: Path | None = None,
+    seed: int | None = None,
+) -> pd.DataFrame:
+    """Run a full-factorial parameter sweep over a GMAT mission.
+
+    Builds the cartesian product of ``grid`` into one :class:`RunSpec` per
+    combination, dispatches them through a fresh :class:`LocalJoblibPool`,
+    appends each completion to a JSON Lines manifest under ``out``, and
+    returns the aggregated ``(run_id, time)``-MultiIndexed
+    :class:`pandas.DataFrame`.
+
+    Parameters
+    ----------
+    mission:
+        Path to the GMAT ``.script`` file every run loads.
+    grid:
+        Mapping from dotted-path field name (e.g. ``"Sat.SMA"``) to the
+        sequence of values to sweep. Iterables are materialised once at call
+        time so callers may pass generators.
+    workers:
+        Number of subprocess workers. ``-1`` (default) uses every available
+        core; positive integers cap the pool. Forwarded to
+        :class:`LocalJoblibPool`.
+    out:
+        Sweep output directory. ``None`` (default) creates a fresh
+        :class:`tempfile.TemporaryDirectory` whose lifetime is tied to the
+        returned DataFrame — the temp dir survives until the caller drops the
+        DataFrame, mirroring the :meth:`gmat_run.Mission.run` Results lifetime
+        trick. Pass an explicit path to keep the per-run Parquet files and
+        the manifest after the call returns.
+    seed:
+        Optional integer recorded on the manifest header. v0.1 does not
+        consume it; reserved for v0.2 Monte Carlo runs.
+
+    Returns
+    -------
+    pandas.DataFrame
+        ``(run_id, time)``-MultiIndexed frame produced by
+        :func:`gmat_sweep.aggregate.lazy_multiindex`. Failed and skipped runs
+        appear as one NaN-filled row with ``__status`` set accordingly — a
+        single bad run does not abort the sweep or raise from this call.
+    """
+    mission_path = Path(mission)
+
+    # Materialise grid values once: expand_grid_to_run_specs would do it for
+    # the cartesian product, but we also need the materialised dict for the
+    # manifest header (generators don't survive json.dumps), so do it up
+    # front and reuse the same object.
+    materialised_grid: dict[str, list[Any]] = {k: list(v) for k, v in grid.items()}
+
+    tempdir: tempfile.TemporaryDirectory[str] | None
+    if out is None:
+        tempdir = tempfile.TemporaryDirectory(prefix="gmat-sweep-")
+        output_dir = Path(tempdir.name)
+    else:
+        tempdir = None
+        output_dir = Path(out)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+    runs = expand_grid_to_run_specs(materialised_grid, mission_path, output_dir)
+    manifest_path = output_dir / _MANIFEST_FILENAME
+
+    with LocalJoblibPool(workers=workers) as pool:
+        df = (
+            Sweep(
+                runs=runs,
+                backend=pool,
+                manifest_path=manifest_path,
+                output_dir=output_dir,
+                script_path=mission_path,
+                parameter_spec=materialised_grid,
+                sweep_seed=seed,
+            )
+            .run()
+            .to_dataframe()
+        )
+
+    if tempdir is not None:
+        # Defer temp-dir cleanup until the user drops the DataFrame so any
+        # downstream Parquet read against a path recorded in the manifest
+        # still finds the file. lazy_multiindex materialises every per-run
+        # frame into memory before returning, so the DataFrame itself is
+        # self-contained — but the manifest path references on disk only
+        # remain valid until the temp dir is removed. weakref.finalize keeps
+        # the TemporaryDirectory alive (its bound cleanup method is the
+        # callback) until the DataFrame is collected.
+        weakref.finalize(df, tempdir.cleanup)
+
+    return df

--- a/src/gmat_sweep/sweep.py
+++ b/src/gmat_sweep/sweep.py
@@ -1,3 +1,194 @@
-"""Sweep orchestrator: owns the run iterable, backend, manifest, and output dir."""
+"""Sweep orchestrator: owns the run iterable, backend, manifest, and output dir.
+
+The single public class is :class:`Sweep`. It binds a list of
+:class:`gmat_sweep.spec.RunSpec` to a backend :class:`gmat_sweep.backends.base.Pool`,
+fans the specs out, drains the resulting outcomes in completion order, and
+records each one as a :class:`gmat_sweep.manifest.ManifestEntry` with an
+fsynced append so a mid-sweep ``Ctrl-C`` leaves a parseable manifest on disk.
+
+The class does **not** own the pool's lifecycle — wrap the supplied
+:class:`Pool` in a ``with`` block at the call site (or call ``close()``)
+so worker processes are cleaned up. The thin :func:`gmat_sweep.api.sweep`
+wrapper takes care of this for the common case.
+"""
 
 from __future__ import annotations
+
+import platform
+from collections.abc import Mapping, Sequence
+from concurrent.futures import Future
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from tqdm.auto import tqdm
+
+from gmat_sweep.aggregate import lazy_multiindex
+from gmat_sweep.manifest import Manifest, ManifestEntry, canonical_script_sha256
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+    from gmat_sweep.backends.base import Pool
+    from gmat_sweep.spec import RunOutcome, RunSpec
+
+__all__ = ["Sweep"]
+
+# Per-run worker log file name. The worker (gmat_sweep.worker.run_one) writes
+# this file under each spec's output_dir; the manifest entry records the path
+# so a downstream "show me the log for failed run N" lookup is one join away.
+_WORKER_LOG_NAME = "worker.log"
+
+
+class Sweep:
+    """Bind run specs, a pool, and a manifest path into a runnable orchestrator.
+
+    Parameters
+    ----------
+    runs:
+        The :class:`RunSpec` instances to dispatch. ``run_id`` values must be
+        unique. Order is preserved on the submission side; outcomes return in
+        completion order.
+    backend:
+        A constructed :class:`Pool`. The caller owns its lifecycle — typically
+        a ``with LocalJoblibPool(...) as pool:`` block.
+    manifest_path:
+        Where the JSON Lines manifest will be written. Parent directories are
+        created on :meth:`run`.
+    output_dir:
+        Sweep root the per-run output directories live under. Used as the
+        anchor for any relative paths the manifest records.
+    script_path:
+        The ``.script`` every run loads. Hashed via
+        :func:`canonical_script_sha256` for the manifest header.
+    parameter_spec:
+        The original sweep parameterisation (e.g. the materialised grid) —
+        recorded verbatim in the manifest header for reproducibility.
+    sweep_seed:
+        Optional integer seed recorded on the manifest. v0.1 does not consume
+        it; reserved for v0.2 Monte Carlo runs.
+    progress:
+        ``True`` (default) wraps the drain loop in a :mod:`tqdm` bar.
+        Set to ``False`` for non-interactive use (tests, CI logs).
+    """
+
+    def __init__(
+        self,
+        *,
+        runs: Sequence[RunSpec],
+        backend: Pool,
+        manifest_path: Path,
+        output_dir: Path,
+        script_path: Path,
+        parameter_spec: Mapping[str, Any],
+        sweep_seed: int | None = None,
+        progress: bool = True,
+    ) -> None:
+        self._runs: list[RunSpec] = list(runs)
+        self._backend = backend
+        self._manifest_path = Path(manifest_path)
+        self._output_dir = Path(output_dir)
+        self._script_path = Path(script_path)
+        self._parameter_spec: dict[str, Any] = dict(parameter_spec)
+        self._sweep_seed = sweep_seed
+        self._progress = progress
+        self._manifest: Manifest | None = None
+
+    def run(self) -> Sweep:
+        """Submit every run, drain outcomes in completion order, return ``self``.
+
+        Builds and saves the manifest header up front (one fsync, with the
+        parent directory created on demand). For each completed
+        :class:`RunOutcome` an entry is appended via
+        :meth:`Manifest.append_entry`, which fsyncs each line — a ``Ctrl-C``
+        between any two iterations leaves a parseable file containing exactly
+        the runs that finished.
+
+        :exc:`KeyboardInterrupt` is not caught; it propagates so the caller's
+        ``with``-managed pool exits and cancels still-pending futures.
+        """
+        manifest = self._build_manifest()
+        manifest.save(self._manifest_path)
+        self._manifest = manifest
+
+        specs_by_run_id: dict[int, RunSpec] = {s.run_id: s for s in self._runs}
+        futures: list[Future[RunOutcome]] = [self._backend.submit(s) for s in self._runs]
+
+        progress_bar = tqdm(
+            total=len(self._runs),
+            disable=not self._progress,
+            desc="gmat-sweep",
+            unit="run",
+        )
+        try:
+            for outcome in self._backend.as_completed(futures):
+                spec = specs_by_run_id[outcome.run_id]
+                entry = ManifestEntry.from_outcome(
+                    outcome,
+                    overrides=spec.overrides,
+                    log_path=spec.output_dir / _WORKER_LOG_NAME,
+                )
+                manifest.append_entry(entry)
+                progress_bar.update(1)
+        finally:
+            progress_bar.close()
+
+        return self
+
+    def to_manifest(self) -> Manifest:
+        """Return the manifest populated by :meth:`run`."""
+        if self._manifest is None:
+            raise RuntimeError("Sweep.to_manifest requires Sweep.run() to have been called")
+        return self._manifest
+
+    def to_dataframe(self) -> pd.DataFrame:
+        """Aggregate the sweep's per-run Parquet outputs into one DataFrame."""
+        return lazy_multiindex(self.to_manifest(), self._output_dir)
+
+    def _build_manifest(self) -> Manifest:
+        # Local import: gmat_sweep.__init__ sets __version__ as part of module
+        # load, but importing it at module top level would create a cycle
+        # (gmat_sweep imports Sweep). Resolved lazily on first run() call.
+        from gmat_sweep import __version__ as sweep_version
+
+        return Manifest(
+            script_sha256=canonical_script_sha256(self._script_path),
+            gmat_sweep_version=sweep_version,
+            gmat_run_version=_gmat_run_version(),
+            gmat_install_version=_gmat_install_version(),
+            python_version=platform.python_version(),
+            os_platform=platform.platform(),
+            sweep_seed=self._sweep_seed,
+            parameter_spec=self._parameter_spec,
+            run_count=len(self._runs),
+        )
+
+
+def _gmat_run_version() -> str:
+    """Return ``gmat_run.__version__`` if importable, else ``"unknown"``.
+
+    Importing :mod:`gmat_run` does not bootstrap ``gmatpy`` (the heavy SWIG
+    bring-up happens inside :meth:`gmat_run.Mission.load`), so this is safe to
+    call from the driver process.
+    """
+    try:
+        import gmat_run
+    except ImportError:
+        return "unknown"
+    return str(getattr(gmat_run, "__version__", "unknown"))
+
+
+def _gmat_install_version() -> str:
+    """Return the resolved GMAT install version, or ``"unknown"`` on any failure.
+
+    :func:`gmat_run.install.locate_gmat` walks the filesystem and reads version
+    files — it does not bootstrap ``gmatpy`` and so is cheap from the driver.
+    Any failure (gmat-run missing, no install discoverable, version file
+    unreadable) maps to ``"unknown"`` so the manifest header is always built.
+    """
+    try:
+        from gmat_run.install import locate_gmat
+
+        info = locate_gmat()
+    except Exception:
+        return "unknown"
+    return info.version or "unknown"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,210 @@
+"""Tests for gmat_sweep.api.sweep — end-to-end wrapper over Sweep + LocalJoblibPool."""
+
+from __future__ import annotations
+
+import gc
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pytest
+
+from gmat_sweep.api import sweep
+from gmat_sweep.manifest import Manifest
+from tests.conftest import FakeGmatRun, FakeResults
+
+
+def _write_script(tmp_path: Path) -> Path:
+    path = tmp_path / "mission.script"
+    path.write_text("% GMAT mission\nCreate Spacecraft Sat;\n", encoding="utf-8")
+    return path
+
+
+def _payload_run_hook(value: float = 1.0) -> Any:
+    payload = pd.DataFrame({"time": pd.to_datetime(["2026-05-04T00:00:00"]), "x": [value]})
+
+    def _run(**_: Any) -> FakeResults:
+        return FakeResults(reports={"R": payload})
+
+    return _run
+
+
+# ---- explicit out --------------------------------------------------------
+
+
+def test_sweep_returns_multiindexed_dataframe(tmp_path: Path, fake_gmat_run: FakeGmatRun) -> None:
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    df = sweep(
+        script,
+        grid={"Sat.SMA": [7000.0, 7100.0]},
+        workers=1,
+        out=out,
+    )
+
+    assert df.index.names == ["run_id", "time"]
+    assert sorted(df.index.get_level_values("run_id").unique().tolist()) == [0, 1]
+    assert (out / "manifest.jsonl").exists()
+
+
+def test_sweep_writes_manifest_with_grid_in_header(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    sweep(
+        script,
+        grid={"Sat.SMA": [7000.0, 7100.0]},
+        workers=1,
+        out=out,
+        seed=42,
+    )
+
+    manifest = Manifest.load(out / "manifest.jsonl")
+    assert manifest.parameter_spec == {"Sat.SMA": [7000.0, 7100.0]}
+    assert manifest.sweep_seed == 42
+    assert manifest.run_count == 2
+
+
+def test_sweep_string_path_is_accepted(tmp_path: Path, fake_gmat_run: FakeGmatRun) -> None:
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    df = sweep(
+        str(script),
+        grid={"Sat.SMA": [7000.0]},
+        workers=1,
+        out=out,
+    )
+
+    assert len(df) == 1
+
+
+def test_sweep_creates_out_directory_when_missing(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    script = _write_script(tmp_path)
+    out = tmp_path / "does" / "not" / "exist"
+    assert not out.exists()
+
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    sweep(script, grid={"Sat.SMA": [7000.0]}, workers=1, out=out)
+
+    assert out.is_dir()
+    assert (out / "manifest.jsonl").exists()
+
+
+# ---- no out: temp dir lifetime --------------------------------------------
+
+
+def test_sweep_with_no_out_returns_usable_dataframe(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    """lazy_multiindex materialises Parquet in-memory before returning, so the
+    DataFrame is usable even after the temp dir would have been GC'd."""
+    script = _write_script(tmp_path)
+
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook(value=3.14))
+
+    df = sweep(
+        script,
+        grid={"Sat.SMA": [7000.0]},
+        workers=1,
+        out=None,
+    )
+
+    assert df["x"].iloc[0] == 3.14
+
+
+def test_sweep_with_no_out_cleans_up_temp_dir_after_df_dropped(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Dropping the returned DataFrame triggers the weakref finalizer that
+    cleans up the sweep-scoped temp directory."""
+    import tempfile as _tempfile
+
+    captured_paths: list[Path] = []
+    real_tempdir = _tempfile.TemporaryDirectory
+
+    def _spy_tempdir(*args: Any, **kwargs: Any) -> Any:
+        td = real_tempdir(*args, **kwargs)
+        captured_paths.append(Path(td.name))
+        return td
+
+    monkeypatch.setattr("gmat_sweep.api.tempfile.TemporaryDirectory", _spy_tempdir)
+
+    script = _write_script(tmp_path)
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    df = sweep(script, grid={"Sat.SMA": [7000.0]}, workers=1, out=None)
+
+    assert len(captured_paths) == 1
+    sweep_dir = captured_paths[0]
+    assert sweep_dir.is_dir()
+
+    del df
+    gc.collect()
+
+    assert not sweep_dir.exists()
+
+
+# ---- failure modes don't raise -------------------------------------------
+
+
+def test_sweep_with_failing_run_includes_failed_row(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+
+    def _setitem(_key: str, value: Any) -> None:
+        if value == 7100.0:
+            raise ValueError("rejected")
+
+    fake_gmat_run.install_loader(setitem_hook=_setitem, run_hook=_payload_run_hook())
+
+    df = sweep(
+        script,
+        grid={"Sat.SMA": [7000.0, 7100.0]},
+        workers=1,
+        out=out,
+    )
+
+    statuses = set(df["__status"].unique())
+    assert statuses == {"ok", "failed"}
+
+
+# ---- empty grid ----------------------------------------------------------
+
+
+def test_sweep_with_empty_grid_runs_once(tmp_path: Path, fake_gmat_run: FakeGmatRun) -> None:
+    """full_factorial({}) yields a single empty override dict; sweep() honours it."""
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    df = sweep(script, grid={}, workers=1, out=out)
+
+    run_ids = sorted(df.index.get_level_values("run_id").unique().tolist())
+    assert run_ids == [0]
+
+
+# ---- module-import-time logger config -----------------------------------
+
+
+def test_gmat_sweep_logger_default_level_is_warning() -> None:
+    """gmat_sweep configures its top-level logger at module import; without it
+    every per-run INFO record would land in the parent process's handlers."""
+    import logging
+
+    assert logging.getLogger("gmat_sweep").level == logging.WARNING

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -1,0 +1,324 @@
+"""Tests for gmat_sweep.sweep — orchestrator wiring, manifest fsync, ctrl-c safety."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from concurrent.futures import Future
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pytest
+
+from gmat_sweep.backends.base import Pool
+from gmat_sweep.backends.joblib import LocalJoblibPool
+from gmat_sweep.manifest import Manifest, canonical_script_sha256
+from gmat_sweep.spec import RunOutcome, RunSpec
+from gmat_sweep.sweep import Sweep
+from tests.conftest import FakeGmatRun, FakeResults
+
+
+def _write_script(tmp_path: Path, name: str = "mission.script") -> Path:
+    path = tmp_path / name
+    path.write_text("% GMAT script\nCreate Spacecraft Sat;\n", encoding="utf-8")
+    return path
+
+
+def _make_runs(script: Path, output_dir: Path, n: int) -> list[RunSpec]:
+    return [
+        RunSpec(
+            script_path=script,
+            overrides={"Sat.SMA": 7000.0 + i},
+            output_dir=output_dir / f"run-{i}",
+            run_id=i,
+            seed=None,
+            run_options={},
+        )
+        for i in range(n)
+    ]
+
+
+def _payload_run_hook(rows: int = 1) -> Any:
+    payload = pd.DataFrame(
+        {
+            "time": pd.to_datetime([f"2026-05-04T00:00:0{i}" for i in range(rows)]),
+            "x": [float(i) for i in range(rows)],
+        }
+    )
+
+    def _run(**_: Any) -> FakeResults:
+        return FakeResults(reports={"R": payload})
+
+    return _run
+
+
+# ---- run() basics ---------------------------------------------------------
+
+
+def test_sweep_run_returns_self(tmp_path: Path, fake_gmat_run: FakeGmatRun) -> None:
+    script = _write_script(tmp_path)
+    output_dir = tmp_path / "out"
+    runs = _make_runs(script, output_dir, n=1)
+
+    with LocalJoblibPool(workers=1) as pool:
+        sweep = Sweep(
+            runs=runs,
+            backend=pool,
+            manifest_path=output_dir / "manifest.jsonl",
+            output_dir=output_dir,
+            script_path=script,
+            parameter_spec={"Sat.SMA": [7000.0]},
+            progress=False,
+        )
+        assert sweep.run() is sweep
+
+
+def test_sweep_run_writes_one_manifest_entry_per_run(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    script = _write_script(tmp_path)
+    output_dir = tmp_path / "out"
+    runs = _make_runs(script, output_dir, n=4)
+
+    with LocalJoblibPool(workers=1) as pool:
+        Sweep(
+            runs=runs,
+            backend=pool,
+            manifest_path=output_dir / "manifest.jsonl",
+            output_dir=output_dir,
+            script_path=script,
+            parameter_spec={"Sat.SMA": [7000.0, 7001.0, 7002.0, 7003.0]},
+            progress=False,
+        ).run()
+
+    manifest = Manifest.load(output_dir / "manifest.jsonl")
+    assert manifest.run_count == 4
+    assert len(manifest.entries) == 4
+    assert {e.run_id for e in manifest.entries} == {0, 1, 2, 3}
+    by_run_id = {e.run_id: e for e in manifest.entries}
+    for run_id in range(4):
+        entry = by_run_id[run_id]
+        assert entry.status == "ok"
+        assert entry.overrides == {"Sat.SMA": 7000.0 + run_id}
+        assert entry.log_path == output_dir / f"run-{run_id}" / "worker.log"
+
+
+def test_sweep_manifest_header_carries_script_hash_seed_and_spec(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    script = _write_script(tmp_path, name="m.script")
+    expected_sha = canonical_script_sha256(script)
+    output_dir = tmp_path / "out"
+    runs = _make_runs(script, output_dir, n=1)
+
+    with LocalJoblibPool(workers=1) as pool:
+        Sweep(
+            runs=runs,
+            backend=pool,
+            manifest_path=output_dir / "manifest.jsonl",
+            output_dir=output_dir,
+            script_path=script,
+            parameter_spec={"Sat.SMA": [7000.0]},
+            sweep_seed=1729,
+            progress=False,
+        ).run()
+
+    reloaded = Manifest.load(output_dir / "manifest.jsonl")
+    assert reloaded.script_sha256 == expected_sha
+    assert reloaded.sweep_seed == 1729
+    assert reloaded.parameter_spec == {"Sat.SMA": [7000.0]}
+    assert reloaded.run_count == 1
+    # gmat_sweep_version is the package version pulled at import time —
+    # asserting it equals the live module value is the cheapest way to confirm
+    # it isn't a stale string literal in sweep.py.
+    import gmat_sweep
+
+    assert reloaded.gmat_sweep_version == gmat_sweep.__version__
+
+
+def test_sweep_manifest_parent_directory_is_created(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    script = _write_script(tmp_path)
+    output_dir = tmp_path / "deeply" / "nested" / "out"
+    runs = _make_runs(script, output_dir, n=1)
+
+    with LocalJoblibPool(workers=1) as pool:
+        Sweep(
+            runs=runs,
+            backend=pool,
+            manifest_path=output_dir / "manifest.jsonl",
+            output_dir=output_dir,
+            script_path=script,
+            parameter_spec={},
+            progress=False,
+        ).run()
+
+    assert (output_dir / "manifest.jsonl").exists()
+
+
+# ---- aggregation ---------------------------------------------------------
+
+
+def test_sweep_to_dataframe_returns_multiindexed_frame(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    script = _write_script(tmp_path)
+    output_dir = tmp_path / "out"
+    runs = _make_runs(script, output_dir, n=3)
+
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook(rows=2))
+
+    with LocalJoblibPool(workers=1) as pool:
+        sweep = Sweep(
+            runs=runs,
+            backend=pool,
+            manifest_path=output_dir / "manifest.jsonl",
+            output_dir=output_dir,
+            script_path=script,
+            parameter_spec={"Sat.SMA": [7000.0, 7001.0, 7002.0]},
+            progress=False,
+        ).run()
+
+    df = sweep.to_dataframe()
+    assert df.index.names == ["run_id", "time"]
+    assert sorted(df.index.get_level_values("run_id").unique().tolist()) == [0, 1, 2]
+    assert (df["__status"] == "ok").all()
+
+
+def test_sweep_to_dataframe_marks_failed_run(tmp_path: Path, fake_gmat_run: FakeGmatRun) -> None:
+    script = _write_script(tmp_path)
+    output_dir = tmp_path / "out"
+    runs = _make_runs(script, output_dir, n=3)
+
+    def _setitem(_key: str, value: Any) -> None:
+        if value == 7001.0:
+            raise ValueError("rejected by GMAT")
+
+    fake_gmat_run.install_loader(setitem_hook=_setitem, run_hook=_payload_run_hook(rows=1))
+
+    with LocalJoblibPool(workers=1) as pool:
+        sweep = Sweep(
+            runs=runs,
+            backend=pool,
+            manifest_path=output_dir / "manifest.jsonl",
+            output_dir=output_dir,
+            script_path=script,
+            parameter_spec={},
+            progress=False,
+        ).run()
+
+    df = sweep.to_dataframe()
+    assert set(df["__status"].unique()) == {"ok", "failed"}
+    failed_rows = df.loc[df["__status"] == "failed"]
+    assert len(failed_rows) == 1
+    assert failed_rows.index.get_level_values("run_id").tolist() == [1]
+
+
+def test_sweep_to_manifest_requires_run_first(tmp_path: Path, fake_gmat_run: FakeGmatRun) -> None:
+    script = _write_script(tmp_path)
+    output_dir = tmp_path / "out"
+    runs = _make_runs(script, output_dir, n=1)
+
+    with LocalJoblibPool(workers=1) as pool:
+        sweep = Sweep(
+            runs=runs,
+            backend=pool,
+            manifest_path=output_dir / "manifest.jsonl",
+            output_dir=output_dir,
+            script_path=script,
+            parameter_spec={},
+            progress=False,
+        )
+        with pytest.raises(RuntimeError, match="run"):
+            sweep.to_manifest()
+
+
+# ---- progress -------------------------------------------------------------
+
+
+def test_sweep_progress_disabled_quiet_on_stderr(
+    tmp_path: Path,
+    fake_gmat_run: FakeGmatRun,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    script = _write_script(tmp_path)
+    output_dir = tmp_path / "out"
+    runs = _make_runs(script, output_dir, n=2)
+
+    with LocalJoblibPool(workers=1) as pool:
+        Sweep(
+            runs=runs,
+            backend=pool,
+            manifest_path=output_dir / "manifest.jsonl",
+            output_dir=output_dir,
+            script_path=script,
+            parameter_spec={},
+            progress=False,
+        ).run()
+
+    captured = capsys.readouterr()
+    # tqdm draws a progress bar by writing carriage returns and percentages
+    # to stderr; with progress=False neither should appear.
+    assert "gmat-sweep" not in captured.err
+    assert "%" not in captured.err
+
+
+# ---- ctrl-c safety --------------------------------------------------------
+
+
+class _InterruptingPool(Pool):
+    """Pool that yields N outcomes successfully, then raises KeyboardInterrupt.
+
+    Used to drive the partial-manifest assertion without standing up a real
+    subprocess pool — the actual loky path is exercised separately in
+    test_backends_joblib.
+    """
+
+    def __init__(self, *, yield_count: int) -> None:
+        self._submitted: list[RunSpec] = []
+        self._yield_count = yield_count
+
+    def submit(self, spec: RunSpec) -> Future[RunOutcome]:
+        self._submitted.append(spec)
+        return Future()
+
+    def as_completed(self, _futures: Iterable[Future[RunOutcome]]) -> Iterator[RunOutcome]:
+        now = datetime.now(timezone.utc)
+        for spec in self._submitted[: self._yield_count]:
+            yield RunOutcome.ok(
+                run_id=spec.run_id,
+                output_paths={},
+                started_at=now,
+                ended_at=now,
+            )
+        raise KeyboardInterrupt
+
+    def close(self) -> None:
+        pass
+
+
+def test_sweep_keyboard_interrupt_leaves_parsable_partial_manifest(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    script = _write_script(tmp_path)
+    output_dir = tmp_path / "out"
+    runs = _make_runs(script, output_dir, n=4)
+
+    pool = _InterruptingPool(yield_count=2)
+    sweep = Sweep(
+        runs=runs,
+        backend=pool,
+        manifest_path=output_dir / "manifest.jsonl",
+        output_dir=output_dir,
+        script_path=script,
+        parameter_spec={},
+        progress=False,
+    )
+    with pytest.raises(KeyboardInterrupt):
+        sweep.run()
+
+    reloaded = Manifest.load(output_dir / "manifest.jsonl")
+    assert len(reloaded.entries) == 2
+    assert {e.run_id for e in reloaded.entries} == {0, 1}


### PR DESCRIPTION
## Summary

- `gmat_sweep.sweep.Sweep` binds run specs, a `Pool`, and a manifest path into a runnable orchestrator: submit → drain in completion order → fsync each `ManifestEntry` on completion → tqdm tick. `KeyboardInterrupt` propagates so the caller's `with`-managed pool cancels still-pending futures, and the partial manifest on disk is parseable through the last completed run.
- `gmat_sweep.api.sweep(mission, *, grid, workers=-1, out=None, seed=None)` is the thin public wrapper: materialises the grid, expands it to `RunSpec`s, runs the sweep through a fresh `LocalJoblibPool`, and returns the `(run_id, time)`-MultiIndexed DataFrame. With `out=None` the sweep-scoped `TemporaryDirectory` is kept alive via `weakref.finalize` on the returned DataFrame, mirroring the `Mission.run` Results lifetime trick.
- `gmat_sweep.__init__` exports `Sweep` and `sweep`, and pins the top-level `gmat_sweep` logger to `WARNING` at module import (only when its level is `NOTSET`, so explicit user config wins). `pyproject.toml` adds the `tqdm` mypy override to match the existing `joblib`/`pyarrow` pattern.

## Test plan

- [x] `uv run ruff check`
- [x] `uv run ruff format --check`
- [x] `uv run mypy` (strict-clean across `sweep.py` and `api.py` per the issue's acceptance bullet)
- [x] `uv run pytest` (138 passed; 18 new across `tests/test_sweep.py` and `tests/test_api.py`)
- [ ] Cross-platform CI (Ubuntu + Windows) — kicked off by the push
- [ ] Real-GMAT integration coverage of the four-line vision-snippet sweep — lands with #11

Closes #9