### PR TITLE
Cut v0.1.0: bump version, drop pre-alpha, rewrite README, add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,74 @@ All notable changes to gmat-sweep are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] — 2026-05-04
+
+Initial public release. The MVP slice of the charter: full-factorial parameter
+sweeps over a `gmat-run` mission, parallelised across subprocess workers,
+aggregated into a `(run_id, time)`-MultiIndexed `pandas.DataFrame`, and backed
+by a durable JSON Lines manifest.
+
+### Added
+
+- `sweep(mission, grid=..., workers=...)` — public entry point for
+  full-factorial parameter grids. Materialises the cartesian product into one
+  [`RunSpec`][gmat_sweep.RunSpec] per cell, dispatches through the default
+  [`LocalJoblibPool`][gmat_sweep.Pool] backend, and returns the aggregated
+  multi-indexed DataFrame (#9).
+- `gmat_sweep.full_factorial` and `gmat_sweep.expand_grid_to_run_specs` —
+  cartesian-product expansion with deterministic, lexicographic key ordering
+  and zero-based `run_id` assignment, the contract every manifest and future
+  resume flow depends on (#4).
+- [`Pool`][gmat_sweep.Pool] ABC with the `subprocess_isolated` invariant
+  enforced at class-definition time, plus the default
+  [`LocalJoblibPool`][gmat_sweep.Pool] implementation backed by joblib's loky
+  executor — every run spawns a fresh Python interpreter that imports
+  `gmatpy` once, sidestepping the well-known reinit limitation (#7).
+- Single-run worker callable that imports `gmat_run`, applies overrides via the
+  dotted-path setter, runs the mission, serialises every `ReportFile` to
+  Parquet, and converts every exception into a `RunOutcome.failed(...)` so a
+  single bad run never aborts the sweep (#6).
+- Lazy `(run_id, time)`-MultiIndex aggregation from per-run Parquet via
+  pyarrow's dataset API. Failed and skipped runs surface as one row with the
+  `__status` column populated (#8).
+- JSON Lines manifest with one header line and one fsync'd
+  [`ManifestEntry`][gmat_sweep.ManifestEntry] per run. `Manifest.load`
+  tolerates a single torn last line (a `Ctrl-C`'d sweep leaves a parseable
+  file). Header captures canonical script SHA-256, `gmat_sweep` /
+  `gmat_run` / GMAT install / Python / OS versions, the materialised parameter
+  spec, and the run count. Includes `find_failed` / `find_missing` lookup
+  helpers for the v0.2 resume flow (#5).
+- Typed exception hierarchy under `gmat_sweep.errors` rooted at
+  [`GmatSweepError`][gmat_sweep.GmatSweepError] —
+  [`SweepConfigError`][gmat_sweep.SweepConfigError],
+  [`RunFailed`][gmat_sweep.RunFailed],
+  [`BackendError`][gmat_sweep.BackendError], and
+  [`ManifestCorruptError`][gmat_sweep.ManifestCorruptError] — alongside
+  JSON-serialisable [`RunSpec`][gmat_sweep.RunSpec] /
+  [`SweepSpec`][gmat_sweep.SweepSpec] / [`RunOutcome`][gmat_sweep.RunOutcome]
+  dataclasses (#3).
+- `gmat-sweep` console script with `run` and `show` subcommands. `run`
+  accepts repeated `--grid name=lo:hi:count` linspace and `--grid
+  name=v1,v2,v3` explicit-list axes; `show` prints a one-line summary of an
+  existing manifest (#10).
+- Validation test suite — per-run round-trip, parameter-spec round-trip
+  (float / int / datetime / vector / str enum), 16-run reference-sweep
+  regression, failure-mode coverage (invalid override, divergent solver, bad
+  script, OOM), and a manifest-replay contract test that pins the v0.1
+  manifest format ahead of v0.2's resume flow (#11).
+- MkDocs-Material documentation site auto-deployed to GitHub Pages on tag
+  pushes, with mkdocstrings-driven API reference, parameter-spec and
+  manifest-schema reference pages, supported-versions table, and FAQ
+  (#12, #28).
+- Three runnable example notebooks rendered into the docs site —
+  single-axis SMA scan, two-axis epoch × time-of-flight grid, and a
+  surviving-a-kill walkthrough demonstrating manifest durability (#13, #29).
+- CI on Ubuntu + Windows × Python 3.10 / 3.11 / 3.12 × R2025a / R2026a (12
+  cells) via `astro-tools/setup-gmat`, with both unit and integration suites
+  enabled. Coverage gates: ≥ 80 % overall and ≥ 95 % each on `grids.py`,
+  `distributions.py`, `manifest.py`, and `aggregate.py` (#2).
+- Release workflow: `uv build` → PyPI trusted publishing →
+  `gh release create --generate-notes` on `v*` tags (#2).
+
+[0.1.0]: https://github.com/astro-tools/gmat-sweep/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -1,11 +1,161 @@
 # gmat-sweep
 
+[![CI](https://github.com/astro-tools/gmat-sweep/actions/workflows/ci.yml/badge.svg)](https://github.com/astro-tools/gmat-sweep/actions/workflows/ci.yml)
+[![Docs](https://github.com/astro-tools/gmat-sweep/actions/workflows/docs.yml/badge.svg)](https://astro-tools.github.io/gmat-sweep/)
+[![PyPI](https://img.shields.io/pypi/v/gmat-sweep.svg)](https://pypi.org/project/gmat-sweep/)
+[![Python versions](https://img.shields.io/pypi/pyversions/gmat-sweep.svg)](https://pypi.org/project/gmat-sweep/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
 Run parameter sweeps and Monte Carlo dispersions over GMAT missions in parallel from Python.
 
-> Pre-alpha. Public surface is not yet usable. The v0.1 milestone tracks the work
-> needed to ship the first PyPI release; see the
-> [issue tracker](https://github.com/astro-tools/gmat-sweep/issues) for progress.
+## What this is
 
-## License
+A parallel orchestrator on top of [`gmat-run`](https://github.com/astro-tools/gmat-run)'s
+single-run primitive. Point `gmat-sweep` at a working `.script`, declare a parameter grid,
+and it fans the cartesian product across subprocess workers, aggregates each run's
+`ReportFile` into a single `(run_id, time)`-MultiIndexed pandas DataFrame, and writes a
+JSON Lines manifest alongside the results so any sweep is reproducible bit-for-bit.
 
-MIT — see [LICENSE](LICENSE).
+## What this is not
+
+- **Not** a single-run runner — that's [`gmat-run`](https://github.com/astro-tools/gmat-run);
+  every `gmat-sweep` worker calls into it.
+- **Not** a way to build GMAT missions from scratch in Python — see
+  [`gmatpyplus`](https://github.com/weasdown/gmatpyplus).
+- **Not** a `.script` text generator — see [`pygmat`](https://pypi.org/project/pygmat/).
+- **Not** an optimiser. Gradient-, Bayesian-, and population-based optimisation
+  (CasADi, pagmo2, scikit-optimize) is a different problem; `gmat-sweep` may serve as the
+  parallel evaluator inside one, but it ships no optimiser of its own.
+- Monte Carlo dispersion (`monte_carlo`), Latin hypercube sampling (`latin_hypercube`),
+  and programmatic resume of partial sweeps land in **v0.2** — see the roadmap below. v0.1
+  ships the full-factorial grid path and the durability contract those features build on.
+
+## Requirements
+
+- Python 3.10, 3.11, or 3.12.
+- [`gmat-run`](https://github.com/astro-tools/gmat-run) ≥ 0.3 — installed as a transitive
+  dependency from PyPI. `gmat-sweep` never imports `gmatpy` directly; the import happens
+  inside each worker subprocess on first call.
+- A local GMAT install. `gmat-sweep` does not ship GMAT binaries; it relies on `gmat-run`'s
+  install discovery, which honours `$GMAT_ROOT` or finds a build under a conventional path.
+  Download GMAT from the
+  [SourceForge release page](https://sourceforge.net/projects/gmat/files/GMAT/) — see
+  [`gmat-run`'s install guide](https://astro-tools.github.io/gmat-run/install-gmat/) for the
+  unpack-and-discover steps.
+
+### Supported GMAT versions
+
+| GMAT release | Status | CI |
+|---|---|---|
+| R2026a | Primary development target | Exercised on every PR (Ubuntu + Windows, Python 3.10/3.11/3.12) |
+| R2025a | Supported | Exercised on every PR (Ubuntu + Windows, Python 3.10/3.11/3.12) |
+
+R2023a and R2024a were never released by the upstream GMAT project; R2025a and R2026a are
+the only releases supported in v0.1. macOS is exercised by `gmat-run` and lands in
+`gmat-sweep`'s CI matrix in v0.2.
+
+## Installation
+
+```bash
+pip install gmat-sweep
+```
+
+The `[examples]` extra pulls in matplotlib for the example notebooks:
+
+```bash
+pip install gmat-sweep[examples]
+```
+
+## Quick start
+
+```python
+from gmat_sweep import sweep
+
+df = sweep(
+    "mission.script",
+    grid={"Sat.SMA": [7000, 7100, 7200]},
+    workers=8,
+)
+print(df)
+```
+
+That call runs `mission.script` three times — once per `Sat.SMA` value — each in a fresh
+subprocess, and returns a `(run_id, time)`-MultiIndexed `pandas.DataFrame` containing
+the rows from every run's `ReportFile` plus a `__status` column flagging
+`ok` / `failed` / `skipped`. A single failed run lands as a `failed` row with the captured
+GMAT stderr in the manifest — never as a silent zero-row DataFrame and never as an
+unhandled exception that aborts the whole sweep.
+
+By default the per-run Parquet files and the manifest land in a temporary directory
+whose lifetime is tied to the returned DataFrame. Pass `out=Path(...)` to keep them.
+
+A `gmat-sweep` console script is also installed for shell-script and CI use:
+
+```bash
+gmat-sweep run --grid Sat.SMA=7000:7200:3 --workers 8 --out ./sweep mission.script
+gmat-sweep show ./sweep/manifest.jsonl
+```
+
+See the [CLI reference in the docs](https://astro-tools.github.io/gmat-sweep/parameter-spec/#cli-mini-grammar)
+for the full grid grammar.
+
+## Outputs
+
+Every sweep emits two artefacts:
+
+- The returned **DataFrame** — `(run_id, time)`-MultiIndexed, one column per `ReportFile`
+  channel plus the `__status` column. Built lazily from per-run Parquet files via
+  pyarrow's dataset API, so a 10,000-run sweep does not have to fit in memory at once.
+- A **JSON Lines manifest** (`manifest.jsonl`) — append-only, fsync'd after every entry.
+  Records the canonical script SHA-256, software-version fingerprint, full parameter
+  spec, and per-run status, timing, output paths, and captured stderr. A `Ctrl-C`
+  mid-sweep leaves the manifest in a parseable state. See the
+  [manifest schema](https://astro-tools.github.io/gmat-sweep/manifest-schema/) for the
+  full contract.
+
+## Documentation
+
+Full docs at **<https://astro-tools.github.io/gmat-sweep/>**, including a
+[getting-started guide](https://astro-tools.github.io/gmat-sweep/getting-started/),
+the [parameter spec reference](https://astro-tools.github.io/gmat-sweep/parameter-spec/),
+the [manifest schema](https://astro-tools.github.io/gmat-sweep/manifest-schema/),
+the [supported-version matrix](https://astro-tools.github.io/gmat-sweep/supported-versions/),
+the [FAQ](https://astro-tools.github.io/gmat-sweep/faq/),
+and the [API reference](https://astro-tools.github.io/gmat-sweep/api/).
+
+Runnable example notebooks:
+
+- [Single-axis SMA scan](https://astro-tools.github.io/gmat-sweep/examples/01_sma_scan/) —
+  fifty runs across `np.linspace(7000, 8000, 50)` of `Sat.SMA`, parallel-dispatched and
+  overlaid on a single altitude-vs-time plot.
+- [Two-axis epoch × time-of-flight grid](https://astro-tools.github.io/gmat-sweep/examples/02_epoch_arrival_grid/) —
+  cartesian product over `Sat.Epoch` and a script-level `Variable TOF`, contoured by
+  per-run miss distance.
+- [Surviving a kill](https://astro-tools.github.io/gmat-sweep/examples/03_killed_sweep_recovery/) —
+  launch a sweep, send `SIGINT` mid-run, and walk through inspecting the partial manifest
+  with `gmat-sweep show` before reloading the partial DataFrame from disk.
+
+## Roadmap
+
+| Release | Scope |
+|---|---|
+| **v0.1** *(current)* | Full-factorial `sweep(grid=...)`. `LocalJoblibPool` default backend with subprocess isolation per run. Lazy `(run_id, time)` aggregation from per-run Parquet. JSON Lines manifest with append/fsync durability. `gmat-sweep run`/`show` CLI. Ubuntu + Windows CI on R2025a + R2026a × Python 3.10/3.11/3.12. |
+| **v0.2** *(next)* | `monte_carlo()` and `latin_hypercube()` plus explicit-row `samples=DataFrame` sweeps. Programmatic resume via `Sweep.from_manifest(...).resume()`. Ephemeris and contact aggregation across runs. macOS added to CI. Manifest format frozen as a stable v1 schema. Coverage gate raised to 85%. |
+
+Past releases live in [`CHANGELOG.md`](CHANGELOG.md).
+
+## Development
+
+To work on `gmat-sweep` itself:
+
+```bash
+git clone https://github.com/astro-tools/gmat-sweep.git
+cd gmat-sweep
+uv sync --all-groups
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full branch / PR / test workflow.
+
+## Licence
+
+MIT. See [LICENSE](LICENSE).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,18 +2,22 @@
 
 ## Install
 
-`gmat-sweep` is not yet on PyPI. Install from source:
-
 ```bash
-pip install git+https://github.com/astro-tools/gmat-sweep.git
+pip install gmat-sweep
 ```
 
-Or, if you are working inside a checkout:
+The `[examples]` extra pulls in `matplotlib` for the example notebooks:
+
+```bash
+pip install gmat-sweep[examples]
+```
+
+To work on `gmat-sweep` itself, clone and sync the dev groups:
 
 ```bash
 git clone https://github.com/astro-tools/gmat-sweep.git
 cd gmat-sweep
-uv sync
+uv sync --all-groups
 ```
 
 You also need a working **GMAT install** on the same machine. `gmat-sweep`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gmat-sweep"
-version = "0.0.0"
+version = "0.1.0"
 description = "Run parameter sweeps and Monte Carlo dispersions over GMAT missions in parallel from Python."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -21,7 +21,7 @@ keywords = [
   "parallel",
 ]
 classifiers = [
-  "Development Status :: 2 - Pre-Alpha",
+  "Development Status :: 3 - Alpha",
   "Intended Audience :: Science/Research",
   "License :: OSI Approved :: MIT License",
   "Operating System :: POSIX :: Linux",
@@ -58,8 +58,10 @@ gmat-sweep = "gmat_sweep.cli:main"
 
 [project.urls]
 Homepage = "https://github.com/astro-tools/gmat-sweep"
+Documentation = "https://astro-tools.github.io/gmat-sweep/"
 Repository = "https://github.com/astro-tools/gmat-sweep"
 Issues = "https://github.com/astro-tools/gmat-sweep/issues"
+Changelog = "https://github.com/astro-tools/gmat-sweep/blob/main/CHANGELOG.md"
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -1239,7 +1239,7 @@ wheels = [
 
 [[package]]
 name = "gmat-sweep"
-version = "0.0.0"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "gmat-run" },


### PR DESCRIPTION
## Summary

- Bump `version` from `0.0.0` to `0.1.0`, promote the `Development Status` classifier from `2 - Pre-Alpha` to `3 - Alpha`, and extend `[project.urls]` with `Documentation` and `Changelog` rows per charter §7 Phase 0 PyPI listing audit.
- Regenerate `uv.lock` so the editable `gmat-sweep` entry resolves to `0.1.0`.
- Rewrite `README.md` from the pre-alpha stub: badge row, four-line quick-start, supported-version matrix (R2025a/R2026a × Py3.10/3.11/3.12 × Ubuntu/Windows), "what gmat-sweep is not" pointers at gmatpyplus / pygmat / future MC + Latin hypercube, `gmat-run` hard-dependency note with install discipline, current + next roadmap row only.
- Replace `docs/getting-started.md`'s "not yet on PyPI" install block with `pip install gmat-sweep`; keep the source/dev install as the secondary path.
- Aggregate every v0.1 PR (#2–#13, #28, #29) into a `[0.1.0]` `CHANGELOG.md` section.

This is the source-side of v0.1.0. After merge, the release is cut by pushing a `v0.1.0` tag, which fires `release.yml` (sdist + wheel build, PyPI trusted publishing, GitHub Release with auto-generated notes) and `docs.yml` (rebuild + deploy to Pages under the tag).

## Release prerequisites — to do before tagging

These are GitHub-side, not in the diff. Surfaced here so they aren't missed:

- [ ] **Create the `pypi` GitHub Actions environment** on `astro-tools/gmat-sweep`. The repo currently only has `github-pages`; `release.yml`'s `publish-pypi` job references `environment: pypi` and will fail otherwise.
- [ ] **Bind PyPI's pending publisher** for `astro-tools/gmat-sweep`: project name `gmat-sweep`, owner `astro-tools`, repo `gmat-sweep`, workflow `release.yml`, environment `pypi`. The PyPI project doesn't exist yet — pending-publisher creates it on first publish.
- [ ] **Add required status checks** to `main` branch protection: `lint`, `typecheck`, `minimal install smoke`, plus all 12 `test (...)` matrix cells. Branch protection currently has zero required contexts. Easier to do now than earlier because the context names are stable.

## Post-tag actions

- [ ] Verify `pip install gmat-sweep==0.1.0` works on a clean Python 3.10 / 3.11 / 3.12 venv.
- [ ] Verify the docs site is published on the `v0.1.0` tag and reachable at <https://astro-tools.github.io/gmat-sweep/>.
- [ ] Set the repo `homepage` field on GitHub to `https://astro-tools.github.io/gmat-sweep/` (currently empty).
- [ ] Close the v0.1 milestone.

## Test plan

- [x] `uv run ruff check` — clean.
- [x] `uv run ruff format --check` — 36 files already formatted.
- [x] `uv run mypy` — no issues found in 33 source files.
- [x] `uv run pytest -m "integration or not integration"` — 202 passed, 0 deselected.
- [x] `uv build` — produces `gmat_sweep-0.1.0.tar.gz` and `gmat_sweep-0.1.0-py3-none-any.whl`.
- [x] `uv run mkdocs build --strict` — clean.
- [x] Cross-OS CI (Ubuntu + Windows) green on this PR.

## v0.1 Definition of Done — verification (charter §4)

- [ ] `pip install gmat-sweep` succeeds from PyPI on Python 3.10, 3.11, 3.12 — verifiable post-tag.
- [x] Vision-snippet grid sweep against a stock GMAT R2026a sample returns a `(run_id, time)`-indexed DataFrame with `__status == "ok"` everywhere — covered by `tests/test_reference_sweep.py` and the example notebooks.
- [x] Killing the sweep mid-run with `Ctrl-C` leaves a parsable manifest — covered by `tests/test_manifest_replay_contract.py` and `docs/examples/03_killed_sweep_recovery.ipynb`.
- [x] Integration test suite green on Ubuntu and Windows — verifiable via this PR's CI run.
- [x] `mypy --strict`, `ruff check`, `ruff format --check` all pass.
- [x] Coverage thresholds met: ≥ 95 % on `grids.py`, `distributions.py`, `manifest.py`, `aggregate.py`; ≥ 80 % overall (current run is 99 % overall).
- [x] README documents `gmat-run` as a hard dependency, the supported-version matrix, what `gmat-sweep` is not, and a working grid-sweep quick-start.
- [x] A single failed run surfaces as a `__status == "failed"` row with stderr captured in the manifest — covered by `tests/test_failure_modes.py`.
- [ ] Docs site published on the `v0.1.0` tag and linked from the README — link is in the new README; deploy fires on tag push.

Closes #14
