### PR TITLE
Add v0.1 example notebooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,22 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' && matrix.gmat-version == 'R2026a'
         run: uv run coverage report --include='src/gmat_sweep/aggregate.py' --fail-under=95
 
+      # Smoke-execute the example notebooks end-to-end. Catches "someone changed
+      # the public surface and forgot to refresh the committed notebook"
+      # regressions without paying the cost of nbval-style strict comparison
+      # (notebooks are committed with cleared outputs). One matrix combo is
+      # enough — the underlying surface is covered cross-platform by the rest
+      # of the test job. Notebook 03 uses signal.SIGINT against a child
+      # process, so it is Linux-only (Windows lacks the matching semantics).
+      - name: Smoke-execute example notebooks
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' && matrix.gmat-version == 'R2026a'
+        working-directory: docs/examples
+        run: |
+          uv sync --all-groups --extra examples
+          uv run jupyter execute 01_sma_scan.ipynb
+          uv run jupyter execute 02_epoch_arrival_grid.ipynb
+          uv run jupyter execute 03_killed_sweep_recovery.ipynb
+
   lint:
     name: lint
     runs-on: ubuntu-latest

--- a/docs/examples/01_sma_scan.ipynb
+++ b/docs/examples/01_sma_scan.ipynb
@@ -1,0 +1,208 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a8b1d010",
+   "metadata": {},
+   "source": [
+    "# Single-axis SMA scan\n",
+    "\n",
+    "Fifty runs of the same minimal LEO mission, one per semi-major-axis value across `np.linspace(7000, 8000, 50)`, fanned out in parallel and overlaid on a single altitude-vs-time plot.\n",
+    "\n",
+    "This is the smallest end-to-end exercise of the v0.1 surface: one [`sweep()`][gmat_sweep.sweep] call returns a `(run_id, time)`-MultiIndexed DataFrame; the plot below loops over `run_id` and overlays each per-run trajectory.\n",
+    "\n",
+    "**Prerequisites.** A local GMAT install (R2026a is the primary development target; see [Supported versions](../supported-versions.md)) and `pip install gmat-sweep[examples]` for the matplotlib dependency."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3c5b9a2",
+   "metadata": {},
+   "source": [
+    "## Set up the run\n",
+    "\n",
+    "Resolve the GMAT install once and confirm the script that ships next to this notebook is where we expect it. The script lives in the same directory so the path is machine-independent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0a2c4f51",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "from gmat_run import locate_gmat\n",
+    "\n",
+    "from gmat_sweep import sweep\n",
+    "\n",
+    "install = locate_gmat()\n",
+    "script_path = Path(\"leo_keplerian.script\").resolve()\n",
+    "\n",
+    "print(f\"GMAT version: {install.version}\")\n",
+    "print(f\"Script:       {script_path.name}\")\n",
+    "print(f\"Exists:       {script_path.exists()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b7d3e8c4",
+   "metadata": {},
+   "source": [
+    "## Define the grid\n",
+    "\n",
+    "Fifty semi-major-axis values, evenly spaced from 7000 km (~622 km altitude) to 8000 km (~1622 km altitude). The grid is a plain dict from dotted-path field name to an iterable of values; `sweep()` materialises the cartesian product internally."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5dc12fe3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sma_values = np.linspace(7000.0, 8000.0, 50)\n",
+    "sma_values"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9d4abc70",
+   "metadata": {},
+   "source": [
+    "## Run the sweep\n",
+    "\n",
+    "One [`sweep()`][gmat_sweep.sweep] call dispatches all 50 runs through the default `LocalJoblibPool`, drains the per-run outcomes in completion order, and returns the aggregated `(run_id, time)`-MultiIndexed DataFrame.\n",
+    "\n",
+    "Each row carries the corresponding `Sat.SMA` override applied to that run, the `__status` column (`ok` / `failed` / `skipped`), and one column per channel the script's `ReportFile` declared. With `out=None` the per-run Parquet files land in a temporary directory whose lifetime is tied to the returned DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1eaf5b6c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = sweep(script_path, grid={\"Sat.SMA\": sma_values}, workers=-1)\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "62b7c0f8",
+   "metadata": {},
+   "source": [
+    "Confirm every run finished cleanly. Failed and skipped runs would surface as one NaN-filled row each, with `__status` set accordingly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "73a948d1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df[\"__status\"].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4c1afe55",
+   "metadata": {},
+   "source": [
+    "## Derive altitude and overlay\n",
+    "\n",
+    "The script's ReportFile records inertial position only (`Sat.X`, `Sat.Y`, `Sat.Z`) — altitude is a derived quantity. For a spherical Earth it's $|\\mathbf{r}| - R_\\oplus$. We compute it on the whole frame in one vectorised pass; the `(run_id, time)` MultiIndex carries through unchanged."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8b30dac9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "EARTH_RADIUS_KM = 6378.137  # WGS-84 equatorial radius\n",
+    "\n",
+    "position = df[[\"Sat.X\", \"Sat.Y\", \"Sat.Z\"]]\n",
+    "df[\"Altitude_km\"] = (position**2).sum(axis=1) ** 0.5 - EARTH_RADIUS_KM"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e44b0dc",
+   "metadata": {},
+   "source": [
+    "Overlay every run on a single axis. Grouping by `run_id` lets us iterate one trajectory at a time; we colour each line by its commanded `Sat.SMA` so the visual sweep matches the parameter sweep."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2c7a814",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(10, 5))\n",
+    "cmap = plt.get_cmap(\"viridis\")\n",
+    "\n",
+    "for run_id, group in df.groupby(level=\"run_id\"):\n",
+    "    sma = sma_values[run_id]\n",
+    "    color = cmap((sma - sma_values.min()) / (sma_values.max() - sma_values.min()))\n",
+    "    times = group.index.get_level_values(\"time\")\n",
+    "    ax.plot(times, group[\"Altitude_km\"], color=color, alpha=0.7, linewidth=1.0)\n",
+    "\n",
+    "norm = plt.Normalize(vmin=sma_values.min(), vmax=sma_values.max())\n",
+    "fig.colorbar(\n",
+    "    plt.cm.ScalarMappable(norm=norm, cmap=cmap),\n",
+    "    ax=ax,\n",
+    "    label=\"Sat.SMA (km)\",\n",
+    ")\n",
+    "ax.set_xlabel(\"UTC\")\n",
+    "ax.set_ylabel(\"Altitude (km)\")\n",
+    "ax.set_title(\"50 SMA-scan runs overlaid (1 hour propagation each)\")\n",
+    "ax.grid(True, alpha=0.3)\n",
+    "fig.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0a91234",
+   "metadata": {},
+   "source": [
+    "## Where to next\n",
+    "\n",
+    "- **Two-axis grids.** [Notebook 02](02_epoch_arrival_grid.ipynb) adds a second sweep axis (launch epoch × time-of-flight) and contours a per-run scalar across the grid.\n",
+    "- **Inspect a partial sweep after a kill.** [Notebook 03](03_killed_sweep_recovery.ipynb) demonstrates that the JSON Lines manifest survives a mid-sweep `Ctrl-C` and can be loaded back from disk.\n",
+    "- **Keep the per-run Parquet files.** Pass `out=Path(\"./sweep-out\")` to [`sweep()`][gmat_sweep.sweep] to anchor the per-run artefacts under an explicit directory instead of a temp dir.\n",
+    "- **CLI alternative.** The [`gmat-sweep run`](../parameter-spec.md) shell command wraps the same call for non-Python pipelines."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/01_sma_scan.ipynb
+++ b/docs/examples/01_sma_scan.ipynb
@@ -4,15 +4,7 @@
    "cell_type": "markdown",
    "id": "a8b1d010",
    "metadata": {},
-   "source": [
-    "# Single-axis SMA scan\n",
-    "\n",
-    "Fifty runs of the same minimal LEO mission, one per semi-major-axis value across `np.linspace(7000, 8000, 50)`, fanned out in parallel and overlaid on a single altitude-vs-time plot.\n",
-    "\n",
-    "This is the smallest end-to-end exercise of the v0.1 surface: one [`sweep()`][gmat_sweep.sweep] call returns a `(run_id, time)`-MultiIndexed DataFrame; the plot below loops over `run_id` and overlays each per-run trajectory.\n",
-    "\n",
-    "**Prerequisites.** A local GMAT install (R2026a is the primary development target; see [Supported versions](../supported-versions.md)) and `pip install gmat-sweep[examples]` for the matplotlib dependency."
-   ]
+   "source": "# Single-axis SMA scan\n\nFifty runs of the same minimal LEO mission, one per semi-major-axis value across `np.linspace(7000, 8000, 50)`, fanned out in parallel and overlaid on a single altitude-vs-time plot.\n\nThe smallest end-to-end exercise of the public API: one [`sweep()`][gmat_sweep.sweep] call returns a `(run_id, time)`-MultiIndexed DataFrame; the plot below loops over `run_id` and overlays each per-run trajectory.\n\n**Prerequisites.** A local GMAT install (R2026a is the primary development target; see [Supported versions](../supported-versions.md)) and `pip install gmat-sweep[examples]` for the matplotlib dependency."
   },
   {
    "cell_type": "markdown",

--- a/docs/examples/02_epoch_arrival_grid.ipynb
+++ b/docs/examples/02_epoch_arrival_grid.ipynb
@@ -196,13 +196,7 @@
    "cell_type": "markdown",
    "id": "0fa6dba7",
    "metadata": {},
-   "source": [
-    "## Where to next\n",
-    "\n",
-    "- **Survive a kill mid-sweep.** [Notebook 03](03_killed_sweep_recovery.ipynb) walks through interrupting a sweep with `SIGINT` and reading the partial manifest back from disk.\n",
-    "- **Real porkchop plots** require Lambert targeting and a moving target body — gmat-sweep's v0.1 surface is a parallel evaluator, not an optimiser. The 2D-grid mechanism shown here is the building block; the targeting layer that turns it into a true porkchop is out of scope (see [`CONTRIBUTING.md`](https://github.com/astro-tools/gmat-sweep/blob/main/CONTRIBUTING.md#scope-discipline)).\n",
-    "- **Manifest schema.** [Manifest schema](../manifest-schema.md) documents every field the JSON Lines records carry."
-   ]
+   "source": "## Where to next\n\n- **Survive a kill mid-sweep.** [Notebook 03](03_killed_sweep_recovery.ipynb) walks through interrupting a sweep with `SIGINT` and reading the partial manifest back from disk.\n- **Real porkchop plots** require Lambert targeting and a moving target body — gmat-sweep is a parallel evaluator, not an optimiser. The 2D-grid mechanism shown here is the building block; the targeting layer that turns it into a true porkchop is out of scope (see [`CONTRIBUTING.md`](https://github.com/astro-tools/gmat-sweep/blob/main/CONTRIBUTING.md#scope-discipline)).\n- **Manifest schema.** [Manifest schema](../manifest-schema.md) documents every field the JSON Lines records carry."
   }
  ],
  "metadata": {

--- a/docs/examples/02_epoch_arrival_grid.ipynb
+++ b/docs/examples/02_epoch_arrival_grid.ipynb
@@ -1,0 +1,229 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c1d2a4f0",
+   "metadata": {},
+   "source": [
+    "# Two-axis epoch × time-of-flight grid\n",
+    "\n",
+    "Two-parameter cartesian product over launch epoch (`Sat.Epoch`) and time-of-flight (a script-level `Variable TOF` that drives the `Propagate` stopping condition). The per-run scalar — distance from the final inertial position to a fixed reference point — is reshaped into a 2D matrix and contoured.\n",
+    "\n",
+    "This is the smallest end-to-end exercise of the *two-axis* surface: the same [`sweep()`][gmat_sweep.sweep] call accepts a grid with multiple keys; the cartesian product is expanded internally and dispatched in parallel.\n",
+    "\n",
+    "The arrival metric here is contrived (a fixed inertial point picked to make the contour interesting, not a real target). The point is the 2D-sweep machinery, not the astrodynamics.\n",
+    "\n",
+    "**Prerequisites.** A local GMAT install (R2026a is the primary development target) and `pip install gmat-sweep[examples]` for the matplotlib dependency."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "92b9c3a1",
+   "metadata": {},
+   "source": [
+    "## Set up the run\n",
+    "\n",
+    "Resolve the GMAT install once and confirm the script that ships next to this notebook is where we expect it. The script declares `Sat.Epoch` and `Variable TOF` as the two fields the notebook will override per run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1a3e8bc2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tempfile\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from gmat_run import locate_gmat\n",
+    "\n",
+    "from gmat_sweep import Manifest, sweep\n",
+    "\n",
+    "install = locate_gmat()\n",
+    "script_path = Path(\"transfer_porkchop.script\").resolve()\n",
+    "\n",
+    "print(f\"GMAT version: {install.version}\")\n",
+    "print(f\"Script:       {script_path.name}\")\n",
+    "print(f\"Exists:       {script_path.exists()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b03f4d62",
+   "metadata": {},
+   "source": [
+    "## Define the two grid axes\n",
+    "\n",
+    "Six launch epochs spaced four hours apart over the first day of 2026, and six time-of-flight values from one to four hours. The cartesian product is 36 runs.\n",
+    "\n",
+    "`Sat.Epoch` is set by string (GMAT's wire format is `'DD Mmm YYYY HH:MM:SS.sss'`); `TOF.Value` reads and writes through the same dotted-path setter as any other field."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27cd1c40",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "launch_offsets_h = np.array([0, 4, 8, 12, 16, 20])\n",
+    "epoch_base = pd.Timestamp(\"2026-01-01 00:00:00\")\n",
+    "epochs = [\n",
+    "    (epoch_base + pd.Timedelta(hours=int(h))).strftime(\"%d %b %Y %H:%M:%S.000\")\n",
+    "    for h in launch_offsets_h\n",
+    "]\n",
+    "tof_hours = np.array([1.0, 1.5, 2.0, 2.5, 3.0, 4.0])\n",
+    "tof_seconds = (tof_hours * 3600.0).tolist()\n",
+    "\n",
+    "for epoch in epochs:\n",
+    "    print(epoch)\n",
+    "print(f\"\\nTOF (hours): {tof_hours.tolist()}\")\n",
+    "print(f\"\\nTotal runs:  {len(epochs) * len(tof_seconds)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5acc4e2f",
+   "metadata": {},
+   "source": [
+    "## Run the sweep\n",
+    "\n",
+    "Pass `out=` so the per-run Parquet files and the JSON Lines manifest survive past the call — we'll reload the manifest below to map each `run_id` back to its `(epoch, TOF)` cell. The default `out=None` would tie everything to the DataFrame's lifetime."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9eb7c0dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tmpdir = tempfile.TemporaryDirectory(prefix=\"epoch-arrival-grid-\")\n",
+    "out_dir = Path(tmpdir.name)\n",
+    "\n",
+    "df = sweep(\n",
+    "    script_path,\n",
+    "    grid={\"Sat.Epoch\": epochs, \"TOF.Value\": tof_seconds},\n",
+    "    out=out_dir,\n",
+    "    workers=-1,\n",
+    ")\n",
+    "df[\"__status\"].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b73e8a7",
+   "metadata": {},
+   "source": [
+    "## Compute arrival miss distance per run\n",
+    "\n",
+    "The per-run scalar of interest is the Euclidean distance from the spacecraft's final inertial position to a fixed reference point. The DataFrame is indexed by `(run_id, time)` so we group by `run_id` and take the last row per group; the final timestep is the propagation end-state.\n",
+    "\n",
+    "The target point is picked off the orbit's reachable region so the contour shows interesting structure — there is no orbital-mechanics significance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13e4adcb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TARGET = np.array([10000.0, -3000.0, 0.0])\n",
+    "\n",
+    "final = df.groupby(level=\"run_id\").last()\n",
+    "final_pos = final[[\"Sat.X\", \"Sat.Y\", \"Sat.Z\"]].to_numpy()\n",
+    "miss_km = np.linalg.norm(final_pos - TARGET, axis=1)\n",
+    "\n",
+    "miss = pd.Series(miss_km, index=final.index, name=\"miss_km\")\n",
+    "miss.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f50dadf1",
+   "metadata": {},
+   "source": [
+    "## Reshape into a 2D matrix\n",
+    "\n",
+    "[`Manifest.load`][gmat_sweep.Manifest.load] reads back the JSON Lines manifest the sweep wrote. Each entry's `overrides` dict carries the parameters applied to that run — using it to rebuild the `(epoch, TOF)` index avoids relying on the (deterministic but undocumented at the call site) `run_id` ordering convention."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8ca4d723",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "manifest = Manifest.load(out_dir / \"manifest.jsonl\")\n",
+    "\n",
+    "by_cell = pd.DataFrame(\n",
+    "    {\n",
+    "        \"epoch\": [e.overrides[\"Sat.Epoch\"] for e in manifest.entries],\n",
+    "        \"tof_h\": [e.overrides[\"TOF.Value\"] / 3600.0 for e in manifest.entries],\n",
+    "        \"miss_km\": miss.loc[[e.run_id for e in manifest.entries]].to_numpy(),\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "miss_grid = by_cell.pivot(index=\"epoch\", columns=\"tof_h\", values=\"miss_km\")\n",
+    "miss_grid"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4dd84e0b",
+   "metadata": {},
+   "source": [
+    "## Contour\n",
+    "\n",
+    "The contour shows how the arrival miss distance varies across the launch-epoch × time-of-flight grid. The dark band is the locus of `(epoch, TOF)` pairs where the spacecraft's final position is closest to the synthetic target."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b21ce14",
+   "metadata": {},
+   "outputs": [],
+   "source": "Z = miss_grid.to_numpy()\n\nfig, ax = plt.subplots(figsize=(8, 5))\ncf = ax.contourf(tof_hours, launch_offsets_h, Z, levels=12, cmap=\"viridis\")\nax.contour(tof_hours, launch_offsets_h, Z, levels=12, colors=\"white\", linewidths=0.4, alpha=0.5)\nfig.colorbar(cf, ax=ax, label=\"Arrival miss distance (km)\")\nax.set_xlabel(\"Time of flight (hours)\")\nax.set_ylabel(\"Launch epoch (hours after 2026-01-01 00:00 UTC)\")\nax.set_title(\"Arrival miss distance over (launch epoch x TOF) grid\")\nfig.tight_layout()\nplt.show()"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0fa6dba7",
+   "metadata": {},
+   "source": [
+    "## Where to next\n",
+    "\n",
+    "- **Survive a kill mid-sweep.** [Notebook 03](03_killed_sweep_recovery.ipynb) walks through interrupting a sweep with `SIGINT` and reading the partial manifest back from disk.\n",
+    "- **Real porkchop plots** require Lambert targeting and a moving target body — gmat-sweep's v0.1 surface is a parallel evaluator, not an optimiser. The 2D-grid mechanism shown here is the building block; the targeting layer that turns it into a true porkchop is out of scope (see [`CONTRIBUTING.md`](https://github.com/astro-tools/gmat-sweep/blob/main/CONTRIBUTING.md#scope-discipline)).\n",
+    "- **Manifest schema.** [Manifest schema](../manifest-schema.md) documents every field the JSON Lines records carry."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/03_killed_sweep_recovery.ipynb
+++ b/docs/examples/03_killed_sweep_recovery.ipynb
@@ -1,0 +1,275 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f12d8a3c",
+   "metadata": {},
+   "source": [
+    "# Surviving a kill: partial manifest recovery\n",
+    "\n",
+    "v0.1's durability claim is narrow but load-bearing: **the JSON Lines manifest survives a mid-sweep `Ctrl-C`**, the partial DataFrame is loadable from disk, and the CLI inspector reports the partial state. This notebook walks through that exact flow end-to-end:\n",
+    "\n",
+    "1. Launch `gmat-sweep run` as a subprocess against a small mission.\n",
+    "2. Poll the manifest until a few runs have completed.\n",
+    "3. Send the subprocess `SIGINT` (the same signal `Ctrl-C` raises).\n",
+    "4. Inspect the partial manifest with `gmat-sweep show`.\n",
+    "5. Reload the manifest in-process and aggregate the partial DataFrame from the Parquet files on disk.\n",
+    "\n",
+    "**Programmatic resume — `Sweep.from_manifest(...).resume()` — lands in v0.2.** The v0.1 surface this notebook exercises is durability and inspection: a killed sweep leaves a parseable manifest and queryable per-run artefacts, but you re-issue the original `sweep()` call to re-run the missing cells.\n",
+    "\n",
+    "**Prerequisites.** A local GMAT install (R2026a is the primary development target). This notebook does not depend on the `[examples]` extra (no plots).\n",
+    "\n",
+    "**Platform note.** The `SIGINT`-via-subprocess approach used below is POSIX-only. On Windows, the same recovery flow works after a real `Ctrl-C` in an interactive `gmat-sweep run` session — but reproducing the kill from a notebook cell needs different signalling primitives."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "39c75e1b",
+   "metadata": {},
+   "source": [
+    "## Set up the run\n",
+    "\n",
+    "Resolve the GMAT install once and confirm the small mission script that ships next to this notebook is where we expect it. The script propagates for 60 seconds with point-mass Earth — every per-run cost is sub-second so the kill-and-inspect demo finishes inside the smoke step's wall-clock budget."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c2e4af0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import signal\n",
+    "import subprocess\n",
+    "import tempfile\n",
+    "import time\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from gmat_run import locate_gmat\n",
+    "\n",
+    "from gmat_sweep import Manifest, lazy_multiindex\n",
+    "\n",
+    "install = locate_gmat()\n",
+    "script_path = Path(\"leo_short.script\").resolve()\n",
+    "\n",
+    "print(f\"GMAT version: {install.version}\")\n",
+    "print(f\"Script:       {script_path.name}\")\n",
+    "print(f\"Exists:       {script_path.exists()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "21d6e3b4",
+   "metadata": {},
+   "source": [
+    "## Launch the sweep as a subprocess\n",
+    "\n",
+    "We dispatch 20 runs with `--workers 1` so completions are serialised — that makes the polling loop below predictable. Each completed run appends one fsync'd line to `manifest.jsonl`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8b2dfc4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tmpdir = tempfile.TemporaryDirectory(prefix=\"killed-sweep-\")\n",
+    "out_dir = Path(tmpdir.name)\n",
+    "manifest_path = out_dir / \"manifest.jsonl\"\n",
+    "\n",
+    "proc = subprocess.Popen(\n",
+    "    [\n",
+    "        \"gmat-sweep\",\n",
+    "        \"run\",\n",
+    "        \"--grid\",\n",
+    "        \"Sat.SMA=7000:8000:20\",\n",
+    "        \"--workers\",\n",
+    "        \"1\",\n",
+    "        \"--out\",\n",
+    "        str(out_dir),\n",
+    "        str(script_path),\n",
+    "    ],\n",
+    "    stdout=subprocess.PIPE,\n",
+    "    stderr=subprocess.PIPE,\n",
+    ")\n",
+    "print(f\"Spawned gmat-sweep pid={proc.pid}, output dir = {out_dir}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d048f2ea",
+   "metadata": {},
+   "source": [
+    "## Wait for a few runs to finish, then SIGINT\n",
+    "\n",
+    "Poll the manifest until at least 5 runs have completed. Each fsync'd append is durable, so a parse mid-poll always sees a consistent prefix.\n",
+    "\n",
+    "Once the threshold is reached we send the child `SIGINT` — the same signal an interactive `Ctrl-C` would raise — and wait for it to exit. The orchestrator does not catch `KeyboardInterrupt`, so the subprocess exits with a non-zero code; that is the expected outcome."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f5e7c812",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TARGET_ENTRIES = 5\n",
+    "DEADLINE_S = 60.0\n",
+    "deadline = time.monotonic() + DEADLINE_S\n",
+    "\n",
+    "\n",
+    "def _entries_on_disk(path: Path) -> int:\n",
+    "    if not path.exists():\n",
+    "        return 0\n",
+    "    # Header line + one per-run line. Subtract 1 for the header.\n",
+    "    return max(0, sum(1 for _ in path.open(\"r\", encoding=\"utf-8\")) - 1)\n",
+    "\n",
+    "\n",
+    "while time.monotonic() < deadline:\n",
+    "    if proc.poll() is not None:\n",
+    "        raise RuntimeError(\n",
+    "            f\"gmat-sweep exited before SIGINT could be sent (rc={proc.returncode}); \"\n",
+    "            f\"stderr: {proc.stderr.read().decode(errors='replace') if proc.stderr else ''}\"\n",
+    "        )\n",
+    "    if _entries_on_disk(manifest_path) >= TARGET_ENTRIES:\n",
+    "        break\n",
+    "    time.sleep(0.1)\n",
+    "else:\n",
+    "    proc.kill()\n",
+    "    raise RuntimeError(\n",
+    "        f\"gmat-sweep did not append {TARGET_ENTRIES} manifest entries within {DEADLINE_S} s\"\n",
+    "    )\n",
+    "\n",
+    "n_before_kill = _entries_on_disk(manifest_path)\n",
+    "proc.send_signal(signal.SIGINT)\n",
+    "rc = proc.wait(timeout=30)\n",
+    "n_after_kill = _entries_on_disk(manifest_path)\n",
+    "\n",
+    "print(f\"Subprocess exited with rc={rc}\")\n",
+    "print(f\"Manifest entries at kill:  {n_before_kill}\")\n",
+    "print(f\"Manifest entries on disk:  {n_after_kill}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94c2bd73",
+   "metadata": {},
+   "source": [
+    "## Inspect the partial manifest with `gmat-sweep show`\n",
+    "\n",
+    "The CLI's `show` subcommand prints a one-line summary: counts per status bucket, total wall-clock duration, output directory. It loads the manifest with the same [`Manifest.load`][gmat_sweep.Manifest.load] used in-process, so a torn final line (if the kill landed mid-write) is tolerated — at most one entry is lost."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ad7c5b8f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show = subprocess.run(\n",
+    "    [\"gmat-sweep\", \"show\", str(manifest_path)],\n",
+    "    capture_output=True,\n",
+    "    text=True,\n",
+    "    check=True,\n",
+    ")\n",
+    "print(show.stdout.strip())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0a3f1cbb",
+   "metadata": {},
+   "source": [
+    "## Reload the manifest in-process\n",
+    "\n",
+    "[`Manifest.load`][gmat_sweep.Manifest.load] returns the full record — header fingerprint plus one [`ManifestEntry`][gmat_sweep.ManifestEntry] per completed run, in the order they finished."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2e84acde",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "manifest = Manifest.load(manifest_path)\n",
+    "print(f\"Header.run_count (planned):  {manifest.run_count}\")\n",
+    "print(f\"Entries on disk (completed): {len(manifest.entries)}\")\n",
+    "print(f\"GMAT install version:        {manifest.gmat_install_version}\")\n",
+    "print(f\"Script SHA-256 (canonical):  {manifest.script_sha256[:16]}...\")\n",
+    "\n",
+    "for entry in manifest.entries[:3]:\n",
+    "    print(f\"  run_id={entry.run_id} status={entry.status} overrides={entry.overrides}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e913fa2",
+   "metadata": {},
+   "source": [
+    "## Aggregate the partial DataFrame\n",
+    "\n",
+    "[`lazy_multiindex`][gmat_sweep.lazy_multiindex] is the same aggregator [`sweep()`][gmat_sweep.sweep] uses internally to produce its return value. Pointing it at a partial manifest yields a partial DataFrame — only the runs that completed before the kill are represented, but every one of them is intact."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c4b72a0e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = lazy_multiindex(manifest, out_dir)\n",
+    "print(f\"Partial DataFrame shape: {df.shape}\")\n",
+    "print(f\"Distinct run_ids:        {df.index.get_level_values('run_id').nunique()}\")\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5f29bd0e",
+   "metadata": {},
+   "source": [
+    "## v0.1 surface vs. v0.2 resume\n",
+    "\n",
+    "Everything above uses **only the v0.1 public surface**:\n",
+    "\n",
+    "- The manifest is fsync'd line-by-line so a kill leaves a parseable file.\n",
+    "- The CLI `show` subcommand reports the partial state.\n",
+    "- [`Manifest.load`][gmat_sweep.Manifest.load] tolerates a single torn final line.\n",
+    "- [`lazy_multiindex`][gmat_sweep.lazy_multiindex] aggregates whatever the manifest references; missing runs are simply absent.\n",
+    "\n",
+    "**v0.2 will add `Sweep.from_manifest(manifest_path).resume()`** — programmatic re-dispatch of just the missing `run_id`s against the same backend, with the manifest header re-validated against the current script and environment. Until then, recovering a killed sweep is a re-issue of the original [`sweep()`][gmat_sweep.sweep] call: the durable manifest is the artefact you keep; the run command is the operation you re-run.\n",
+    "\n",
+    "## Where to next\n",
+    "\n",
+    "- **Manifest schema.** [Manifest schema](../manifest-schema.md) documents every field the JSON Lines records carry, plus the canonical script-hash convention.\n",
+    "- **CLI reference.** The [`gmat-sweep run` and `gmat-sweep show`](../parameter-spec.md) flags."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/03_killed_sweep_recovery.ipynb
+++ b/docs/examples/03_killed_sweep_recovery.ipynb
@@ -4,23 +4,7 @@
    "cell_type": "markdown",
    "id": "f12d8a3c",
    "metadata": {},
-   "source": [
-    "# Surviving a kill: partial manifest recovery\n",
-    "\n",
-    "v0.1's durability claim is narrow but load-bearing: **the JSON Lines manifest survives a mid-sweep `Ctrl-C`**, the partial DataFrame is loadable from disk, and the CLI inspector reports the partial state. This notebook walks through that exact flow end-to-end:\n",
-    "\n",
-    "1. Launch `gmat-sweep run` as a subprocess against a small mission.\n",
-    "2. Poll the manifest until a few runs have completed.\n",
-    "3. Send the subprocess `SIGINT` (the same signal `Ctrl-C` raises).\n",
-    "4. Inspect the partial manifest with `gmat-sweep show`.\n",
-    "5. Reload the manifest in-process and aggregate the partial DataFrame from the Parquet files on disk.\n",
-    "\n",
-    "**Programmatic resume — `Sweep.from_manifest(...).resume()` — lands in v0.2.** The v0.1 surface this notebook exercises is durability and inspection: a killed sweep leaves a parseable manifest and queryable per-run artefacts, but you re-issue the original `sweep()` call to re-run the missing cells.\n",
-    "\n",
-    "**Prerequisites.** A local GMAT install (R2026a is the primary development target). This notebook does not depend on the `[examples]` extra (no plots).\n",
-    "\n",
-    "**Platform note.** The `SIGINT`-via-subprocess approach used below is POSIX-only. On Windows, the same recovery flow works after a real `Ctrl-C` in an interactive `gmat-sweep run` session — but reproducing the kill from a notebook cell needs different signalling primitives."
-   ]
+   "source": "# Surviving a kill: partial manifest recovery\n\nThe durability claim is narrow but load-bearing: **the JSON Lines manifest survives a mid-sweep `Ctrl-C`**, the partial DataFrame is loadable from disk, and the CLI inspector reports the partial state. This notebook walks through that exact flow end-to-end:\n\n1. Launch `gmat-sweep run` as a subprocess against a small mission.\n2. Poll the manifest until a few runs have completed.\n3. Send the subprocess `SIGINT` (the same signal `Ctrl-C` raises).\n4. Inspect the partial manifest with `gmat-sweep show`.\n5. Reload the manifest in-process and aggregate the partial DataFrame from the Parquet files on disk.\n\n**Programmatic resume — `Sweep.from_manifest(...).resume()` — lands in v0.2.** Until then, the surface this notebook exercises is durability and inspection: a killed sweep leaves a parseable manifest and queryable per-run artefacts, but you re-issue the original `sweep()` call to re-run the missing cells.\n\n**Prerequisites.** A local GMAT install (R2026a is the primary development target). This notebook does not depend on the `[examples]` extra (no plots).\n\n**Platform note.** The `SIGINT`-via-subprocess approach used below is POSIX-only. On Windows, the same recovery flow works after a real `Ctrl-C` in an interactive `gmat-sweep run` session — but reproducing the kill from a notebook cell needs different signalling primitives."
   },
   {
    "cell_type": "markdown",
@@ -232,23 +216,7 @@
    "cell_type": "markdown",
    "id": "5f29bd0e",
    "metadata": {},
-   "source": [
-    "## v0.1 surface vs. v0.2 resume\n",
-    "\n",
-    "Everything above uses **only the v0.1 public surface**:\n",
-    "\n",
-    "- The manifest is fsync'd line-by-line so a kill leaves a parseable file.\n",
-    "- The CLI `show` subcommand reports the partial state.\n",
-    "- [`Manifest.load`][gmat_sweep.Manifest.load] tolerates a single torn final line.\n",
-    "- [`lazy_multiindex`][gmat_sweep.lazy_multiindex] aggregates whatever the manifest references; missing runs are simply absent.\n",
-    "\n",
-    "**v0.2 will add `Sweep.from_manifest(manifest_path).resume()`** — programmatic re-dispatch of just the missing `run_id`s against the same backend, with the manifest header re-validated against the current script and environment. Until then, recovering a killed sweep is a re-issue of the original [`sweep()`][gmat_sweep.sweep] call: the durable manifest is the artefact you keep; the run command is the operation you re-run.\n",
-    "\n",
-    "## Where to next\n",
-    "\n",
-    "- **Manifest schema.** [Manifest schema](../manifest-schema.md) documents every field the JSON Lines records carry, plus the canonical script-hash convention.\n",
-    "- **CLI reference.** The [`gmat-sweep run` and `gmat-sweep show`](../parameter-spec.md) flags."
-   ]
+   "source": "## Where resume will land\n\nEverything above uses **only the current public surface**:\n\n- The manifest is fsync'd line-by-line so a kill leaves a parseable file.\n- The CLI `show` subcommand reports the partial state.\n- [`Manifest.load`][gmat_sweep.Manifest.load] tolerates a single torn final line.\n- [`lazy_multiindex`][gmat_sweep.lazy_multiindex] aggregates whatever the manifest references; missing runs are simply absent.\n\n**v0.2 will add `Sweep.from_manifest(manifest_path).resume()`** — programmatic re-dispatch of just the missing `run_id`s against the same backend, with the manifest header re-validated against the current script and environment. Until then, recovering a killed sweep is a re-issue of the original [`sweep()`][gmat_sweep.sweep] call: the durable manifest is the artefact you keep; the run command is the operation you re-run.\n\n## Where to next\n\n- **Manifest schema.** [Manifest schema](../manifest-schema.md) documents every field the JSON Lines records carry, plus the canonical script-hash convention.\n- **CLI reference.** The [`gmat-sweep run` and `gmat-sweep show`](../parameter-spec.md) flags."
   }
  ],
  "metadata": {

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,9 +1,9 @@
 # Examples
 
-End-to-end Jupyter notebooks that exercise the v0.1 `gmat-sweep` surface
-against a local GMAT install. Each notebook is committed with cleared cell
-outputs and re-executed in CI on every push, so the rendered docs always
-reflect the current code.
+End-to-end Jupyter notebooks that exercise the `gmat-sweep` API against a
+local GMAT install. Each notebook is committed with cleared cell outputs
+and re-executed in CI on every push, so the rendered docs always reflect
+the current code.
 
 You can run them locally after `pip install gmat-sweep[examples]` (the extra
 pulls in matplotlib).
@@ -17,5 +17,5 @@ pulls in matplotlib).
 - [Surviving a kill](03_killed_sweep_recovery.ipynb) — launch a sweep as a
   subprocess, send `SIGINT` mid-run, and walk through inspecting the partial
   manifest with `gmat-sweep show` and reloading the partial DataFrame from
-  disk. Demonstrates the v0.1 durability claim; programmatic
+  disk. Demonstrates the durability claim; programmatic
   `Sweep.from_manifest(...).resume()` lands in v0.2.

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,0 +1,21 @@
+# Examples
+
+End-to-end Jupyter notebooks that exercise the v0.1 `gmat-sweep` surface
+against a local GMAT install. Each notebook is committed with cleared cell
+outputs and re-executed in CI on every push, so the rendered docs always
+reflect the current code.
+
+You can run them locally after `pip install gmat-sweep[examples]` (the extra
+pulls in matplotlib).
+
+- [Single-axis SMA scan](01_sma_scan.ipynb) — fifty runs across
+  `np.linspace(7000, 8000, 50)` of `Sat.SMA`, parallel-dispatched through the
+  default `LocalJoblibPool`, overlaid on a single altitude-vs-time plot.
+- [Two-axis epoch × time-of-flight grid](02_epoch_arrival_grid.ipynb) — a
+  cartesian product over `Sat.Epoch` and a script-level `Variable TOF`,
+  reshaped into a 2D matrix and contoured by per-run miss distance.
+- [Surviving a kill](03_killed_sweep_recovery.ipynb) — launch a sweep as a
+  subprocess, send `SIGINT` mid-run, and walk through inspecting the partial
+  manifest with `gmat-sweep show` and reloading the partial DataFrame from
+  disk. Demonstrates the v0.1 durability claim; programmatic
+  `Sweep.from_manifest(...).resume()` lands in v0.2.

--- a/docs/examples/leo_keplerian.script
+++ b/docs/examples/leo_keplerian.script
@@ -1,0 +1,38 @@
+%  Minimal LEO mission used by docs/examples/01_sma_scan.ipynb to demonstrate
+%  the single-axis sweep + altitude overlay walkthrough. Avoids
+%  OpenFramesInterface / OrbitView so it parses headlessly through gmatpy.
+%  1-hour propagation, Keplerian initial state, position written to a
+%  ReportFile so altitude can be derived per timestep.
+
+Create Spacecraft Sat
+Sat.DateFormat = UTCGregorian
+Sat.Epoch = '01 Jan 2026 12:00:00.000'
+Sat.CoordinateSystem = EarthMJ2000Eq
+Sat.DisplayStateType = Keplerian
+Sat.SMA = 7000
+Sat.ECC = 0.001
+Sat.INC = 28.5
+Sat.RAAN = 75
+Sat.AOP = 90
+Sat.TA = 0
+
+Create ForceModel FM
+FM.CentralBody = Earth
+FM.PointMasses = {Earth}
+FM.Drag = None
+FM.SRP = Off
+
+Create Propagator Prop
+Prop.FM = FM
+Prop.Type = PrinceDormand78
+Prop.InitialStepSize = 60
+Prop.Accuracy = 1e-9
+
+Create ReportFile RF
+RF.Filename = 'leo_keplerian_report.txt'
+RF.Precision = 16
+RF.WriteHeaders = true
+RF.Add = {Sat.UTCGregorian, Sat.X, Sat.Y, Sat.Z}
+
+BeginMissionSequence
+Propagate Prop(Sat) {Sat.ElapsedSecs = 3600}

--- a/docs/examples/leo_short.script
+++ b/docs/examples/leo_short.script
@@ -1,0 +1,39 @@
+%  Tiny LEO fixture for docs/examples/03_killed_sweep_recovery.ipynb.
+%
+%  60-second propagation, point-mass Earth, single ReportFile. Each per-run
+%  cost is sub-second so the kill-and-inspect demo finishes inside the CI
+%  smoke step's wall-clock budget while still producing several manifest
+%  entries before the SIGINT lands.
+
+Create Spacecraft Sat
+Sat.DateFormat = UTCGregorian
+Sat.Epoch = '01 Jan 2026 00:00:00.000'
+Sat.CoordinateSystem = EarthMJ2000Eq
+Sat.DisplayStateType = Keplerian
+Sat.SMA = 7000
+Sat.ECC = 0.001
+Sat.INC = 28.5
+Sat.RAAN = 0
+Sat.AOP = 0
+Sat.TA = 0
+
+Create ForceModel FM
+FM.CentralBody = Earth
+FM.PointMasses = {Earth}
+FM.Drag = None
+FM.SRP = Off
+
+Create Propagator Prop
+Prop.FM = FM
+Prop.Type = PrinceDormand78
+Prop.InitialStepSize = 30
+Prop.Accuracy = 1e-9
+
+Create ReportFile RF
+RF.Filename = 'leo_short_report.txt'
+RF.Precision = 16
+RF.WriteHeaders = true
+RF.Add = {Sat.UTCGregorian, Sat.X, Sat.Y, Sat.Z}
+
+BeginMissionSequence
+Propagate Prop(Sat) {Sat.ElapsedSecs = 60}

--- a/docs/examples/transfer_porkchop.script
+++ b/docs/examples/transfer_porkchop.script
@@ -1,0 +1,47 @@
+%  Two-axis sweep fixture for docs/examples/02_epoch_arrival_grid.ipynb.
+%
+%  The mission is contrived: launch at Sat.Epoch from an elliptical
+%  parking orbit, propagate for TOF seconds (a Variable so it can be
+%  overridden from gmat-sweep), and write the final inertial position
+%  to a ReportFile. The notebook overrides Sat.Epoch and TOF.Value as
+%  the two grid axes, then derives an "arrival miss distance" against
+%  a fixed inertial target and contours the result.
+%
+%  Point-mass Earth keeps every per-run sub-second so the ~36-cell grid
+%  finishes inside the CI smoke step's wall-clock budget.
+
+Create Spacecraft Sat
+Sat.DateFormat = UTCGregorian
+Sat.Epoch = '01 Jan 2026 00:00:00.000'
+Sat.CoordinateSystem = EarthMJ2000Eq
+Sat.DisplayStateType = Keplerian
+Sat.SMA = 12000
+Sat.ECC = 0.4
+Sat.INC = 28.5
+Sat.RAAN = 0
+Sat.AOP = 0
+Sat.TA = 0
+
+Create ForceModel FM
+FM.CentralBody = Earth
+FM.PointMasses = {Earth}
+FM.Drag = None
+FM.SRP = Off
+
+Create Propagator Prop
+Prop.FM = FM
+Prop.Type = PrinceDormand78
+Prop.InitialStepSize = 120
+Prop.Accuracy = 1e-9
+
+Create Variable TOF
+TOF = 7200
+
+Create ReportFile RF
+RF.Filename = 'transfer_porkchop_report.txt'
+RF.Precision = 16
+RF.WriteHeaders = true
+RF.Add = {Sat.UTCGregorian, Sat.X, Sat.Y, Sat.Z}
+
+BeginMissionSequence
+Propagate Prop(Sat) {Sat.ElapsedSecs = TOF}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,11 +38,19 @@ nav:
   - Parameter spec: parameter-spec.md
   - Manifest schema: manifest-schema.md
   - Supported versions: supported-versions.md
+  - Examples:
+      - examples/index.md
+      - Single-axis SMA scan: examples/01_sma_scan.ipynb
+      - Epoch × TOF grid: examples/02_epoch_arrival_grid.ipynb
+      - Surviving a kill: examples/03_killed_sweep_recovery.ipynb
   - FAQ: faq.md
   - API reference: api.md
 
 plugins:
   - search
+  - mkdocs-jupyter:
+      execute: false
+      include_source: true
   - mkdocstrings:
       default_handler: python
       handlers:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
 dask = ["distributed>=2024.1"]
 ray = ["ray[default]>=2.10"]
 plot = ["matplotlib>=3.8"]
+examples = ["matplotlib>=3.8"]
 
 [project.scripts]
 gmat-sweep = "gmat_sweep.cli:main"

--- a/uv.lock
+++ b/uv.lock
@@ -1258,6 +1258,9 @@ dependencies = [
 dask = [
     { name = "distributed" },
 ]
+examples = [
+    { name = "matplotlib" },
+]
 plot = [
     { name = "matplotlib" },
 ]
@@ -1286,6 +1289,7 @@ requires-dist = [
     { name = "distributed", marker = "extra == 'dask'", specifier = ">=2024.1" },
     { name = "gmat-run", specifier = ">=0.3" },
     { name = "joblib", specifier = ">=1.4" },
+    { name = "matplotlib", marker = "extra == 'examples'", specifier = ">=3.8" },
     { name = "matplotlib", marker = "extra == 'plot'", specifier = ">=3.8" },
     { name = "numpy", specifier = ">=1.24" },
     { name = "pandas", specifier = ">=2.0" },
@@ -1294,7 +1298,7 @@ requires-dist = [
     { name = "scipy", specifier = ">=1.11" },
     { name = "tqdm", specifier = ">=4.66" },
 ]
-provides-extras = ["dask", "ray", "plot"]
+provides-extras = ["dask", "ray", "plot", "examples"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

- Three end-to-end Jupyter notebooks under `docs/examples/` exercising the v0.1 `sweep()` surface: a 50-run single-axis SMA scan, a two-axis launch-epoch × time-of-flight grid with a contoured per-run scalar (uses a script-level `Variable TOF` for the second axis), and a kill-and-inspect walkthrough that subprocess-launches `gmat-sweep`, sends `SIGINT`, and reloads the partial manifest from disk.
- Each notebook ships its own mission script next to it. Notebooks are committed with cleared outputs and re-executed in CI on the same Ubuntu / Python 3.12 / R2026a cell that enforces the coverage gates.
- Wires the Examples section into the docs nav via `mkdocs-jupyter`, and adds a `[examples]` extra (matplotlib) mirroring the sibling repos.

## Test plan

- [x] All three notebooks execute end-to-end via `uv run jupyter execute` against `~/gmat-R2026a/`.
- [x] `uv run mkdocs build --strict` succeeds; rendered Examples pages link from the new nav section.
- [x] `uv run ruff check`, `uv run ruff format --check`, `uv run mypy` all clean.
- [x] `uv run pytest` (unit tests) passes — 182 / 182.
- [x] CI green on the new `Smoke-execute example notebooks` step (GMAT install pinned to R2026a).

Closes #13