### PR TITLE
Add MkDocs-Material docs site for the v0.1 surface

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,53 @@
+# API reference
+
+Every public symbol re-exported from the `gmat_sweep` top-level package,
+auto-generated from docstrings via
+[`mkdocstrings`](https://mkdocstrings.github.io/).
+
+## Sweep entry points
+
+::: gmat_sweep.sweep
+
+::: gmat_sweep.Sweep
+
+## Execution backend
+
+::: gmat_sweep.Pool
+
+## Specs and outcomes
+
+::: gmat_sweep.RunSpec
+
+::: gmat_sweep.SweepSpec
+
+::: gmat_sweep.RunOutcome
+
+## Grid expansion
+
+::: gmat_sweep.full_factorial
+
+::: gmat_sweep.expand_grid_to_run_specs
+
+## Manifest
+
+::: gmat_sweep.Manifest
+
+::: gmat_sweep.ManifestEntry
+
+::: gmat_sweep.canonical_script_sha256
+
+## Aggregation
+
+::: gmat_sweep.lazy_multiindex
+
+## Exceptions
+
+::: gmat_sweep.GmatSweepError
+
+::: gmat_sweep.SweepConfigError
+
+::: gmat_sweep.RunFailed
+
+::: gmat_sweep.BackendError
+
+::: gmat_sweep.ManifestCorruptError

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,63 @@
+# FAQ
+
+## Why does each run go in its own subprocess?
+
+GMAT is not safe to reuse for multiple `.script` loads inside a single
+Python process. Two reasons stack:
+
+1. **Bootstrap cost is paid once per process anyway.** The first
+   `import gmat_run` plus `Mission.load(...)` in any process pays the
+   `gmatpy` SWIG bring-up. Subsequent calls in the same process are cheap,
+   but you only get that benefit if it is safe to *use* the same process for
+   the next run — and it is not (point 2).
+2. **GMAT relies on process-global singletons that do not survive a second
+   `Mission.load`.** Reusing a Python process across runs that load
+   different scripts (or even the same script with different overrides)
+   produces inconsistent state — sometimes silently wrong, sometimes a hard
+   crash deep inside the engine.
+
+The [`Pool`][gmat_sweep.Pool] ABC enforces this at class-definition time
+via its `subprocess_isolated` class attribute. Any `Pool` subclass that
+tries to set it to anything other than `True` is rejected when its module
+is imported, before a sweep can start. Each worker subprocess imports
+`gmat_run` once on its first run and reuses that import for the rest of the
+runs that worker handles.
+
+The trade-off is the bootstrap cost amortising over batches — for a sweep
+of N runs with W workers, you pay roughly W bootstraps total, not 1 and not
+N. For a small sweep that's overhead worth knowing about; for a meaningfully
+large sweep it is a rounding error.
+
+## Why does `gmat-sweep` depend on `gmat-run`?
+
+`gmat-sweep` is the parallel orchestrator. `gmat-run` is the single-run
+primitive — it owns GMAT install discovery, the `gmatpy` bootstrap, the
+`Mission` API, the dotted-path setter, the `ReportFile` parser, and the
+`Results` object. `gmat-sweep` would have to re-implement all of that just
+to launch a single run, so it does not — every worker subprocess calls into `gmat_run.Mission`.
+
+That layering also keeps `gmat-sweep`'s scope narrow. The package's job is:
+expand a grid into [`RunSpec`][gmat_sweep.RunSpec]s, fan them out to a
+[`Pool`][gmat_sweep.Pool], record outcomes in the
+[manifest](manifest-schema.md), and aggregate the per-run Parquet outputs
+into one DataFrame. Anything below the per-run line — script parsing,
+field setters, GMAT engine invocation — is
+[`gmat-run`'s](https://astro-tools.github.io/gmat-run/) problem.
+
+## Where do I get GMAT?
+
+GMAT is distributed by NASA's General Mission Analysis Tool project on
+SourceForge:
+[https://sourceforge.net/projects/gmat/files/GMAT/](https://sourceforge.net/projects/gmat/files/GMAT/).
+R2026a is the primary development target; R2025a is also supported. See
+[supported versions](supported-versions.md) for the full matrix.
+
+Once unpacked, [`gmat-run`'s install
+guide](https://astro-tools.github.io/gmat-run/install-gmat/) covers
+discovery — typically `gmat-run` finds the install via `$GMAT_ROOT`, a
+conventional install path, or a same-prefix sibling directory.
+
+If you are wiring a CI job, use
+[`astro-tools/setup-gmat`](https://github.com/astro-tools/setup-gmat) — it
+caches the install across runs and exposes the same discovery hooks
+`gmat-run` uses locally.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,89 @@
+# Getting started
+
+## Install
+
+`gmat-sweep` is not yet on PyPI. Install from source:
+
+```bash
+pip install git+https://github.com/astro-tools/gmat-sweep.git
+```
+
+Or, if you are working inside a checkout:
+
+```bash
+git clone https://github.com/astro-tools/gmat-sweep.git
+cd gmat-sweep
+uv sync
+```
+
+You also need a working **GMAT install** on the same machine. `gmat-sweep`
+does not bundle GMAT binaries; it depends on
+[`gmat-run`](https://github.com/astro-tools/gmat-run) for the single-run
+primitive, and `gmat-run` discovers your local install at runtime. See
+[`gmat-run`'s install guide](https://astro-tools.github.io/gmat-run/install-gmat/)
+for download and configuration steps. R2025a and R2026a are the supported
+releases; see [Supported versions](supported-versions.md) for the full matrix.
+
+## The four-line vision snippet
+
+Once GMAT is installed and `gmat-sweep` is importable:
+
+```python
+from gmat_sweep import sweep
+
+df = sweep("mission.script", grid={"Sat.SMA": [7000, 7100, 7200]})
+print(df)
+```
+
+That call runs `mission.script` three times — once per `Sat.SMA` value —
+each in a fresh subprocess, and returns a `(run_id, time)`-MultiIndexed
+`pandas.DataFrame` containing the rows from every run's `ReportFile`,
+labelled with a `__status` column.
+
+The snippet is runnable against any of the GMAT-shipped sample scripts (e.g.
+`samples/Tut_GettingStarted.script`) — pick one that defines a Spacecraft
+named `Sat` and a `ReportFile`, or change the grid key to match your script.
+
+## What just happened
+
+Behind that single call:
+
+1. The grid is materialised into a cartesian product of override dicts.
+2. Each combination becomes a [`RunSpec`][gmat_sweep.RunSpec] with a unique
+   `run_id` and its own per-run output directory.
+3. A [`Pool`][gmat_sweep.Pool] (the default `LocalJoblibPool`, backed by
+   `joblib`'s loky executor) fans the specs out to subprocess workers. Each worker imports `gmat_run` once, loads `mission.script`,
+   applies its overrides via the dotted-path setter, runs the mission, and
+   writes each `ReportFile` as a Parquet file under the per-run directory.
+4. As workers complete, the orchestrator appends one
+   [`ManifestEntry`][gmat_sweep.ManifestEntry] per run to a `manifest.jsonl`
+   in the sweep's output directory — fsync'd line by line so a `Ctrl-C`
+   leaves a parseable file containing every run that finished.
+5. Once the pool drains, the per-run Parquet files are stitched into the
+   returned DataFrame.
+
+By default the output directory is a `tempfile.TemporaryDirectory` whose
+lifetime is tied to the returned DataFrame. To keep the per-run Parquet
+files and the manifest, pass an explicit `out=Path(...)` to
+[`sweep()`][gmat_sweep.sweep].
+
+## CLI alternative
+
+The same call from a shell:
+
+```bash
+gmat-sweep run --grid Sat.SMA=7000:7200:3 --out ./sweep mission.script
+```
+
+`--grid name=lo:hi:count` produces `count` evenly spaced points from `lo` to
+`hi` inclusive; `--grid name=v1,v2,v3` uses an explicit list. Repeat
+`--grid` for additional axes; the cartesian product is run. See
+[Parameter spec](parameter-spec.md) for the full grammar.
+
+## Next steps
+
+- [Parameter spec](parameter-spec.md) — what overrides are valid and how
+  the cartesian product is laid out.
+- [Manifest schema](manifest-schema.md) — what's in `manifest.jsonl` and
+  how to load it back.
+- [API reference](api.md) — every public symbol, auto-generated.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,57 @@
+# gmat-sweep
+
+Run parameter sweeps and Monte Carlo dispersions over [GMAT](https://software.nasa.gov/software/GSC-17177-1)
+missions in parallel from Python.
+
+!!! warning "Pre-alpha"
+    The public surface is not yet usable for production work. The
+    [v0.1 milestone](https://github.com/astro-tools/gmat-sweep/milestone/1)
+    tracks the work needed to ship the first PyPI release.
+
+## What it does
+
+`gmat-sweep` takes one GMAT `.script` file and runs it many times under
+different parameter overrides, in parallel subprocesses, then aggregates the
+per-run reports into a single multi-indexed `pandas.DataFrame`. The single
+public entry point is [`sweep()`][gmat_sweep.sweep]: pass it a script, a
+parameter grid, and (optionally) a worker count.
+
+```python
+from gmat_sweep import sweep
+
+df = sweep(
+    "mission.script",
+    grid={
+        "Sat.SMA": [7000, 7100, 7200],
+        "Sat.DryMass": [100, 200],
+    },
+)
+```
+
+That call runs the cartesian product (six runs in this example), one fresh
+GMAT subprocess per run, and returns a `(run_id, time)`-MultiIndexed
+DataFrame with one row per (run, time-step) pair plus a `__status` column
+flagging `ok` / `failed` / `skipped` runs.
+
+## Where to go next
+
+- **[Getting started](getting-started.md)** — install and the four-line
+  vision snippet.
+- **[Parameter spec](parameter-spec.md)** — how grids, dotted-path overrides,
+  and the CLI's mini-grammar work.
+- **[Manifest schema](manifest-schema.md)** — the JSON Lines manifest each
+  sweep writes alongside its outputs.
+- **[Supported versions](supported-versions.md)** — GMAT × Python × OS matrix.
+- **[FAQ](faq.md)** — subprocess isolation, the `gmat-run` dependency, and
+  where to get GMAT.
+- **[API reference](api.md)** — auto-generated from docstrings.
+
+## Scope
+
+`gmat-sweep` is deliberately narrow: run an existing `.script` N times under
+N different overrides via [`gmat-run`](https://github.com/astro-tools/gmat-run),
+in parallel, and aggregate the results. It is not an optimiser, not a
+script-builder, and does not own GMAT installation.
+
+For the full scope rationale and pointers to neighbouring tools see
+[`CONTRIBUTING.md`](https://github.com/astro-tools/gmat-sweep/blob/main/CONTRIBUTING.md#scope-discipline).

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,11 +3,6 @@
 Run parameter sweeps and Monte Carlo dispersions over [GMAT](https://software.nasa.gov/software/GSC-17177-1)
 missions in parallel from Python.
 
-!!! warning "Pre-alpha"
-    The public surface is not yet usable for production work. The
-    [v0.1 milestone](https://github.com/astro-tools/gmat-sweep/milestone/1)
-    tracks the work needed to ship the first PyPI release.
-
 ## What it does
 
 `gmat-sweep` takes one GMAT `.script` file and runs it many times under

--- a/docs/manifest-schema.md
+++ b/docs/manifest-schema.md
@@ -1,0 +1,143 @@
+# Manifest schema
+
+Every sweep writes a `manifest.jsonl` next to its per-run output
+directories. It is the durable record of *what was run*, *with what
+overrides*, *and how it turned out* — designed so a mid-sweep `Ctrl-C`
+leaves a parseable file and so a future resume flow can rebuild the
+unfinished tail of the sweep.
+
+## On-disk format
+
+The file is **JSON Lines**:
+
+- **Line 1** — one JSON object: the **header**, written once by
+  [`Manifest.save()`][gmat_sweep.Manifest.save] and never rewritten.
+- **Lines 2..N** — one JSON object per run: a
+  [`ManifestEntry`][gmat_sweep.ManifestEntry], appended one at a time by
+  [`Manifest.append_entry()`][gmat_sweep.Manifest.append_entry] with `fsync`
+  after each write.
+
+Each line is a single complete JSON document with `sort_keys=True`, so the
+file is bit-for-bit deterministic across processes and trivially
+`grep`-friendly. The trailing newline on the final line is significant —
+[`Manifest.load()`][gmat_sweep.Manifest.load] tolerates a single torn last
+line by dropping it (a partial write loses one entry; the rest of the file
+parses cleanly).
+
+The header's `run_count` field is the *expected* run count at sweep launch
+time. It is **not rewritten** as entries arrive, so the on-disk header may
+report more runs than the file actually contains during and after a
+`Ctrl-C`'d sweep. Read `len(manifest.entries)` for the actual count.
+
+## Header fields
+
+```json
+{
+  "script_sha256":       "<hex>",
+  "gmat_sweep_version":  "0.1.0",
+  "gmat_run_version":    "0.3.x",
+  "gmat_install_version": "R2026a",
+  "python_version":      "3.12.x",
+  "os_platform":         "Linux-6.x.x-...",
+  "sweep_seed":          null,
+  "parameter_spec":      { "<dotted-path>": [<value>, ...], ... },
+  "run_count":           <int>
+}
+```
+
+| Field                  | What it carries                                                                                  |
+|------------------------|--------------------------------------------------------------------------------------------------|
+| `script_sha256`        | SHA-256 of the `.script` after line-ending and trailing-newline normalisation. See below.        |
+| `gmat_sweep_version`   | `gmat_sweep.__version__` at sweep time.                                                          |
+| `gmat_run_version`     | `gmat_run.__version__`, or `"unknown"` if `gmat_run` is not importable.                          |
+| `gmat_install_version` | The discovered GMAT install's version string (e.g. `"R2026a"`), or `"unknown"`.                  |
+| `python_version`       | `platform.python_version()`.                                                                     |
+| `os_platform`          | `platform.platform()` — same string `gmat-run` records.                                          |
+| `sweep_seed`           | The seed passed to [`sweep(seed=...)`][gmat_sweep.sweep], or `null`. Reserved for v0.2 Monte Carlo runs. |
+| `parameter_spec`       | The materialised grid: every iterable expanded to a list, keys preserved verbatim.               |
+| `run_count`            | The number of runs in the sweep at launch.                                                       |
+
+### Canonical script hash
+
+`script_sha256` is computed by
+[`canonical_script_sha256()`][gmat_sweep.canonical_script_sha256], which
+normalises line endings (`\r\n` and lone `\r` → `\n`) and trims trailing
+newlines to exactly one before hashing. Two clones of the same script
+checked out under different line-ending settings produce identical hashes.
+
+## Entry fields
+
+```json
+{
+  "run_id":        0,
+  "overrides":     { "<dotted-path>": <value>, ... },
+  "status":        "ok" | "failed" | "skipped",
+  "output_paths":  { "<report_name>": "<path>", ... },
+  "started_at":    "<ISO-8601 datetime>",
+  "ended_at":      "<ISO-8601 datetime>",
+  "duration_s":    1.234,
+  "stderr":        null,
+  "log_path":      "<path>" | null
+}
+```
+
+| Field          | What it carries                                                                                              |
+|----------------|--------------------------------------------------------------------------------------------------------------|
+| `run_id`       | Sequential integer assigned at grid-expansion time, starting at `0`. Unique within a sweep.                  |
+| `overrides`    | The override dict applied for this run — exactly the slice of the grid that produced it.                     |
+| `status`       | One of `"ok"`, `"failed"`, `"skipped"`. v0.1 only emits `"ok"` and `"failed"`.                                |
+| `output_paths` | Map from the report name (matched against the parsed `ReportFile` resource) to the per-run Parquet path. Empty `{}` for non-`ok` runs. |
+| `started_at`   | UTC `datetime` the worker began this run, ISO-8601 with tz offset.                                           |
+| `ended_at`     | UTC `datetime` the worker returned its outcome, ISO-8601.                                                    |
+| `duration_s`   | `(ended_at - started_at).total_seconds()`. Computed once on the worker side; the three timing fields cannot disagree. |
+| `stderr`       | `null` for successful runs. For failed runs: the formatted Python traceback, optionally followed by the captured GMAT engine log. |
+| `log_path`     | Path to the worker log file (`worker.log` under the per-run output directory), or `null`. Present whether the run succeeded or failed. |
+
+### `output_paths` invariant
+
+For `status == "ok"` entries, `output_paths` is non-empty. v0.1 assumes
+exactly one `ReportFile` per run; if a future script produces multiple,
+[`lazy_multiindex()`][gmat_sweep.lazy_multiindex] raises `NotImplementedError`
+and defers to the v0.2 reshape helpers. Whether a Parquet path is recorded
+as relative or absolute depends on how the worker wrote it; the aggregator
+resolves relative paths against the sweep's `output_dir`.
+
+## Loading a manifest back
+
+```python
+from pathlib import Path
+from gmat_sweep import Manifest
+
+manifest = Manifest.load(Path("./sweep/manifest.jsonl"))
+print(manifest.script_sha256, manifest.run_count, len(manifest.entries))
+
+# Find runs that need attention:
+failed_ids = manifest.find_failed()                       # [list of run_id]
+missing_ids = manifest.find_missing(range(manifest.run_count))
+```
+
+## CLI summary
+
+`gmat-sweep show` prints a one-line summary of an existing manifest
+without re-running anything:
+
+```bash
+$ gmat-sweep show ./sweep/manifest.jsonl
+6 runs (5 ok, 1 failed) in 12.34 s — output: sweep
+```
+
+## Append-only invariant
+
+The manifest is written **append-only with fsync after every entry**:
+
+- The header is written once, then never touched.
+- Each [`Manifest.append_entry()`][gmat_sweep.Manifest.append_entry] call
+  writes one line and `fsync`s the file (and, on POSIX, the parent
+  directory) before returning.
+
+A `Ctrl-C`, OOM kill, or `kill -9` can lose only the in-flight write —
+every entry that returned successfully from `append_entry` is durable.
+[`Manifest.load()`][gmat_sweep.Manifest.load] silently tolerates a single
+torn last line; anything more corrupted raises
+[`ManifestCorruptError`][gmat_sweep.ManifestCorruptError] with the offending
+file's path attached.

--- a/docs/parameter-spec.md
+++ b/docs/parameter-spec.md
@@ -1,0 +1,130 @@
+# Parameter spec
+
+The `grid` argument to [`sweep()`][gmat_sweep.sweep] is a mapping from
+**dotted-path field names** to sequences of values. `gmat-sweep` builds the
+cartesian product of those sequences and runs the mission script once per
+combination.
+
+```python
+from gmat_sweep import sweep
+
+df = sweep(
+    "mission.script",
+    grid={
+        "Sat.SMA": [7000, 7100, 7200],   # 3 values
+        "Sat.DryMass": [100, 200],       # 2 values
+    },
+)
+# 3 × 2 = 6 runs
+```
+
+## Dotted-path keys
+
+Every key in the `grid` mapping is a dotted-path that addresses one field on
+one resource in the loaded `.script`, exactly as `gmat-run`'s
+`Mission.__setitem__` consumes it. Examples:
+
+| Key                       | What it sets                                    |
+|---------------------------|-------------------------------------------------|
+| `Sat.SMA`                 | `Sat`'s semi-major axis                         |
+| `Sat.DryMass`             | `Sat`'s dry mass                                |
+| `Prop.Type`               | the propagator's integrator type (string)       |
+| `MainBurn.Element1`       | the first impulsive-burn delta-V component      |
+
+The first dotted segment is the resource name as it appears in the script
+(`Create Spacecraft Sat;` → `Sat`); the rest is the field path.
+`gmat-sweep` does not validate the path itself — `gmat-run` raises at run
+time if the path or value is rejected by GMAT, and that one run lands as a
+`failed` row in the result DataFrame.
+
+For a tour of the dotted-path syntax see `gmat-run`'s
+[Mission reference](https://astro-tools.github.io/gmat-run/reference/mission/).
+
+## Valid override types
+
+Override values cross a process boundary as JSON, so they must be
+JSON-encodable. In practice that means:
+
+- **`int`** and **`float`** — most numeric fields (lengths, masses,
+  durations, etc.).
+- **`str`** — enum-style fields (e.g. `Prop.Type = "RungeKutta89"`).
+- **`bool`** — flags.
+- **`list`** of the above — for vector fields like burn elements.
+
+`numpy` scalars and arrays should be cast to native Python types before
+being passed in. `gmat-run` itself accepts numpy on the receive side, but
+`gmat-sweep`'s [`RunSpec`][gmat_sweep.RunSpec] is the worker-boundary
+serialisation surface and JSON does not encode numpy scalars natively.
+
+## Full-factorial expansion
+
+[`sweep()`][gmat_sweep.sweep] uses the full-factorial expansion in
+[`full_factorial()`][gmat_sweep.full_factorial]:
+
+- Keys are emitted in **lexicographic order**, so the iteration order of
+  the input `grid` dict does not matter.
+- The cartesian product enumerates in `itertools.product` order over the
+  materialised input iterables. The lexicographically-first key varies
+  *slowest*; the last key varies *fastest*.
+
+For `{"a": [1, 2], "b": [10, 20, 30]}` the six override dicts come out as:
+
+```text
+(a=1, b=10), (a=1, b=20), (a=1, b=30),
+(a=2, b=10), (a=2, b=20), (a=2, b=30)
+```
+
+`run_id` values are assigned in this order starting at `0`, and that
+ordering is what the manifest and any future resume flow rely on.
+
+The expansion is byte-for-byte deterministic across processes and machines:
+two runs serialised through `json.dumps(..., sort_keys=True)` produce
+identical bytes. This is the property the
+[`canonical_script_sha256()`][gmat_sweep.canonical_script_sha256] hash and
+the manifest header are designed against.
+
+Empty grids (`grid={}`) are valid and produce a single run with no
+overrides — the cartesian product of nothing has one element. Empty
+*values* (e.g. `{"a": []}`) are rejected with
+[`SweepConfigError`][gmat_sweep.SweepConfigError].
+
+## CLI mini-grammar
+
+The `gmat-sweep run` CLI accepts the same grids via repeated `--grid`
+flags. The right-hand side of each `--grid` argument has two forms:
+
+### Linspace: `name=lo:hi:count`
+
+`count` evenly-spaced values from `lo` to `hi` *inclusive*, via
+`numpy.linspace`. `lo` and `hi` are floats, `count` is an integer ≥ 2.
+
+```bash
+gmat-sweep run --grid Sat.SMA=7000:7400:5 --out ./sweep mission.script
+# Sat.SMA ∈ {7000.0, 7100.0, 7200.0, 7300.0, 7400.0}
+```
+
+### Explicit list: `name=v1,v2,v3`
+
+A comma-separated list. Each token is coerced to `int` if possible, then
+`float`, then left as a `str`:
+
+```bash
+gmat-sweep run \
+  --grid Sat.SMA=7000,7100,7200 \
+  --grid Sat.DryMass=100,200 \
+  --grid Prop.Type=RungeKutta89,PrinceDormand78 \
+  --out ./sweep \
+  mission.script
+```
+
+That sweep runs 3 × 2 × 2 = 12 cells.
+
+A grid name may only appear once per CLI invocation; passing the same name
+twice raises [`SweepConfigError`][gmat_sweep.SweepConfigError]. There is no
+way to mix linspace and explicit notation on the same axis — pick one.
+
+## See also
+
+- [API reference: `sweep`](api.md#gmat_sweep.sweep)
+- [Manifest schema](manifest-schema.md) — how the resulting manifest
+  records the materialised grid.

--- a/docs/supported-versions.md
+++ b/docs/supported-versions.md
@@ -1,0 +1,64 @@
+# Supported versions
+
+The CI matrix below is the authoritative supported set for v0.1. `gmat-sweep`
+runs on every cell on every PR, with both unit and integration suites enabled.
+
+## v0.1 matrix
+
+| Axis      | Versions                                                       |
+|-----------|----------------------------------------------------------------|
+| GMAT      | R2025a, R2026a (R2026a is the primary development target)      |
+| Python    | 3.10, 3.11, 3.12                                               |
+| Operating system | Ubuntu (`ubuntu-latest`), Windows (`windows-latest`)    |
+
+That gives 2 × 3 × 2 = 12 cells covered on every PR.
+
+### Notes per axis
+
+#### GMAT
+
+GMAT installs are provisioned in CI via
+[`astro-tools/setup-gmat`](https://github.com/astro-tools/setup-gmat). Locally,
+download a build from the
+[GMAT SourceForge release page](https://sourceforge.net/projects/gmat/files/GMAT/);
+[`gmat-run`'s install guide](https://astro-tools.github.io/gmat-run/install-gmat/)
+walks through unpacking and pointing Python at it.
+
+Older GMAT releases (R2022a and earlier) are not in the matrix. The GMAT
+project skipped public R2023a and R2024a releases, so R2025a and R2026a are
+the only releases supported in v0.1.
+
+#### Python
+
+3.10 is the floor (`requires-python = ">=3.10"` in `pyproject.toml`). 3.13
+is not in the v0.1 matrix; it will be added once `pyarrow` and `joblib`'s
+loky backend ship stable wheels for it.
+
+#### Operating system
+
+macOS is **deferred to v0.2**. The blocker is `setup-gmat`'s macOS support,
+not `gmat-sweep` itself. If you need macOS today, building a stub `Pool`
+implementation that runs jobs in-process is straightforward — see the
+[`Pool`][gmat_sweep.Pool] ABC for the contract.
+
+## Runtime dependencies
+
+`gmat-sweep` does **not** ship GMAT. It depends at runtime on:
+
+- A working **GMAT install** discoverable on the host (see the
+  [getting-started page](getting-started.md#install)).
+- [**`gmat-run`**](https://github.com/astro-tools/gmat-run) ≥ 0.3 — the
+  single-run primitive every worker calls into. Installed as a transitive
+  dependency from PyPI.
+
+`gmat-run` is in turn responsible for finding, importing, and bootstrapping
+`gmatpy`. `gmat-sweep` itself never imports `gmatpy` directly — the import
+happens inside each worker subprocess on first call. See the
+[FAQ](faq.md#why-does-each-run-go-in-its-own-subprocess) for why.
+
+## Beyond the support matrix
+
+If your environment is outside the supported matrix, the package may still
+work — it is pure Python and the only platform-specific bits are inherited
+from `gmat-run` and the GMAT install itself. Just do not expect CI to catch
+regressions for you.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,80 @@
+site_name: gmat-sweep
+site_description: Run parameter sweeps and Monte Carlo dispersions over GMAT missions in parallel from Python.
+site_url: https://astro-tools.github.io/gmat-sweep/
+repo_url: https://github.com/astro-tools/gmat-sweep
+repo_name: astro-tools/gmat-sweep
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  features:
+    - content.code.copy
+    - navigation.indexes
+    - navigation.instant
+    - navigation.sections
+    - navigation.top
+    - search.highlight
+    - search.suggest
+    - toc.follow
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+nav:
+  - Home: index.md
+  - Getting started: getting-started.md
+  - Parameter spec: parameter-spec.md
+  - Manifest schema: manifest-schema.md
+  - Supported versions: supported-versions.md
+  - FAQ: faq.md
+  - API reference: api.md
+
+plugins:
+  - search
+  - mkdocstrings:
+      default_handler: python
+      handlers:
+        python:
+          paths: [src]
+          options:
+            show_source: false
+            show_root_heading: true
+            show_root_full_path: false
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+            members_order: source
+            separate_signature: true
+            show_signature_annotations: true
+            signature_crossrefs: true
+            docstring_style: google
+            merge_init_into_class: true
+            filters: ["!^_"]
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - tables
+  - toc:
+      permalink: true
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/astro-tools/gmat-sweep


### PR DESCRIPTION
## Summary

- Adds `mkdocs.yml` and seven `docs/` pages for the v0.1 public surface — landing + quick-start, getting-started (install + four-line vision snippet), parameter spec, manifest schema, supported-versions matrix, FAQ, and an auto-generated API reference via `mkdocstrings[python]` over every symbol re-exported from `gmat_sweep`.
- Mirrors the conventions used by the sibling `astro-tools/gmat-run` docs site (Material theme, Google docstring style, `paths: [src]`).
- No source changes — the `docs` dependency group already had `mkdocs-material` and `mkdocstrings[python]`.

## Test plan

- [x] `uv run mkdocs build --strict` passes locally.
- [x] All internal cross-references resolve to the API page (verified via `grep` over `site/`).
- [x] All 17 public symbols from `gmat_sweep.__all__` (minus `__version__`) render under `docs/api.md`.
- [x] `uv run ruff check` and `uv run ruff format --check` clean.
- [x] CI `Docs / build` job passes.
- [ ] Post-merge: run `workflow_dispatch` on the `Docs` workflow to seed `gh-pages`, then point Pages settings at the `gh-pages` branch.

## Notes for the reviewer

- `gh-pages` is **not** seeded by this PR. The existing `docs.yml` deploys on `workflow_dispatch` and on `v*` tags only — the first `workflow_dispatch` after merge is the seed step the issue calls out.
- README is intentionally untouched (out of scope per the issue body).

Closes #12