### PR TITLE
Add distribution specs, seeded sampling, and rv_frozen coercion

### DIFF
--- a/docs/parameter-spec.md
+++ b/docs/parameter-spec.md
@@ -56,6 +56,53 @@ being passed in. `gmat-run` itself accepts numpy on the receive side, but
 `gmat-sweep`'s [`RunSpec`][gmat_sweep.RunSpec] is the worker-boundary
 serialisation surface and JSON does not encode numpy scalars natively.
 
+## Stochastic specs
+
+For Monte Carlo and Latin hypercube sweeps the per-axis value is a
+*distribution* rather than a sequence. `gmat-sweep` accepts three
+shorthand tuples and a pass-through for any pre-frozen
+[`scipy.stats`](https://docs.scipy.org/doc/scipy/reference/stats.html)
+distribution:
+
+| Spec                          | Equivalent `scipy.stats` call                       |
+|-------------------------------|------------------------------------------------------|
+| `("normal", mu, sigma)`       | `scipy.stats.norm(loc=mu, scale=sigma)`              |
+| `("uniform", lo, hi)`         | `scipy.stats.uniform(loc=lo, scale=hi - lo)`         |
+| `("lognormal", mu, sigma)`    | `scipy.stats.lognorm(s=sigma, scale=exp(mu))`        |
+| any `scipy.stats.*` frozen rv | the rv itself (passes through unchanged)             |
+
+```python
+import math
+from scipy import stats
+
+# Three shorthand forms.
+("normal", 7000.0, 5.0)            # SMA, ±5 km 1-σ
+("uniform", 0.0, 360.0)             # RAAN, anywhere on the equator
+("lognormal", math.log(100), 0.1)   # dry mass around 100 kg, log-normal spread
+
+# Anything else: hand in a pre-frozen distribution directly.
+stats.triang(c=0.5, loc=-1, scale=2)
+```
+
+The shorthands cover the cases that come up day-to-day in dispersion
+analyses; reach for the pre-frozen path when you need a different shape
+(triangular, beta, a truncated normal via `scipy.stats.truncnorm`, etc.).
+
+`mu` and `sigma` for `lognormal` are the parameters of the *underlying*
+normal — the mean and standard deviation of `log(X)`, not of `X`. This
+matches `scipy.stats.lognorm`'s convention but trips up callers expecting
+to specify the lognormal's own mean directly.
+
+Validation is strict and happens up front:
+
+- Tag must be one of `"normal"`, `"uniform"`, `"lognormal"`.
+- `sigma` must be `> 0` for `normal` and `lognormal`.
+- `hi` must be `> lo` for `uniform`.
+- All numeric parameters must be finite (no `nan` or `inf`).
+
+Any violation raises [`SweepConfigError`][gmat_sweep.SweepConfigError]
+before any run starts.
+
 ## Full-factorial expansion
 
 [`sweep()`][gmat_sweep.sweep] uses the full-factorial expansion in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,12 @@ ignore_missing_imports = true
 module = ["tqdm", "tqdm.*"]
 ignore_missing_imports = true
 
+# scipy ships no py.typed marker; distributions.py imports scipy.stats and
+# the rv_frozen base class for the small surface used by to_rv_frozen / sample.
+[[tool.mypy.overrides]]
+module = ["scipy", "scipy.*"]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 minversion = "8.0"
 testpaths = ["tests"]

--- a/src/gmat_sweep/distributions.py
+++ b/src/gmat_sweep/distributions.py
@@ -1,3 +1,152 @@
-"""Distribution specs, seeded sampling, and conversion to scipy.stats.rv_frozen."""
+"""Distribution specs, seeded sampling, and conversion to scipy.stats.rv_frozen.
+
+Internal infrastructure for the upcoming Monte Carlo (#33) and Latin hypercube
+(#35) public APIs. None of the symbols here are re-exported from
+:mod:`gmat_sweep` — callers reach in via ``gmat_sweep.distributions.*``.
+
+:func:`derive_run_seeds` is **the** contract Monte Carlo replays depend on
+(charter §5): spawning child :class:`numpy.random.SeedSequence` instances from
+a parent and reading the first 32-bit word of each child's ``generate_state(1)``
+yields a list of per-run integer seeds that is identical across calls in the
+same process and across fresh processes. Two callers given the same
+``parent_seed`` and ``n`` reconstruct the same per-run RNG state; this is what
+lets a Monte Carlo sweep be replayed run-by-run from its manifest alone.
+"""
 
 from __future__ import annotations
+
+import math
+from typing import Any, Literal, TypeAlias, cast
+
+import numpy as np
+from scipy import stats
+from scipy.stats._distn_infrastructure import rv_frozen
+
+from gmat_sweep.errors import SweepConfigError
+
+__all__ = [
+    "DistSpec",
+    "derive_run_seeds",
+    "sample",
+    "to_rv_frozen",
+]
+
+
+_NormalSpec: TypeAlias = tuple[Literal["normal"], float, float]
+_UniformSpec: TypeAlias = tuple[Literal["uniform"], float, float]
+_LognormalSpec: TypeAlias = tuple[Literal["lognormal"], float, float]
+
+DistSpec: TypeAlias = _NormalSpec | _UniformSpec | _LognormalSpec | rv_frozen
+"""User-facing distribution specification.
+
+One of three shorthand tuples or a pre-frozen scipy distribution:
+
+* ``("normal", mu, sigma)`` — :func:`scipy.stats.norm` with ``loc=mu, scale=sigma``.
+* ``("uniform", lo, hi)`` — :func:`scipy.stats.uniform` with ``loc=lo, scale=hi - lo``.
+* ``("lognormal", mu, sigma)`` — :func:`scipy.stats.lognorm` with ``s=sigma, scale=exp(mu)``.
+* a pre-frozen :class:`scipy.stats._distn_infrastructure.rv_frozen` — passes
+  through :func:`to_rv_frozen` unchanged for callers that need a distribution
+  shape outside the three shorthands.
+"""
+
+
+def to_rv_frozen(spec: DistSpec) -> rv_frozen:
+    """Coerce a :data:`DistSpec` into a frozen scipy distribution.
+
+    A pre-frozen ``rv_frozen`` is returned unchanged (same object identity).
+    Shorthand tuples are validated and mapped to the corresponding
+    :mod:`scipy.stats` factory.
+
+    Raises :class:`SweepConfigError` for: an unknown shorthand tag, a tuple of
+    the wrong length, non-numeric or non-finite parameters, ``sigma <= 0``
+    (normal, lognormal), or ``hi <= lo`` (uniform).
+    """
+    if isinstance(spec, rv_frozen):
+        return spec
+
+    if not isinstance(spec, tuple):
+        raise SweepConfigError(
+            f"distribution spec must be a shorthand tuple or scipy rv_frozen, "
+            f"got {type(spec).__name__}"
+        )
+
+    if len(spec) == 0:
+        raise SweepConfigError("distribution spec tuple is empty")
+
+    tag = spec[0]
+    if tag == "normal":
+        mu, sigma = _two_floats(spec, "normal")
+        if sigma <= 0:
+            raise SweepConfigError(f"'normal' distribution sigma must be > 0, got {sigma!r}")
+        return cast(rv_frozen, stats.norm(loc=mu, scale=sigma))
+    if tag == "uniform":
+        lo, hi = _two_floats(spec, "uniform")
+        if hi <= lo:
+            raise SweepConfigError(
+                f"'uniform' distribution requires hi > lo, got lo={lo!r}, hi={hi!r}"
+            )
+        return cast(rv_frozen, stats.uniform(loc=lo, scale=hi - lo))
+    if tag == "lognormal":
+        mu, sigma = _two_floats(spec, "lognormal")
+        if sigma <= 0:
+            raise SweepConfigError(f"'lognormal' distribution sigma must be > 0, got {sigma!r}")
+        return cast(rv_frozen, stats.lognorm(s=sigma, scale=math.exp(mu)))
+    raise SweepConfigError(
+        f"unknown distribution shorthand tag {tag!r}; "
+        f"expected one of 'normal', 'uniform', 'lognormal'"
+    )
+
+
+def _two_floats(spec: tuple[Any, ...], tag: str) -> tuple[float, float]:
+    if len(spec) != 3:
+        raise SweepConfigError(
+            f"{tag!r} distribution spec must be a length-3 tuple, got length {len(spec)}"
+        )
+    a_raw, b_raw = spec[1], spec[2]
+    if isinstance(a_raw, bool) or isinstance(b_raw, bool):
+        raise SweepConfigError(
+            f"{tag!r} distribution parameters must be numeric, got {a_raw!r} and {b_raw!r}"
+        )
+    try:
+        a = float(a_raw)
+        b = float(b_raw)
+    except (TypeError, ValueError) as e:
+        raise SweepConfigError(
+            f"{tag!r} distribution parameters must be numeric, got {a_raw!r} and {b_raw!r}"
+        ) from e
+    if not (math.isfinite(a) and math.isfinite(b)):
+        raise SweepConfigError(
+            f"{tag!r} distribution parameters must be finite, got {a!r} and {b!r}"
+        )
+    return a, b
+
+
+def derive_run_seeds(parent_seed: int | None, n: int) -> list[int]:
+    """Derive ``n`` per-run integer seeds from ``parent_seed``.
+
+    Uses ``numpy.random.SeedSequence(parent_seed).spawn(n)`` and reads the
+    first 32-bit word of each child's ``generate_state(1)``. For an integer
+    ``parent_seed`` the result is identical across calls in the same process
+    and across fresh processes — the Monte Carlo replay contract.
+
+    ``parent_seed=None`` falls back to OS entropy and is **not** reproducible.
+    ``n`` must be ``>= 0``; ``n=0`` returns ``[]``.
+    """
+    if n < 0:
+        raise SweepConfigError(f"derive_run_seeds requires n >= 0, got {n}")
+    if n == 0:
+        return []
+    seq = np.random.SeedSequence(parent_seed)
+    children = seq.spawn(n)
+    return [int(child.generate_state(1)[0]) for child in children]
+
+
+def sample(spec: DistSpec, seed: int) -> float:
+    """Draw one float from ``spec`` using a fresh ``numpy.random.default_rng(seed)``.
+
+    Reproducible per ``(spec, seed)``: each call constructs its own RNG, so
+    nothing about the draw depends on global RNG state or call order.
+    """
+    rv = to_rv_frozen(spec)
+    rng = np.random.default_rng(seed)
+    return float(rv.rvs(size=1, random_state=rng)[0])

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -1,0 +1,264 @@
+"""Tests for gmat_sweep.distributions — distribution coercion and seeded sampling."""
+
+from __future__ import annotations
+
+import json
+import math
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+from scipy import stats
+from scipy.stats._distn_infrastructure import rv_frozen
+
+from gmat_sweep.distributions import derive_run_seeds, sample, to_rv_frozen
+from gmat_sweep.errors import SweepConfigError
+
+# ---- to_rv_frozen: shorthand mapping --------------------------------------
+
+
+def test_normal_shorthand_maps_to_scipy_norm() -> None:
+    rv = to_rv_frozen(("normal", 3.0, 2.0))
+    assert isinstance(rv, rv_frozen)
+    # scipy.stats.norm uses (loc, scale) in args; freeze stores them as kwds.
+    assert rv.kwds == {"loc": 3.0, "scale": 2.0}
+    assert rv.dist.name == "norm"
+
+
+def test_uniform_shorthand_maps_to_scipy_uniform_with_loc_and_scale() -> None:
+    rv = to_rv_frozen(("uniform", 5.0, 11.0))
+    assert isinstance(rv, rv_frozen)
+    assert rv.kwds == {"loc": 5.0, "scale": 6.0}
+    assert rv.dist.name == "uniform"
+
+
+def test_lognormal_shorthand_maps_to_scipy_lognorm_with_s_and_scale() -> None:
+    rv = to_rv_frozen(("lognormal", 1.0, 0.5))
+    assert isinstance(rv, rv_frozen)
+    assert rv.kwds == {"s": 0.5, "scale": pytest.approx(math.exp(1.0))}
+    assert rv.dist.name == "lognorm"
+
+
+def test_pre_frozen_rv_passes_through_unchanged() -> None:
+    pre = stats.beta(2, 5)
+    out = to_rv_frozen(pre)
+    assert out is pre
+
+
+def test_shorthand_accepts_int_parameters_and_coerces_to_float() -> None:
+    rv = to_rv_frozen(("normal", 0, 1))
+    assert rv.kwds == {"loc": 0.0, "scale": 1.0}
+
+
+# ---- to_rv_frozen: round-trip moments within 5% ---------------------------
+
+
+def _moments_within_5pct(rv: rv_frozen, expected_mean: float, expected_std: float) -> None:
+    samples = rv.rvs(size=10_000, random_state=np.random.default_rng(20260504))
+    sample_mean = float(np.mean(samples))
+    sample_std = float(np.std(samples))
+    # 5% of the magnitude of the expected value, falling back to 5% of std when
+    # the expected mean is zero.
+    mean_tol = 0.05 * (abs(expected_mean) if expected_mean != 0 else expected_std)
+    std_tol = 0.05 * abs(expected_std)
+    assert abs(sample_mean - expected_mean) <= mean_tol, (
+        f"mean {sample_mean} not within 5% of {expected_mean}"
+    )
+    assert abs(sample_std - expected_std) <= std_tol, (
+        f"std {sample_std} not within 5% of {expected_std}"
+    )
+
+
+def test_normal_round_trip_moments_within_5pct() -> None:
+    _moments_within_5pct(to_rv_frozen(("normal", 3.0, 2.0)), expected_mean=3.0, expected_std=2.0)
+
+
+def test_uniform_round_trip_moments_within_5pct() -> None:
+    lo, hi = 5.0, 11.0
+    expected_mean = (lo + hi) / 2
+    expected_std = (hi - lo) / math.sqrt(12)
+    _moments_within_5pct(to_rv_frozen(("uniform", lo, hi)), expected_mean, expected_std)
+
+
+def test_lognormal_round_trip_moments_within_5pct() -> None:
+    mu, sigma = 1.0, 0.5
+    expected_mean = math.exp(mu + sigma**2 / 2)
+    expected_std = math.sqrt((math.exp(sigma**2) - 1) * math.exp(2 * mu + sigma**2))
+    _moments_within_5pct(to_rv_frozen(("lognormal", mu, sigma)), expected_mean, expected_std)
+
+
+# ---- to_rv_frozen: validation errors --------------------------------------
+
+
+def test_unknown_shorthand_tag_raises() -> None:
+    with pytest.raises(SweepConfigError, match="unknown distribution shorthand tag"):
+        to_rv_frozen(("triangular", 0, 1))
+
+
+def test_non_tuple_non_rv_raises_for_string() -> None:
+    with pytest.raises(SweepConfigError, match="must be a shorthand tuple or scipy rv_frozen"):
+        to_rv_frozen("normal")
+
+
+def test_non_tuple_non_rv_raises_for_int() -> None:
+    with pytest.raises(SweepConfigError, match="must be a shorthand tuple or scipy rv_frozen"):
+        to_rv_frozen(42)
+
+
+def test_empty_tuple_raises() -> None:
+    with pytest.raises(SweepConfigError, match="distribution spec tuple is empty"):
+        to_rv_frozen(())
+
+
+@pytest.mark.parametrize("tag", ["normal", "uniform", "lognormal"])
+def test_wrong_tuple_length_too_short_raises(tag: str) -> None:
+    with pytest.raises(
+        SweepConfigError, match=f"{tag!r} distribution spec must be a length-3 tuple"
+    ):
+        to_rv_frozen((tag, 1.0))
+
+
+@pytest.mark.parametrize("tag", ["normal", "uniform", "lognormal"])
+def test_wrong_tuple_length_too_long_raises(tag: str) -> None:
+    with pytest.raises(
+        SweepConfigError, match=f"{tag!r} distribution spec must be a length-3 tuple"
+    ):
+        to_rv_frozen((tag, 1.0, 2.0, 3.0))
+
+
+@pytest.mark.parametrize("tag", ["normal", "uniform", "lognormal"])
+def test_non_numeric_parameter_raises(tag: str) -> None:
+    with pytest.raises(SweepConfigError, match="parameters must be numeric"):
+        to_rv_frozen((tag, "oops", 1.0))
+
+
+@pytest.mark.parametrize("tag", ["normal", "uniform", "lognormal"])
+def test_bool_parameter_rejected_as_non_numeric(tag: str) -> None:
+    # bool is an int subclass; reject explicitly so callers don't accidentally
+    # turn `("normal", True, 1.0)` into a degenerate normal at 1.0.
+    with pytest.raises(SweepConfigError, match="parameters must be numeric"):
+        to_rv_frozen((tag, True, 1.0))
+
+
+@pytest.mark.parametrize("tag", ["normal", "uniform", "lognormal"])
+def test_non_finite_inf_parameter_raises(tag: str) -> None:
+    with pytest.raises(SweepConfigError, match="parameters must be finite"):
+        to_rv_frozen((tag, math.inf, 1.0))
+
+
+@pytest.mark.parametrize("tag", ["normal", "uniform", "lognormal"])
+def test_non_finite_nan_parameter_raises(tag: str) -> None:
+    with pytest.raises(SweepConfigError, match="parameters must be finite"):
+        to_rv_frozen((tag, 0.0, math.nan))
+
+
+@pytest.mark.parametrize("sigma", [0.0, -1.0])
+def test_normal_non_positive_sigma_raises(sigma: float) -> None:
+    with pytest.raises(SweepConfigError, match="'normal' distribution sigma must be > 0"):
+        to_rv_frozen(("normal", 0.0, sigma))
+
+
+@pytest.mark.parametrize("sigma", [0.0, -0.5])
+def test_lognormal_non_positive_sigma_raises(sigma: float) -> None:
+    with pytest.raises(SweepConfigError, match="'lognormal' distribution sigma must be > 0"):
+        to_rv_frozen(("lognormal", 0.0, sigma))
+
+
+@pytest.mark.parametrize(("lo", "hi"), [(1.0, 1.0), (5.0, 1.0)])
+def test_uniform_degenerate_range_raises(lo: float, hi: float) -> None:
+    with pytest.raises(SweepConfigError, match="requires hi > lo"):
+        to_rv_frozen(("uniform", lo, hi))
+
+
+# ---- derive_run_seeds -----------------------------------------------------
+
+
+def test_derive_run_seeds_returns_n_distinct_ints_for_fixed_parent() -> None:
+    seeds = derive_run_seeds(42, 1000)
+    assert len(seeds) == 1000
+    assert all(isinstance(s, int) for s in seeds)
+    assert len(set(seeds)) == 1000
+
+
+def test_derive_run_seeds_in_process_reproducible() -> None:
+    a = derive_run_seeds(42, 1000)
+    b = derive_run_seeds(42, 1000)
+    assert a == b
+
+
+def test_derive_run_seeds_cross_process_reproducible() -> None:
+    code = (
+        "from gmat_sweep.distributions import derive_run_seeds; "
+        "import json; "
+        "print(json.dumps(derive_run_seeds(42, 1000)))"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    cross_proc = json.loads(result.stdout.strip())
+    assert cross_proc == derive_run_seeds(42, 1000)
+
+
+def test_derive_run_seeds_different_parents_differ() -> None:
+    assert derive_run_seeds(42, 8) != derive_run_seeds(43, 8)
+
+
+def test_derive_run_seeds_zero_returns_empty_list_for_int_parent() -> None:
+    assert derive_run_seeds(42, 0) == []
+
+
+def test_derive_run_seeds_zero_returns_empty_list_for_none_parent() -> None:
+    assert derive_run_seeds(None, 0) == []
+
+
+def test_derive_run_seeds_negative_n_raises() -> None:
+    with pytest.raises(SweepConfigError, match="requires n >= 0"):
+        derive_run_seeds(42, -1)
+
+
+def test_derive_run_seeds_none_parent_returns_correct_shape() -> None:
+    # OS-entropy parent: only assert shape and types. Two calls almost surely
+    # differ but we don't assert that — would be flaky.
+    seeds = derive_run_seeds(None, 5)
+    assert len(seeds) == 5
+    assert all(isinstance(s, int) for s in seeds)
+
+
+# ---- sample ---------------------------------------------------------------
+
+
+def test_sample_reproducible_per_spec_seed_pair() -> None:
+    a = sample(("normal", 0.0, 1.0), seed=42)
+    b = sample(("normal", 0.0, 1.0), seed=42)
+    assert a == b
+
+
+def test_sample_differs_across_seeds() -> None:
+    a = sample(("normal", 0.0, 1.0), seed=42)
+    b = sample(("normal", 0.0, 1.0), seed=43)
+    assert a != b
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        ("normal", 0.0, 1.0),
+        ("uniform", -1.0, 1.0),
+        ("lognormal", 0.0, 0.25),
+    ],
+)
+def test_sample_returns_python_float_for_each_shorthand(spec: tuple[str, float, float]) -> None:
+    out = sample(spec, seed=7)
+    assert isinstance(out, float)
+
+
+def test_sample_works_with_pre_frozen_rv() -> None:
+    pre = stats.beta(2, 5)
+    a = sample(pre, seed=99)
+    b = sample(pre, seed=99)
+    assert a == b
+    assert isinstance(a, float)


### PR DESCRIPTION
## Summary

- New `gmat_sweep/distributions.py` (replaces the stub): `DistSpec` shorthand types, `to_rv_frozen` coercion with strict up-front validation, `derive_run_seeds` (the Monte Carlo replay contract per charter §5), and `sample`. Internal infrastructure for the upcoming `monte_carlo()` (#33) and `latin_hypercube()` (#35) — no new public re-exports.
- `docs/parameter-spec.md`: new "Stochastic specs" section listing the three shorthand forms and the pre-frozen pass-through.
- `pyproject.toml`: scipy added to the `ignore_missing_imports` overrides (no `py.typed` upstream).

## Test plan

- [x] `uv run pytest tests/test_distributions.py` — 50 new tests pass.
- [x] `uv run pytest --cov` — 233/233 pass; `distributions.py` at 100% (gate is 95%); overall 99%.
- [x] `uv run ruff check` — clean.
- [x] `uv run ruff format --check` — clean.
- [x] `uv run mypy` (strict) — clean.
- [x] Cross-process determinism asserted via subprocess in `test_derive_run_seeds_cross_process_reproducible`.

Closes #31