### PR TITLE
Add ipywidgets to docs group, strip TqdmWarning from notebook outputs

### DIFF
--- a/docs/examples/01_sma_scan.ipynb
+++ b/docs/examples/01_sma_scan.ipynb
@@ -30,10 +30,10 @@
    "id": "0a2c4f51",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:27:15.929398Z",
-     "iopub.status.busy": "2026-05-04T17:27:15.929245Z",
-     "iopub.status.idle": "2026-05-04T17:27:20.391647Z",
-     "shell.execute_reply": "2026-05-04T17:27:20.390613Z"
+     "iopub.execute_input": "2026-05-04T17:59:55.586202Z",
+     "iopub.status.busy": "2026-05-04T17:59:55.586033Z",
+     "iopub.status.idle": "2026-05-04T18:00:00.717456Z",
+     "shell.execute_reply": "2026-05-04T18:00:00.716401Z"
     }
    },
    "outputs": [
@@ -44,14 +44,6 @@
       "GMAT version: R2026a\n",
       "Script:       leo_keplerian.script\n",
       "Exists:       True\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/mnt/d/MyProjects/AstroTools/src/gmat-sweep/.venv/lib/python3.12/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
      ]
     }
    ],
@@ -88,10 +80,10 @@
    "id": "5dc12fe3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:27:20.393333Z",
-     "iopub.status.busy": "2026-05-04T17:27:20.393091Z",
-     "iopub.status.idle": "2026-05-04T17:27:20.400142Z",
-     "shell.execute_reply": "2026-05-04T17:27:20.399144Z"
+     "iopub.execute_input": "2026-05-04T18:00:00.719265Z",
+     "iopub.status.busy": "2026-05-04T18:00:00.719012Z",
+     "iopub.status.idle": "2026-05-04T18:00:00.725575Z",
+     "shell.execute_reply": "2026-05-04T18:00:00.724581Z"
     }
    },
    "outputs": [
@@ -141,10 +133,10 @@
    "id": "1eaf5b6c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:27:20.402087Z",
-     "iopub.status.busy": "2026-05-04T17:27:20.401878Z",
-     "iopub.status.idle": "2026-05-04T17:27:28.218052Z",
-     "shell.execute_reply": "2026-05-04T17:27:28.216973Z"
+     "iopub.execute_input": "2026-05-04T18:00:00.726967Z",
+     "iopub.status.busy": "2026-05-04T18:00:00.726809Z",
+     "iopub.status.idle": "2026-05-04T18:00:09.058094Z",
+     "shell.execute_reply": "2026-05-04T18:00:09.057068Z"
     }
    },
    "outputs": [
@@ -274,10 +266,10 @@
    "id": "73a948d1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:27:28.219648Z",
-     "iopub.status.busy": "2026-05-04T17:27:28.219477Z",
-     "iopub.status.idle": "2026-05-04T17:27:28.226122Z",
-     "shell.execute_reply": "2026-05-04T17:27:28.225113Z"
+     "iopub.execute_input": "2026-05-04T18:00:09.059511Z",
+     "iopub.status.busy": "2026-05-04T18:00:09.059349Z",
+     "iopub.status.idle": "2026-05-04T18:00:09.065833Z",
+     "shell.execute_reply": "2026-05-04T18:00:09.064885Z"
     }
    },
    "outputs": [
@@ -314,10 +306,10 @@
    "id": "8b30dac9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:27:28.227521Z",
-     "iopub.status.busy": "2026-05-04T17:27:28.227319Z",
-     "iopub.status.idle": "2026-05-04T17:27:28.232998Z",
-     "shell.execute_reply": "2026-05-04T17:27:28.231943Z"
+     "iopub.execute_input": "2026-05-04T18:00:09.067258Z",
+     "iopub.status.busy": "2026-05-04T18:00:09.067086Z",
+     "iopub.status.idle": "2026-05-04T18:00:09.073091Z",
+     "shell.execute_reply": "2026-05-04T18:00:09.072074Z"
     }
    },
    "outputs": [],
@@ -342,10 +334,10 @@
    "id": "f2c7a814",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:27:28.234380Z",
-     "iopub.status.busy": "2026-05-04T17:27:28.234228Z",
-     "iopub.status.idle": "2026-05-04T17:27:28.659357Z",
-     "shell.execute_reply": "2026-05-04T17:27:28.658416Z"
+     "iopub.execute_input": "2026-05-04T18:00:09.074684Z",
+     "iopub.status.busy": "2026-05-04T18:00:09.074515Z",
+     "iopub.status.idle": "2026-05-04T18:00:09.488234Z",
+     "shell.execute_reply": "2026-05-04T18:00:09.487126Z"
     }
    },
    "outputs": [

--- a/docs/examples/02_epoch_arrival_grid.ipynb
+++ b/docs/examples/02_epoch_arrival_grid.ipynb
@@ -32,10 +32,10 @@
    "id": "1a3e8bc2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:27:36.507348Z",
-     "iopub.status.busy": "2026-05-04T17:27:36.507197Z",
-     "iopub.status.idle": "2026-05-04T17:27:40.818123Z",
-     "shell.execute_reply": "2026-05-04T17:27:40.817002Z"
+     "iopub.execute_input": "2026-05-04T18:00:17.196221Z",
+     "iopub.status.busy": "2026-05-04T18:00:17.196070Z",
+     "iopub.status.idle": "2026-05-04T18:00:21.822291Z",
+     "shell.execute_reply": "2026-05-04T18:00:21.821040Z"
     }
    },
    "outputs": [
@@ -46,14 +46,6 @@
       "GMAT version: R2026a\n",
       "Script:       transfer_porkchop.script\n",
       "Exists:       True\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/mnt/d/MyProjects/AstroTools/src/gmat-sweep/.venv/lib/python3.12/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
      ]
     }
    ],
@@ -94,10 +86,10 @@
    "id": "27cd1c40",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:27:40.819854Z",
-     "iopub.status.busy": "2026-05-04T17:27:40.819608Z",
-     "iopub.status.idle": "2026-05-04T17:27:40.825529Z",
-     "shell.execute_reply": "2026-05-04T17:27:40.824480Z"
+     "iopub.execute_input": "2026-05-04T18:00:21.824105Z",
+     "iopub.status.busy": "2026-05-04T18:00:21.823833Z",
+     "iopub.status.idle": "2026-05-04T18:00:21.829971Z",
+     "shell.execute_reply": "2026-05-04T18:00:21.828966Z"
     }
    },
    "outputs": [
@@ -150,10 +142,10 @@
    "id": "9eb7c0dd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:27:40.826909Z",
-     "iopub.status.busy": "2026-05-04T17:27:40.826755Z",
-     "iopub.status.idle": "2026-05-04T17:27:49.244672Z",
-     "shell.execute_reply": "2026-05-04T17:27:49.243581Z"
+     "iopub.execute_input": "2026-05-04T18:00:21.831453Z",
+     "iopub.status.busy": "2026-05-04T18:00:21.831291Z",
+     "iopub.status.idle": "2026-05-04T18:00:29.696411Z",
+     "shell.execute_reply": "2026-05-04T18:00:29.695343Z"
     }
    },
    "outputs": [
@@ -202,10 +194,10 @@
    "id": "13e4adcb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:27:49.246252Z",
-     "iopub.status.busy": "2026-05-04T17:27:49.246062Z",
-     "iopub.status.idle": "2026-05-04T17:27:49.256496Z",
-     "shell.execute_reply": "2026-05-04T17:27:49.255445Z"
+     "iopub.execute_input": "2026-05-04T18:00:29.697842Z",
+     "iopub.status.busy": "2026-05-04T18:00:29.697678Z",
+     "iopub.status.idle": "2026-05-04T18:00:29.707916Z",
+     "shell.execute_reply": "2026-05-04T18:00:29.706930Z"
     }
    },
    "outputs": [
@@ -253,10 +245,10 @@
    "id": "8ca4d723",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:27:49.258010Z",
-     "iopub.status.busy": "2026-05-04T17:27:49.257835Z",
-     "iopub.status.idle": "2026-05-04T17:27:49.295860Z",
-     "shell.execute_reply": "2026-05-04T17:27:49.294834Z"
+     "iopub.execute_input": "2026-05-04T18:00:29.709308Z",
+     "iopub.status.busy": "2026-05-04T18:00:29.709136Z",
+     "iopub.status.idle": "2026-05-04T18:00:29.745694Z",
+     "shell.execute_reply": "2026-05-04T18:00:29.744645Z"
     }
    },
    "outputs": [
@@ -413,10 +405,10 @@
    "id": "7b21ce14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:27:49.297311Z",
-     "iopub.status.busy": "2026-05-04T17:27:49.297138Z",
-     "iopub.status.idle": "2026-05-04T17:27:49.740242Z",
-     "shell.execute_reply": "2026-05-04T17:27:49.739206Z"
+     "iopub.execute_input": "2026-05-04T18:00:29.747165Z",
+     "iopub.status.busy": "2026-05-04T18:00:29.747001Z",
+     "iopub.status.idle": "2026-05-04T18:00:30.192131Z",
+     "shell.execute_reply": "2026-05-04T18:00:30.191017Z"
     }
    },
    "outputs": [

--- a/docs/examples/03_killed_sweep_recovery.ipynb
+++ b/docs/examples/03_killed_sweep_recovery.ipynb
@@ -38,10 +38,10 @@
    "id": "6c2e4af0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:27:57.526726Z",
-     "iopub.status.busy": "2026-05-04T17:27:57.526576Z",
-     "iopub.status.idle": "2026-05-04T17:28:00.889457Z",
-     "shell.execute_reply": "2026-05-04T17:28:00.888343Z"
+     "iopub.execute_input": "2026-05-04T18:00:37.958516Z",
+     "iopub.status.busy": "2026-05-04T18:00:37.958353Z",
+     "iopub.status.idle": "2026-05-04T18:00:41.514778Z",
+     "shell.execute_reply": "2026-05-04T18:00:41.513728Z"
     }
    },
    "outputs": [
@@ -52,14 +52,6 @@
       "GMAT version: R2026a\n",
       "Script:       leo_short.script\n",
       "Exists:       True\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/mnt/d/MyProjects/AstroTools/src/gmat-sweep/.venv/lib/python3.12/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
      ]
     }
    ],
@@ -98,10 +90,10 @@
    "id": "e8b2dfc4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:28:00.891080Z",
-     "iopub.status.busy": "2026-05-04T17:28:00.890854Z",
-     "iopub.status.idle": "2026-05-04T17:28:00.927666Z",
-     "shell.execute_reply": "2026-05-04T17:28:00.926606Z"
+     "iopub.execute_input": "2026-05-04T18:00:41.516359Z",
+     "iopub.status.busy": "2026-05-04T18:00:41.516136Z",
+     "iopub.status.idle": "2026-05-04T18:00:41.547968Z",
+     "shell.execute_reply": "2026-05-04T18:00:41.546779Z"
     }
    },
    "outputs": [
@@ -109,7 +101,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Spawned gmat-sweep pid=14314, output dir = /tmp/killed-sweep-rb5bfhsy\n"
+      "Spawned gmat-sweep pid=15479, output dir = /tmp/killed-sweep-ruyovrkm\n"
      ]
     }
    ],
@@ -154,10 +146,10 @@
    "id": "f5e7c812",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:28:00.929327Z",
-     "iopub.status.busy": "2026-05-04T17:28:00.929149Z",
-     "iopub.status.idle": "2026-05-04T17:28:06.007299Z",
-     "shell.execute_reply": "2026-05-04T17:28:06.006270Z"
+     "iopub.execute_input": "2026-05-04T18:00:41.549503Z",
+     "iopub.status.busy": "2026-05-04T18:00:41.549317Z",
+     "iopub.status.idle": "2026-05-04T18:00:46.678693Z",
+     "shell.execute_reply": "2026-05-04T18:00:46.677588Z"
     }
    },
    "outputs": [
@@ -225,10 +217,10 @@
    "id": "ad7c5b8f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:28:06.008824Z",
-     "iopub.status.busy": "2026-05-04T17:28:06.008659Z",
-     "iopub.status.idle": "2026-05-04T17:28:09.240101Z",
-     "shell.execute_reply": "2026-05-04T17:28:09.239032Z"
+     "iopub.execute_input": "2026-05-04T18:00:46.680113Z",
+     "iopub.status.busy": "2026-05-04T18:00:46.679947Z",
+     "iopub.status.idle": "2026-05-04T18:00:49.918659Z",
+     "shell.execute_reply": "2026-05-04T18:00:49.917551Z"
     }
    },
    "outputs": [
@@ -236,7 +228,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "5 runs (5 ok) in 1.47 s — output: /tmp/killed-sweep-rb5bfhsy\n"
+      "5 runs (5 ok) in 1.45 s — output: /tmp/killed-sweep-ruyovrkm\n"
      ]
     }
    ],
@@ -266,10 +258,10 @@
    "id": "2e84acde",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:28:09.241620Z",
-     "iopub.status.busy": "2026-05-04T17:28:09.241454Z",
-     "iopub.status.idle": "2026-05-04T17:28:09.246297Z",
-     "shell.execute_reply": "2026-05-04T17:28:09.245184Z"
+     "iopub.execute_input": "2026-05-04T18:00:49.920205Z",
+     "iopub.status.busy": "2026-05-04T18:00:49.920029Z",
+     "iopub.status.idle": "2026-05-04T18:00:49.924725Z",
+     "shell.execute_reply": "2026-05-04T18:00:49.923687Z"
     }
    },
    "outputs": [
@@ -314,10 +306,10 @@
    "id": "c4b72a0e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-04T17:28:09.247728Z",
-     "iopub.status.busy": "2026-05-04T17:28:09.247569Z",
-     "iopub.status.idle": "2026-05-04T17:28:09.312934Z",
-     "shell.execute_reply": "2026-05-04T17:28:09.311797Z"
+     "iopub.execute_input": "2026-05-04T18:00:49.926042Z",
+     "iopub.status.busy": "2026-05-04T18:00:49.925884Z",
+     "iopub.status.idle": "2026-05-04T18:00:49.989604Z",
+     "shell.execute_reply": "2026-05-04T18:00:49.988701Z"
     }
    },
    "outputs": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,12 @@ docs = [
   "mkdocs-material>=9.5",
   "mkdocstrings[python]>=0.26",
   "mkdocs-jupyter>=0.25",
+  # Satisfies tqdm.auto's IProgress dependency at notebook-execution time.
+  # Without it, every `jupyter execute --inplace` of an example notebook
+  # captures a TqdmWarning to stderr (which bakes the executor's local venv
+  # path into the committed cell output). Required at refresh time, not at
+  # docs-build time, so it lives here rather than as a runtime dependency.
+  "ipywidgets>=8.1",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/uv.lock
+++ b/uv.lock
@@ -1279,6 +1279,7 @@ dev = [
     { name = "ruff" },
 ]
 docs = [
+    { name = "ipywidgets" },
     { name = "mkdocs-jupyter" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
@@ -1310,6 +1311,7 @@ dev = [
     { name = "ruff", specifier = ">=0.6" },
 ]
 docs = [
+    { name = "ipywidgets", specifier = ">=8.1" },
     { name = "mkdocs-jupyter", specifier = ">=0.25" },
     { name = "mkdocs-material", specifier = ">=9.5" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.26" },
@@ -1559,6 +1561,23 @@ wheels = [
 ]
 
 [[package]]
+name = "ipywidgets"
+version = "8.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "comm" },
+    { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "ipython", version = "9.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "jupyterlab-widgets" },
+    { name = "traitlets" },
+    { name = "widgetsnbextension" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/ae/c5ce1edc1afe042eadb445e95b0671b03cee61895264357956e61c0d2ac0/ipywidgets-8.1.8.tar.gz", hash = "sha256:61f969306b95f85fba6b6986b7fe45d73124d1d9e3023a8068710d47a22ea668", size = 116739, upload-time = "2025-11-01T21:18:12.393Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/6d/0d9848617b9f753b87f214f1c682592f7ca42de085f564352f10f0843026/ipywidgets-8.1.8-py3-none-any.whl", hash = "sha256:ecaca67aed704a338f88f67b1181b58f821ab5dc89c1f0f5ef99db43c1c2921e", size = 139808, upload-time = "2025-11-01T21:18:10.956Z" },
+]
+
+[[package]]
 name = "jedi"
 version = "0.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1654,6 +1673,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/90/51/9187be60d989df97f5f0aba133fa54e7300f17616e065d1ada7d7646b6d6/jupyterlab_pygments-0.3.0.tar.gz", hash = "sha256:721aca4d9029252b11cfa9d185e5b5af4d54772bb8072f9b7036f4170054d35d", size = 512900, upload-time = "2023-11-23T09:26:37.44Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/dd/ead9d8ea85bf202d90cc513b533f9c363121c7792674f78e0d8a854b63b4/jupyterlab_pygments-0.3.0-py3-none-any.whl", hash = "sha256:841a89020971da1d8693f1a99997aefc5dc424bb1b251fd6322462a1b8842780", size = 15884, upload-time = "2023-11-23T09:26:34.325Z" },
+]
+
+[[package]]
+name = "jupyterlab-widgets"
+version = "3.0.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/2d/ef58fed122b268c69c0aa099da20bc67657cdfb2e222688d5731bd5b971d/jupyterlab_widgets-3.0.16.tar.gz", hash = "sha256:423da05071d55cf27a9e602216d35a3a65a3e41cdf9c5d3b643b814ce38c19e0", size = 897423, upload-time = "2025-11-01T21:11:29.724Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/b5/36c712098e6191d1b4e349304ef73a8d06aed77e56ceaac8c0a306c7bda1/jupyterlab_widgets-3.0.16-py3-none-any.whl", hash = "sha256:45fa36d9c6422cf2559198e4db481aa243c7a32d9926b500781c830c80f7ecf8", size = 914926, upload-time = "2025-11-01T21:11:28.008Z" },
 ]
 
 [[package]]
@@ -4578,6 +4606,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
+]
+
+[[package]]
+name = "widgetsnbextension"
+version = "4.0.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/f4/c67440c7fb409a71b7404b7aefcd7569a9c0d6bd071299bf4198ae7a5d95/widgetsnbextension-4.0.15.tar.gz", hash = "sha256:de8610639996f1567952d763a5a41af8af37f2575a41f9852a38f947eb82a3b9", size = 1097402, upload-time = "2025-11-01T21:15:55.178Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/0e/fa3b193432cfc60c93b42f3be03365f5f909d2b3ea410295cf36df739e31/widgetsnbextension-4.0.15-py3-none-any.whl", hash = "sha256:8156704e4346a571d9ce73b84bee86a29906c9abfd7223b7228a28899ccf3366", size = 2196503, upload-time = "2025-11-01T21:15:53.565Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Refreshing the example notebooks captures a `TqdmWarning` to stderr at `gmat_sweep` import time, and the warning text bakes the executor's local venv path (e.g. `/mnt/d/MyProjects/AstroTools/src/gmat-sweep/.venv/...`) into the committed cell output — visible on the published docs site after every refresh.

Root cause: `tqdm.auto` checks for `ipywidgets` to decide whether to use the widget-style progress bar; when missing, it emits a one-line `IProgress not found` warning at import. The CI/refresh environments don't have `ipywidgets` installed, so the warning fires every time.

Fix: add `ipywidgets>=8.1` to the `docs` dependency group. Satisfying the dependency at notebook-refresh time silences the warning at source — no library code changes, no per-notebook suppression boilerplate, no risk of authors forgetting to mute it on the next refresh. Re-executed all three notebooks `--inplace` against `~/gmat-R2026a/`; the stderr block is gone from each setup cell, and the only outputs that remain are the intended stdout prints / plots / DataFrame reprs.

## Test plan

- [x] All three notebook setup cells now have zero stderr blocks (verified via JSON inspection).
- [x] No remaining `/mnt/...` or `site-packages` substrings in any captured cell text.
- [x] `uv run mkdocs build --strict`, `uv run ruff check`, `uv run ruff format --check`, `uv run mypy`, `uv run pytest -q` all clean (183 / 183).
- [ ] CI green on the `Smoke-execute example notebooks` step.

Follow-up to #28 — no separate issue.