### PR TITLE
Add gmat-sweep run/show CLI

### DIFF
--- a/src/gmat_sweep/cli.py
+++ b/src/gmat_sweep/cli.py
@@ -1,3 +1,245 @@
-"""Console-script entry point: gmat-sweep run / show / resume."""
+"""Console-script entry point: ``gmat-sweep run`` / ``gmat-sweep show``.
+
+The CLI is a thin wrapper over :func:`gmat_sweep.api.sweep` and
+:meth:`gmat_sweep.manifest.Manifest.load`. Argument parsing and grid-spec
+parsing live here; everything else delegates to the existing public surface.
+
+Exit codes
+----------
+``0``   success
+``1``   any other :class:`gmat_sweep.errors.GmatSweepError`
+``2``   :class:`gmat_sweep.errors.SweepConfigError` or argparse usage error
+``3``   :class:`gmat_sweep.errors.ManifestCorruptError`
+``4``   :class:`gmat_sweep.errors.BackendError`
+"""
 
 from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from gmat_sweep.api import sweep
+from gmat_sweep.errors import (
+    BackendError,
+    GmatSweepError,
+    ManifestCorruptError,
+    SweepConfigError,
+)
+from gmat_sweep.manifest import Manifest
+
+__all__ = ["main"]
+
+EXIT_OK = 0
+EXIT_GENERIC = 1
+EXIT_CONFIG = 2
+EXIT_MANIFEST = 3
+EXIT_BACKEND = 4
+
+
+def _parse_grid_value(token: str) -> int | float | str:
+    """Coerce a single explicit-list token via int → float → str fallback."""
+    try:
+        return int(token)
+    except ValueError:
+        pass
+    try:
+        return float(token)
+    except ValueError:
+        pass
+    return token
+
+
+def _parse_grid_spec(spec: str) -> tuple[str, list[Any]]:
+    """Parse one ``--grid`` argument into ``(dotted_path, values)``.
+
+    Two forms:
+
+    * ``name=lo:hi:count`` — ``count`` evenly spaced points from ``lo`` to
+      ``hi`` inclusive (``numpy.linspace``). ``lo`` and ``hi`` are floats;
+      ``count`` is an integer ≥ 2.
+    * ``name=v1,v2,v3`` — explicit values, each coerced via int → float → str.
+
+    Empty, malformed, or numerically invalid specs raise
+    :class:`SweepConfigError`.
+    """
+    if "=" not in spec:
+        raise SweepConfigError(
+            f"grid spec must contain '=': {spec!r} "
+            "(expected 'name=lo:hi:count' or 'name=v1,v2,...')"
+        )
+    name, _, rhs = spec.partition("=")
+    name = name.strip()
+    if not name:
+        raise SweepConfigError(f"grid spec is missing a name: {spec!r}")
+    if not rhs:
+        raise SweepConfigError(f"grid spec for {name!r} has no values: {spec!r}")
+
+    if ":" in rhs:
+        parts = rhs.split(":")
+        if len(parts) != 3:
+            raise SweepConfigError(
+                f"linspace grid spec for {name!r} must have three colon-separated parts "
+                f"'lo:hi:count', got {rhs!r}"
+            )
+        lo_str, hi_str, count_str = parts
+        try:
+            lo = float(lo_str)
+            hi = float(hi_str)
+        except ValueError as exc:
+            raise SweepConfigError(
+                f"linspace bounds for {name!r} must be numeric, got {lo_str!r}:{hi_str!r}"
+            ) from exc
+        try:
+            count = int(count_str)
+        except ValueError as exc:
+            raise SweepConfigError(
+                f"linspace count for {name!r} must be an integer, got {count_str!r}"
+            ) from exc
+        if count < 2:
+            raise SweepConfigError(f"linspace count for {name!r} must be >= 2, got {count}")
+        return name, np.linspace(lo, hi, count).tolist()
+
+    tokens = rhs.split(",")
+    if any(t == "" for t in tokens):
+        raise SweepConfigError(f"explicit grid spec for {name!r} has an empty value: {rhs!r}")
+    return name, [_parse_grid_value(t) for t in tokens]
+
+
+def _format_summary(manifest: Manifest, output_dir: Path) -> str:
+    """One-line summary: ``N runs (A ok[, B failed][, C skipped]) in T.TT s — output: PATH``.
+
+    Zero-count buckets are suppressed.
+    """
+    counts: dict[str, int] = {"ok": 0, "failed": 0, "skipped": 0}
+    duration = 0.0
+    for entry in manifest.entries:
+        counts[entry.status] += 1
+        duration += entry.duration_s
+
+    parts = [f"{counts[k]} {k}" for k in ("ok", "failed", "skipped") if counts[k] > 0]
+    breakdown = ", ".join(parts) if parts else "0 ok"
+    n = len(manifest.entries)
+    return f"{n} runs ({breakdown}) in {duration:.2f} s — output: {output_dir}"
+
+
+def _cmd_run(args: argparse.Namespace) -> int:
+    script = Path(args.script)
+    if not script.is_file():
+        print(f"gmat-sweep: script not found: {script}", file=sys.stderr)
+        return EXIT_CONFIG
+
+    grid: dict[str, list[Any]] = {}
+    for raw in args.grid:
+        name, values = _parse_grid_spec(raw)
+        if name in grid:
+            raise SweepConfigError(f"grid spec for {name!r} given more than once")
+        grid[name] = values
+
+    out = Path(args.out)
+    sweep(script, grid=grid, workers=args.workers, out=out)
+
+    manifest = Manifest.load(out / "manifest.jsonl")
+    print(_format_summary(manifest, out))
+    return EXIT_OK
+
+
+def _cmd_show(args: argparse.Namespace) -> int:
+    manifest_path = Path(args.manifest)
+    if not manifest_path.is_file():
+        print(f"gmat-sweep: manifest not found: {manifest_path}", file=sys.stderr)
+        return EXIT_MANIFEST
+    manifest = Manifest.load(manifest_path)
+    print(_format_summary(manifest, manifest_path.parent))
+    return EXIT_OK
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="gmat-sweep",
+        description="Run parameter sweeps over a GMAT mission and inspect the resulting manifest.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True, metavar="COMMAND")
+
+    run = subparsers.add_parser(
+        "run",
+        help="Run a parameter sweep over a GMAT script.",
+        description=(
+            "Run a full-factorial parameter sweep. Each --grid flag adds one axis; "
+            "multiple --grid flags combine into the cartesian product."
+        ),
+    )
+    run.add_argument(
+        "--grid",
+        action="append",
+        default=[],
+        required=True,
+        metavar="SPEC",
+        help=(
+            "Grid axis spec. Two forms: "
+            "'name=lo:hi:count' for count evenly-spaced points (e.g. 'Sat.SMA=7000:8000:5'), "
+            "or 'name=v1,v2,v3' for explicit values (e.g. 'Sat.DryMass=100,200,300'). "
+            "Repeat --grid for additional axes; the cartesian product is run."
+        ),
+    )
+    run.add_argument(
+        "--workers",
+        type=int,
+        default=-1,
+        metavar="N",
+        help="Number of subprocess workers. Default -1 uses every available core.",
+    )
+    run.add_argument(
+        "--out",
+        required=True,
+        metavar="PATH",
+        help="Output directory for per-run artefacts and manifest.jsonl.",
+    )
+    run.add_argument(
+        "script",
+        metavar="SCRIPT",
+        help="Path to the GMAT .script file.",
+    )
+    run.set_defaults(func=_cmd_run)
+
+    show = subparsers.add_parser(
+        "show",
+        help="Print a one-line summary of a sweep manifest.",
+        description="Load a manifest.jsonl file and print a one-line summary.",
+    )
+    show.add_argument(
+        "manifest",
+        metavar="MANIFEST",
+        help="Path to a manifest.jsonl produced by 'gmat-sweep run'.",
+    )
+    show.set_defaults(func=_cmd_show)
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point. Returns the process exit code."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return int(args.func(args))
+    except SweepConfigError as exc:
+        print(f"gmat-sweep: {exc}", file=sys.stderr)
+        return EXIT_CONFIG
+    except ManifestCorruptError as exc:
+        print(f"gmat-sweep: {exc} ({exc.path})", file=sys.stderr)
+        return EXIT_MANIFEST
+    except BackendError as exc:
+        print(f"gmat-sweep: backend error: {exc}", file=sys.stderr)
+        return EXIT_BACKEND
+    except GmatSweepError as exc:
+        print(f"gmat-sweep: {exc}", file=sys.stderr)
+        return EXIT_GENERIC
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,398 @@
+"""Tests for gmat_sweep.cli — argparse-driven console-script entry point."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pytest
+
+from gmat_sweep import cli
+from gmat_sweep.errors import SweepConfigError
+from gmat_sweep.manifest import Manifest
+from tests.conftest import FakeGmatRun, FakeResults
+
+
+def _write_script(tmp_path: Path) -> Path:
+    path = tmp_path / "mission.script"
+    path.write_text("% GMAT mission\nCreate Spacecraft Sat;\n", encoding="utf-8")
+    return path
+
+
+def _payload_run_hook() -> Any:
+    payload = pd.DataFrame({"time": pd.to_datetime(["2026-05-04T00:00:00"]), "x": [1.0]})
+
+    def _run(**_: Any) -> FakeResults:
+        return FakeResults(reports={"R": payload})
+
+    return _run
+
+
+# ---- _parse_grid_spec: linspace form ------------------------------------
+
+
+def test_parse_grid_spec_linspace_returns_evenly_spaced_floats() -> None:
+    name, values = cli._parse_grid_spec("Sat.SMA=7000:8000:5")
+    assert name == "Sat.SMA"
+    assert values == [7000.0, 7250.0, 7500.0, 7750.0, 8000.0]
+
+
+def test_parse_grid_spec_linspace_count_2_returns_endpoints() -> None:
+    name, values = cli._parse_grid_spec("a=0:10:2")
+    assert (name, values) == ("a", [0.0, 10.0])
+
+
+def test_parse_grid_spec_linspace_rejects_non_numeric_bounds() -> None:
+    with pytest.raises(SweepConfigError, match="numeric"):
+        cli._parse_grid_spec("a=foo:10:5")
+
+
+def test_parse_grid_spec_linspace_rejects_non_integer_count() -> None:
+    with pytest.raises(SweepConfigError, match="integer"):
+        cli._parse_grid_spec("a=0:10:5.5")
+
+
+def test_parse_grid_spec_linspace_rejects_count_below_two() -> None:
+    with pytest.raises(SweepConfigError, match=">= 2"):
+        cli._parse_grid_spec("a=0:10:1")
+
+
+def test_parse_grid_spec_linspace_rejects_wrong_arity() -> None:
+    with pytest.raises(SweepConfigError, match="three colon-separated"):
+        cli._parse_grid_spec("a=0:10")
+
+
+# ---- _parse_grid_spec: explicit form ------------------------------------
+
+
+def test_parse_grid_spec_explicit_int_values() -> None:
+    name, values = cli._parse_grid_spec("Sat.DryMass=100,200,300")
+    assert name == "Sat.DryMass"
+    assert values == [100, 200, 300]
+    assert all(isinstance(v, int) for v in values)
+
+
+def test_parse_grid_spec_explicit_float_values() -> None:
+    _, values = cli._parse_grid_spec("a=1.5,2.5,3.5")
+    assert values == [1.5, 2.5, 3.5]
+
+
+def test_parse_grid_spec_explicit_string_fallback() -> None:
+    _, values = cli._parse_grid_spec("Mode=Cartesian,Keplerian")
+    assert values == ["Cartesian", "Keplerian"]
+
+
+def test_parse_grid_spec_explicit_single_value() -> None:
+    _, values = cli._parse_grid_spec("a=42")
+    assert values == [42]
+
+
+def test_parse_grid_spec_explicit_rejects_empty_value() -> None:
+    with pytest.raises(SweepConfigError, match="empty value"):
+        cli._parse_grid_spec("a=1,,3")
+
+
+# ---- _parse_grid_spec: malformed ----------------------------------------
+
+
+def test_parse_grid_spec_rejects_missing_equals() -> None:
+    with pytest.raises(SweepConfigError, match="must contain '='"):
+        cli._parse_grid_spec("Sat.SMA")
+
+
+def test_parse_grid_spec_rejects_empty_name() -> None:
+    with pytest.raises(SweepConfigError, match="missing a name"):
+        cli._parse_grid_spec("=1,2,3")
+
+
+def test_parse_grid_spec_rejects_empty_rhs() -> None:
+    with pytest.raises(SweepConfigError, match="no values"):
+        cli._parse_grid_spec("a=")
+
+
+# ---- run subcommand: end-to-end -----------------------------------------
+
+
+def test_run_writes_manifest_and_prints_summary(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun, capsys: pytest.CaptureFixture[str]
+) -> None:
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    rc = cli.main(
+        [
+            "run",
+            "--grid",
+            "Sat.SMA=7000:8000:3",
+            "--workers",
+            "1",
+            "--out",
+            str(out),
+            str(script),
+        ]
+    )
+
+    assert rc == 0
+    assert (out / "manifest.jsonl").exists()
+    captured = capsys.readouterr()
+    assert "3 runs" in captured.out
+    assert "3 ok" in captured.out
+    assert str(out) in captured.out
+
+
+def test_run_with_two_grid_flags_produces_cartesian_product(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun, capsys: pytest.CaptureFixture[str]
+) -> None:
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    rc = cli.main(
+        [
+            "run",
+            "--grid",
+            "Sat.SMA=7000:8000:2",
+            "--grid",
+            "Sat.ECC=0.0,0.1,0.2",
+            "--workers",
+            "1",
+            "--out",
+            str(out),
+            str(script),
+        ]
+    )
+
+    assert rc == 0
+    manifest = Manifest.load(out / "manifest.jsonl")
+    assert manifest.run_count == 6
+    assert sorted(manifest.parameter_spec.keys()) == ["Sat.ECC", "Sat.SMA"]
+
+
+def test_run_with_failing_runs_summary_shows_breakdown(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun, capsys: pytest.CaptureFixture[str]
+) -> None:
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+
+    def _setitem(_key: str, value: Any) -> None:
+        if value == 8000.0:
+            raise ValueError("rejected")
+
+    fake_gmat_run.install_loader(setitem_hook=_setitem, run_hook=_payload_run_hook())
+
+    rc = cli.main(
+        [
+            "run",
+            "--grid",
+            "Sat.SMA=7000:8000:2",
+            "--workers",
+            "1",
+            "--out",
+            str(out),
+            str(script),
+        ]
+    )
+
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "2 runs" in captured.out
+    assert "1 ok" in captured.out
+    assert "1 failed" in captured.out
+    assert "skipped" not in captured.out
+
+
+def test_run_rejects_missing_script(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    rc = cli.main(
+        [
+            "run",
+            "--grid",
+            "a=1,2",
+            "--out",
+            str(tmp_path / "out"),
+            str(tmp_path / "does-not-exist.script"),
+        ]
+    )
+    assert rc == cli.EXIT_CONFIG
+    assert "script not found" in capsys.readouterr().err
+
+
+def test_run_rejects_malformed_grid(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun, capsys: pytest.CaptureFixture[str]
+) -> None:
+    script = _write_script(tmp_path)
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    rc = cli.main(
+        [
+            "run",
+            "--grid",
+            "no-equals-sign",
+            "--out",
+            str(tmp_path / "out"),
+            str(script),
+        ]
+    )
+    assert rc == cli.EXIT_CONFIG
+    assert "must contain '='" in capsys.readouterr().err
+
+
+def test_run_rejects_duplicate_grid_axis(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun, capsys: pytest.CaptureFixture[str]
+) -> None:
+    script = _write_script(tmp_path)
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    rc = cli.main(
+        [
+            "run",
+            "--grid",
+            "a=1,2",
+            "--grid",
+            "a=3,4",
+            "--out",
+            str(tmp_path / "out"),
+            str(script),
+        ]
+    )
+    assert rc == cli.EXIT_CONFIG
+    assert "more than once" in capsys.readouterr().err
+
+
+# ---- show subcommand ----------------------------------------------------
+
+
+def test_show_prints_summary(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun, capsys: pytest.CaptureFixture[str]
+) -> None:
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    cli.main(
+        [
+            "run",
+            "--grid",
+            "a=1,2,3",
+            "--workers",
+            "1",
+            "--out",
+            str(out),
+            str(script),
+        ]
+    )
+    capsys.readouterr()  # discard run's summary
+
+    rc = cli.main(["show", str(out / "manifest.jsonl")])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "3 runs" in captured.out
+    assert "3 ok" in captured.out
+    assert str(out) in captured.out
+
+
+def test_show_on_missing_file_exits_manifest_code(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    missing = tmp_path / "no-such-manifest.jsonl"
+    rc = cli.main(["show", str(missing)])
+    assert rc == cli.EXIT_MANIFEST
+    assert "not found" in capsys.readouterr().err
+
+
+def test_run_maps_backend_error_to_exit_code(
+    tmp_path: Path,
+    fake_gmat_run: FakeGmatRun,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from gmat_sweep.errors import BackendError
+
+    script = _write_script(tmp_path)
+
+    def _boom(*_a: Any, **_kw: Any) -> Any:
+        raise BackendError("worker pool died")
+
+    monkeypatch.setattr("gmat_sweep.cli.sweep", _boom)
+
+    rc = cli.main(
+        [
+            "run",
+            "--grid",
+            "a=1,2",
+            "--out",
+            str(tmp_path / "out"),
+            str(script),
+        ]
+    )
+    assert rc == cli.EXIT_BACKEND
+    assert "backend error" in capsys.readouterr().err
+
+
+def test_run_maps_generic_gmat_sweep_error_to_exit_code(
+    tmp_path: Path,
+    fake_gmat_run: FakeGmatRun,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from gmat_sweep.errors import GmatSweepError
+
+    script = _write_script(tmp_path)
+
+    class _Custom(GmatSweepError):
+        pass
+
+    def _boom(*_a: Any, **_kw: Any) -> Any:
+        raise _Custom("something else broke")
+
+    monkeypatch.setattr("gmat_sweep.cli.sweep", _boom)
+
+    rc = cli.main(
+        [
+            "run",
+            "--grid",
+            "a=1,2",
+            "--out",
+            str(tmp_path / "out"),
+            str(script),
+        ]
+    )
+    assert rc == cli.EXIT_GENERIC
+    assert "something else broke" in capsys.readouterr().err
+
+
+def test_show_on_corrupt_file_exits_manifest_code(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    bad = tmp_path / "manifest.jsonl"
+    bad.write_text("not json at all\n", encoding="utf-8")
+
+    rc = cli.main(["show", str(bad)])
+    assert rc == cli.EXIT_MANIFEST
+    assert "manifest" in capsys.readouterr().err
+
+
+# ---- top-level --help / no args -----------------------------------------
+
+
+def test_main_with_help_exits_zero(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["--help"])
+    assert exc_info.value.code == 0
+    assert "gmat-sweep" in capsys.readouterr().out
+
+
+def test_main_with_no_args_exits_two(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main([])
+    assert exc_info.value.code == 2
+
+
+def test_run_help_lists_grid_flag(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["run", "--help"])
+    assert exc_info.value.code == 0
+    captured = capsys.readouterr()
+    assert "--grid" in captured.out
+    assert "lo:hi:count" in captured.out


### PR DESCRIPTION
## Summary
- `gmat_sweep/cli.py` becomes a working argparse-driven console script with `run` and `show` subcommands; the entry point already wired in `pyproject.toml` now resolves to a real CLI.
- `--grid SPEC` accepts the linspace form `name=lo:hi:count` or the explicit form `name=v1,v2,v3`; multiple `--grid` flags combine into a full-factorial sweep.
- Errors map onto the typed exception hierarchy via distinct exit codes (2 `SweepConfigError`, 3 `ManifestCorruptError`, 4 `BackendError`, 1 generic `GmatSweepError`).
- `tests/test_cli.py` covers grid-spec parsing (both forms, malformed input), end-to-end `run` and `show` against the fake `gmat_run` fixture, and the error → exit-code mapping. `cli.py` lands at 100% line+branch coverage; overall suite at 99%.

## Test plan
- [ ] `uv run pytest`
- [ ] `uv run ruff check`
- [ ] `uv run ruff format --check`
- [ ] `uv run mypy`
- [ ] CI (Ubuntu + Windows, Python 3.10–3.12) green.
- [ ] Smoke-test `gmat-sweep --help`, `gmat-sweep run --help`, `gmat-sweep show --help` after install.

Closes #10