### PR TITLE
Aggregate ephemeris and contact outputs across sweep runs

### DIFF
--- a/docs/aggregation.md
+++ b/docs/aggregation.md
@@ -1,0 +1,108 @@
+# Aggregating sweep outputs
+
+`gmat-sweep` writes each run's outputs as one Parquet file per GMAT
+output kind, then assembles them on demand into multi-indexed
+`pandas.DataFrame`s. Three entry points cover the three kinds gmat-run
+surfaces:
+
+| Function | GMAT output kind | Index |
+|----------|------------------|-------|
+| [`lazy_multiindex`][gmat_sweep.lazy_multiindex] | `ReportFile` | `(run_id, time)` |
+| [`lazy_ephemerides`][gmat_sweep.lazy_ephemerides] | `EphemerisFile` (OEM, STK, SPK) | `(run_id, time)` |
+| [`lazy_contacts`][gmat_sweep.lazy_contacts] | `ContactLocator` | `(run_id, interval_id)` |
+
+The matching [`Sweep`][gmat_sweep.Sweep] convenience methods —
+`Sweep.to_dataframe`, `Sweep.to_ephemerides`, `Sweep.to_contacts` —
+delegate to these with the sweep's manifest and output directory already
+bound. [`sweep()`][gmat_sweep.sweep] returns
+`Sweep.to_dataframe(name=None)` directly for the common single-report
+case.
+
+## The `name` selector
+
+Every entry point accepts `name: str | None = None`. With one output of
+the relevant kind across the sweep, `name=None` resolves to that sole
+output automatically. With two or more, `name=None` raises
+[`SweepConfigError`][gmat_sweep.SweepConfigError] listing the available
+names — pass `name="..."` to pick one, and call the same function twice
+to get two frames.
+
+```python
+from pathlib import Path
+
+from gmat_sweep import Manifest, lazy_contacts, lazy_ephemerides, lazy_multiindex, sweep
+
+# Single-report case: sweep() returns the report frame directly.
+reports = sweep(
+    "mission.script",
+    grid={"Sat.SMA": [7000, 7100, 7200]},
+    out=Path("./sweep"),
+)
+
+# Mixed outputs (report + ephemeris + contact): re-load the manifest and
+# pull each frame independently.
+manifest = Manifest.load(Path("./sweep/manifest.jsonl"))
+ephemerides = lazy_ephemerides(manifest, Path("./sweep"))
+contacts = lazy_contacts(manifest, Path("./sweep"))
+
+# Two ReportFiles (e.g. spacecraft state + maneuvers): pass `name=` to pick.
+states = lazy_multiindex(manifest, Path("./sweep"), name="StateReport")
+burns = lazy_multiindex(manifest, Path("./sweep"), name="BurnReport")
+```
+
+## Failed and skipped runs
+
+Failed and skipped runs surface as one row per run with the data columns
+NaN-filled and the `__status` column set to `"failed"` or `"skipped"`.
+The secondary index level carries a kind-appropriate missing value:
+
+- `lazy_multiindex` / `lazy_ephemerides` — `time = NaT` (`datetime64[ns]`).
+- `lazy_contacts` — `interval_id = pd.NA` (nullable `Int64`).
+
+An `ok` run that ran successfully but did not produce the requested
+output kind (e.g. asking for ephemerides on a sweep where one specific
+run only emitted reports) lands the same way, with `__status="ok"` so
+it remains distinguishable from a true failure.
+
+## Index shapes
+
+### Reports and ephemerides — `(run_id, time)`
+
+The worker copies the first datetime column of each frame to a column
+literally named `time` before writing Parquet — so user column names
+(`Sat.UTCGregorian`, `Epoch`, …) round-trip into the aggregated frame
+unchanged, while the aggregator gets the consistent `time` level it
+needs. SPK, STK-TimePosVel, and CCSDS-OEM ephemeris frames all expose
+their epoch as `Epoch`, so the same synthesis covers every gmat-run
+ephemeris format.
+
+### Contacts — `(run_id, interval_id)`
+
+Contact frames are intervals, not point samples — one row per
+visibility interval. The worker assigns a fresh `interval_id` column
+(`range(len(df))`, so `0..K-1` per run) at write time. Use `interval_id`
+the same way you'd use a per-run row position; the actual visibility
+times are still in the data columns (`Start`, `Stop`, `Duration`, etc.,
+depending on the `ContactLocator.ReportFormat` setting).
+
+## Memory: streaming vs. eager reads
+
+`lazy_multiindex` and `lazy_ephemerides` accept `spool: bool = True`.
+With `spool=True` (default) each per-run Parquet is streamed through
+pandas one record batch at a time, so peak conversion memory is one
+batch rather than one full sweep. `spool=False` reads each Parquet
+eagerly in one shot — simpler control flow, higher peak memory, useful
+on small sweeps. The result frame is identical either way.
+
+`lazy_contacts` does not take a `spool` flag — `ContactLocator` outputs
+are typically tiny (one row per pass) and the streaming overhead is not
+worth the knob.
+
+## Migrating from v0.1
+
+v0.1 used a bare `<name>.parquet` per-run layout and keyed
+`output_paths` by `<name>`; v0.2 prepends the kind prefix
+(`report__<name>.parquet`, key `report__<name>`). v0.1 manifests are not
+readable by v0.2 aggregators — the aggregator dispatch is keyed on the
+prefix and v0.1 entries lack one. Re-run any sweep you need to
+re-aggregate under v0.2.

--- a/docs/api.md
+++ b/docs/api.md
@@ -40,6 +40,10 @@ auto-generated from docstrings via
 
 ::: gmat_sweep.lazy_multiindex
 
+::: gmat_sweep.lazy_ephemerides
+
+::: gmat_sweep.lazy_contacts
+
 ## Exceptions
 
 ::: gmat_sweep.GmatSweepError

--- a/docs/manifest-schema.md
+++ b/docs/manifest-schema.md
@@ -86,7 +86,7 @@ checked out under different line-ending settings produce identical hashes.
 | `run_id`       | Sequential integer assigned at grid-expansion time, starting at `0`. Unique within a sweep.                  |
 | `overrides`    | The override dict applied for this run — exactly the slice of the grid that produced it.                     |
 | `status`       | One of `"ok"`, `"failed"`, `"skipped"`. v0.1 only emits `"ok"` and `"failed"`.                                |
-| `output_paths` | Map from the report name (matched against the parsed `ReportFile` resource) to the per-run Parquet path. Empty `{}` for non-`ok` runs. |
+| `output_paths` | Map from the prefixed output basename (`report__<name>`, `ephemeris__<name>`, `contact__<name>`) to the per-run Parquet path. Empty `{}` for non-`ok` runs. The prefix encodes the GMAT output kind so [`lazy_multiindex`][gmat_sweep.lazy_multiindex] / [`lazy_ephemerides`][gmat_sweep.lazy_ephemerides] / [`lazy_contacts`][gmat_sweep.lazy_contacts] can dispatch without reading the file. |
 | `started_at`   | UTC `datetime` the worker began this run, ISO-8601 with tz offset.                                           |
 | `ended_at`     | UTC `datetime` the worker returned its outcome, ISO-8601.                                                    |
 | `duration_s`   | `(ended_at - started_at).total_seconds()`. Computed once on the worker side; the three timing fields cannot disagree. |
@@ -95,12 +95,20 @@ checked out under different line-ending settings produce identical hashes.
 
 ### `output_paths` invariant
 
-For `status == "ok"` entries, `output_paths` is non-empty. v0.1 assumes
-exactly one `ReportFile` per run; if a future script produces multiple,
-[`lazy_multiindex()`][gmat_sweep.lazy_multiindex] raises `NotImplementedError`
-and defers to the v0.2 reshape helpers. Whether a Parquet path is recorded
-as relative or absolute depends on how the worker wrote it; the aggregator
-resolves relative paths against the sweep's `output_dir`.
+For `status == "ok"` entries, `output_paths` is non-empty. Each key is
+one of:
+
+- `report__<name>` — a `ReportFile` resource named `<name>` in the script.
+- `ephemeris__<name>` — an `EphemerisFile` resource (OEM, STK-TimePosVel,
+  or SPK; the worker writes the parsed DataFrame either way).
+- `contact__<name>` — a `ContactLocator` resource. The Parquet carries a
+  fresh integer `interval_id` column (`0..K-1` per run) the aggregator
+  uses as the secondary index.
+
+A single sweep may produce any mix of the three kinds, and any number of
+each. Whether a Parquet path is recorded as relative or absolute depends
+on how the worker wrote it; the aggregator resolves relative paths
+against the sweep's `output_dir`.
 
 ## Loading a manifest back
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
   - Home: index.md
   - Getting started: getting-started.md
   - Parameter spec: parameter-spec.md
+  - Aggregation: aggregation.md
   - Manifest schema: manifest-schema.md
   - Supported versions: supported-versions.md
   - Examples:

--- a/src/gmat_sweep/__init__.py
+++ b/src/gmat_sweep/__init__.py
@@ -3,7 +3,7 @@
 import logging
 from importlib.metadata import PackageNotFoundError, version
 
-from gmat_sweep.aggregate import lazy_multiindex
+from gmat_sweep.aggregate import lazy_contacts, lazy_ephemerides, lazy_multiindex
 from gmat_sweep.api import sweep
 from gmat_sweep.backends import Pool
 from gmat_sweep.errors import (
@@ -49,6 +49,8 @@ __all__ = [
     "canonical_script_sha256",
     "expand_grid_to_run_specs",
     "full_factorial",
+    "lazy_contacts",
+    "lazy_ephemerides",
     "lazy_multiindex",
     "sweep",
 ]

--- a/src/gmat_sweep/aggregate.py
+++ b/src/gmat_sweep/aggregate.py
@@ -1,21 +1,31 @@
-"""Lazy assembly of the multi-indexed parent DataFrame from per-run Parquet files.
+"""Lazy assembly of multi-indexed parent DataFrames from per-run Parquet files.
 
-The single public entry point is :func:`lazy_multiindex`. It walks a
-:class:`gmat_sweep.manifest.Manifest`, reads each successful run's Parquet
-output through :mod:`pyarrow.dataset`, and stitches the per-run frames
-into one ``(run_id, time)``-indexed :class:`pandas.DataFrame`. Failed and
-skipped runs are materialised as one-row, NaN-filled slices so the
-caller sees a complete row per run rather than having to reconcile a
-``DataFrame`` against the manifest by hand.
+Three public entry points cover the three GMAT output kinds gmat-run surfaces:
 
-The default path streams each run's record batches through pandas one
-fragment at a time so peak conversion memory is one batch, not one full
-sweep. ``spool=False`` flips to an eager fragment-at-a-time read for
-small sweeps where the streaming overhead is not worth it; the result
-DataFrame is identical.
+- :func:`lazy_multiindex` — ``ReportFile`` outputs, ``(run_id, time)`` index.
+- :func:`lazy_ephemerides` — ``EphemerisFile`` outputs, ``(run_id, time)`` index.
+- :func:`lazy_contacts` — ``ContactLocator`` outputs, ``(run_id, interval_id)``
+  index.
 
-v0.1 assumes one Parquet output per ``ok`` run. Multi-report runs raise
-:class:`NotImplementedError` and defer to the v0.2 reshape helpers.
+Each walks a :class:`gmat_sweep.manifest.Manifest`, dispatches to per-run
+Parquet files by the ``<kind>__<name>`` key prefix the worker writes, and
+stitches the per-run frames into one multi-indexed
+:class:`pandas.DataFrame`. Failed and skipped runs (and ``ok`` runs that
+did not produce the requested output kind) are materialised as one-row,
+NaN-filled slices so the caller sees a complete row per run rather than
+having to reconcile a ``DataFrame`` against the manifest by hand.
+
+When a sweep produces multiple outputs of the same kind (e.g. two
+``ReportFile`` resources), pass ``name=`` to pick one. With a single
+output of that kind, ``name=None`` resolves it automatically; with two or
+more, ``name=None`` raises :class:`gmat_sweep.errors.SweepConfigError`
+listing the available names.
+
+The default report/ephemeris path streams each run's record batches
+through pandas one fragment at a time so peak conversion memory is one
+batch, not one full sweep. ``spool=False`` flips to an eager
+fragment-at-a-time read for small sweeps where the streaming overhead is
+not worth it; the result DataFrame is identical.
 """
 
 from __future__ import annotations
@@ -28,38 +38,54 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.dataset as ds
 
+from gmat_sweep.errors import SweepConfigError
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from gmat_sweep.manifest import Manifest, ManifestEntry
 
-__all__ = ["lazy_multiindex"]
+__all__ = ["lazy_contacts", "lazy_ephemerides", "lazy_multiindex"]
 
 
-_INDEX_NAMES: tuple[str, str] = ("run_id", "time")
+_RUN_ID_COL = "run_id"
 _STATUS_COL = "__status"
 _TIME_COL = "time"
+_INTERVAL_ID_COL = "interval_id"
+
+# Secondary-index dtype + per-entry "missing" sentinel, keyed by the column
+# name the aggregator uses as the second MultiIndex level. Adding a new
+# secondary-index kind is a one-line edit here.
+_SECONDARY_INDEX_DTYPE: dict[str, str] = {
+    _TIME_COL: "datetime64[ns]",
+    _INTERVAL_ID_COL: "Int64",
+}
+_SECONDARY_INDEX_MISSING: dict[str, Any] = {
+    _TIME_COL: pd.NaT,
+    _INTERVAL_ID_COL: pd.NA,
+}
 
 
 def lazy_multiindex(
     manifest: Manifest,
     output_dir: Path,
     *,
+    name: str | None = None,
     spool: bool = True,
 ) -> pd.DataFrame:
-    """Assemble the public ``(run_id, time)``-indexed DataFrame from a sweep's outputs.
+    """Assemble the ``(run_id, time)``-indexed report DataFrame from a sweep's outputs.
 
     Iterates ``manifest.entries`` in order. For each ``ok`` entry the
-    sole Parquet listed in :attr:`ManifestEntry.output_paths` is read via
-    :mod:`pyarrow.dataset` and tagged with its ``run_id``. For each
-    ``failed`` or ``skipped`` entry one NaN-filled row is materialised
-    with ``time = NaT`` and ``__status`` set to the run-level status.
+    Parquet listed in :attr:`ManifestEntry.output_paths` under the
+    ``report__<name>`` key is read via :mod:`pyarrow.dataset` and tagged
+    with its ``run_id``. For each ``failed`` or ``skipped`` entry — and
+    for any ``ok`` entry that did not produce the requested report — one
+    NaN-filled row is materialised with ``time = NaT`` and ``__status``
+    set to the run-level status (``"failed"`` / ``"skipped"`` for non-ok
+    runs, ``"ok"`` for ok runs missing this report).
+
     Relative paths in ``output_paths`` are resolved against ``output_dir``;
     absolute paths are used as-is.
-
-    The returned frame has a ``(run_id, time)`` :class:`pandas.MultiIndex`,
-    a ``time`` level coerced to ``datetime64[ns]``, and a ``__status``
-    column populated for every row.
 
     Parameters
     ----------
@@ -68,6 +94,13 @@ def lazy_multiindex(
     output_dir
         Sweep output root. Used to anchor any relative paths recorded in
         the manifest.
+    name
+        Report resource name to aggregate. ``None`` (default) picks the
+        sole report if exactly one report is present across the sweep.
+        Sweeps that produced multiple reports per run must pass ``name=``
+        explicitly; the call raises
+        :class:`gmat_sweep.errors.SweepConfigError` listing the available
+        names otherwise.
     spool
         ``True`` (default) streams each run's record batches into pandas
         one batch at a time. ``False`` reads each run's Parquet eagerly
@@ -75,41 +108,153 @@ def lazy_multiindex(
 
     Raises
     ------
-    NotImplementedError
-        If an ``ok`` run has more than one Parquet output. v0.1 assumes a
-        single ReportFile per run; multi-report aggregation is deferred
-        to the v0.2 reshape helpers.
+    SweepConfigError
+        ``name=None`` was passed but the sweep produced more than one
+        report (the exception message lists the available names), or the
+        explicitly-named report does not appear in any ok run's outputs.
     ValueError
-        If an ``ok`` entry has no ``output_paths``, or if a per-run
-        Parquet is missing the ``time`` column required for the index.
+        An ``ok`` entry has no ``output_paths`` at all (a run that ran
+        successfully must have produced something), or a per-run Parquet
+        is missing the ``time`` column required for the index.
     """
+    return _aggregate(
+        manifest,
+        output_dir,
+        kind="report",
+        secondary_index=_TIME_COL,
+        name=name,
+        spool=spool,
+    )
+
+
+def lazy_ephemerides(
+    manifest: Manifest,
+    output_dir: Path,
+    *,
+    name: str | None = None,
+    spool: bool = True,
+) -> pd.DataFrame:
+    """Assemble the ``(run_id, time)``-indexed ephemeris DataFrame from a sweep's outputs.
+
+    Mirrors :func:`lazy_multiindex` but dispatches on ``ephemeris__<name>``
+    keys instead of ``report__<name>``. The worker copies the first
+    datetime column of each ephemeris frame (``Epoch`` for OEM, STK, and
+    SPK formats) to a column named ``time`` before writing Parquet, so
+    the same ``(run_id, time)`` index machinery applies.
+
+    See :func:`lazy_multiindex` for parameter and exception semantics.
+    """
+    return _aggregate(
+        manifest,
+        output_dir,
+        kind="ephemeris",
+        secondary_index=_TIME_COL,
+        name=name,
+        spool=spool,
+    )
+
+
+def lazy_contacts(
+    manifest: Manifest,
+    output_dir: Path,
+    *,
+    name: str | None = None,
+) -> pd.DataFrame:
+    """Assemble the ``(run_id, interval_id)``-indexed contact DataFrame from a sweep's outputs.
+
+    Mirrors :func:`lazy_multiindex` but dispatches on ``contact__<name>``
+    keys and uses ``interval_id`` — the per-run row position the worker
+    assigns at write time, ``0..K-1`` per run — as the secondary index
+    level. ``ContactLocator`` outputs are typically tiny (one row per
+    visibility interval), so there is no ``spool`` knob; reads are
+    fragment-at-a-time eager.
+
+    Failed, skipped, and report-only ``ok`` runs materialise as one row
+    with ``interval_id = pd.NA`` (cast as the nullable ``Int64`` dtype so
+    integer interval indices and missing values share one level).
+
+    See :func:`lazy_multiindex` for the rest of the parameter and
+    exception semantics.
+    """
+    return _aggregate(
+        manifest,
+        output_dir,
+        kind="contact",
+        secondary_index=_INTERVAL_ID_COL,
+        name=name,
+        spool=False,
+    )
+
+
+def _aggregate(
+    manifest: Manifest,
+    output_dir: Path,
+    *,
+    kind: str,
+    secondary_index: str,
+    name: str | None,
+    spool: bool,
+) -> pd.DataFrame:
+    prefix = f"{kind}__"
+    index_names = (_RUN_ID_COL, secondary_index)
+
+    names_seen: set[str] = set()
+    for entry in manifest.entries:
+        if entry.status != "ok":
+            continue
+        if not entry.output_paths:
+            raise ValueError(
+                f"manifest entry for run_id={entry.run_id} has status='ok' but no output_paths"
+            )
+        for key in entry.output_paths:
+            if key.startswith(prefix):
+                names_seen.add(key[len(prefix) :])
+
+    if name is None:
+        if len(names_seen) > 1:
+            raise SweepConfigError(
+                f"sweep produced {len(names_seen)} {kind} outputs "
+                f"({sorted(names_seen)}); pass name= to select one"
+            )
+        if len(names_seen) == 1:
+            name = next(iter(names_seen))
+        # 0 names → name stays None; every ok run is treated as "did not
+        # produce this kind" and lands as a NaN row, matching the
+        # all-failed contract.
+    elif name not in names_seen and any(e.status == "ok" for e in manifest.entries):
+        raise SweepConfigError(
+            f"no {kind} output named {name!r} in this sweep; available: {sorted(names_seen)}"
+        )
+
+    target_key = f"{prefix}{name}" if name is not None else None
+
     paths_with_run_id: list[tuple[Path, int]] = []
     nonok_entries: list[ManifestEntry] = []
     for entry in manifest.entries:
-        if entry.status == "ok":
-            if len(entry.output_paths) == 0:
-                raise ValueError(
-                    f"manifest entry for run_id={entry.run_id} has status='ok' but no output_paths"
-                )
-            if len(entry.output_paths) > 1:
-                raise NotImplementedError(
-                    f"run_id={entry.run_id} produced {len(entry.output_paths)} Parquet "
-                    "outputs; v0.1 lazy_multiindex assumes one ReportFile per run. "
-                    "Multi-report aggregation is deferred to the v0.2 reshape helpers."
-                )
-            ((_name, raw_path),) = entry.output_paths.items()
+        if entry.status == "ok" and target_key is not None and target_key in entry.output_paths:
+            raw_path = entry.output_paths[target_key]
             resolved = raw_path if raw_path.is_absolute() else output_dir / raw_path
             paths_with_run_id.append((resolved, entry.run_id))
         else:
             nonok_entries.append(entry)
 
-    ok_df = _read_ok_runs(paths_with_run_id, spool=spool)
+    ok_df = _read_ok_runs(
+        paths_with_run_id,
+        secondary_index=secondary_index,
+        index_names=index_names,
+        spool=spool,
+    )
     data_columns = [c for c in ok_df.columns if c != _STATUS_COL] if not ok_df.empty else []
-    nonok_df = _materialise_nonok(nonok_entries, data_columns=data_columns)
+    nonok_df = _materialise_nonok(
+        nonok_entries,
+        data_columns=data_columns,
+        secondary_index=secondary_index,
+        index_names=index_names,
+    )
 
     parts = [df for df in (ok_df, nonok_df) if not df.empty]
     if not parts:
-        return _empty_frame()
+        return _empty_frame(secondary_index=secondary_index, index_names=index_names)
 
     return cast(pd.DataFrame, pd.concat(parts, axis=0).sort_index())
 
@@ -117,6 +262,8 @@ def lazy_multiindex(
 def _read_ok_runs(
     paths_with_run_id: Sequence[tuple[Path, int]],
     *,
+    secondary_index: str,
+    index_names: tuple[str, str],
     spool: bool,
 ) -> pd.DataFrame:
     if not paths_with_run_id:
@@ -141,24 +288,34 @@ def _read_ok_runs(
             table = fragment.to_table()
             frames.append(_batch_to_pandas(table, run_id))
 
-    if not frames:
-        return pd.DataFrame()
-
-    merged = pd.concat(frames, ignore_index=True)
-    if _TIME_COL not in merged.columns:
+    merged = pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
+    if secondary_index not in merged.columns:
         raise ValueError(
-            "per-run Parquet output is missing the 'time' column required for the "
-            "(run_id, time) MultiIndex"
+            f"per-run Parquet output is missing the {secondary_index!r} column "
+            f"required for the (run_id, {secondary_index}) MultiIndex"
         )
-    merged[_TIME_COL] = pd.to_datetime(merged[_TIME_COL]).astype("datetime64[ns]")
+    # Cast the secondary index to the per-kind canonical dtype: datetime64[ns]
+    # for time (so NaT is the missing sentinel for non-ok rows), Int64 nullable
+    # for interval_id (so pd.NA can share the same level as ok integer rows).
+    merged[secondary_index] = _coerce_secondary_index(merged[secondary_index], secondary_index)
     merged[_STATUS_COL] = "ok"
-    return cast(pd.DataFrame, merged.set_index(list(_INDEX_NAMES)))
+    return cast(pd.DataFrame, merged.set_index(list(index_names)))
+
+
+def _coerce_secondary_index(series: pd.Series, secondary_index: str) -> pd.Series:
+    # pandas-stubs overloads .astype on literal dtype strings, so the dynamic
+    # lookup on _SECONDARY_INDEX_DTYPE has to widen to Any to satisfy the
+    # checker. Runtime behaviour matches every static overload.
+    dtype: Any = _SECONDARY_INDEX_DTYPE[secondary_index]
+    if secondary_index == _TIME_COL:
+        return pd.to_datetime(series).astype(dtype)
+    return series.astype(dtype)
 
 
 def _batch_to_pandas(batch_or_table: Any, run_id: int) -> pd.DataFrame:
     n_rows = batch_or_table.num_rows
     run_id_col = pa.array([run_id] * n_rows, type=pa.int64())
-    augmented = batch_or_table.append_column("run_id", run_id_col)
+    augmented = batch_or_table.append_column(_RUN_ID_COL, run_id_col)
     return cast(pd.DataFrame, augmented.to_pandas())
 
 
@@ -166,28 +323,28 @@ def _materialise_nonok(
     entries: Sequence[ManifestEntry],
     *,
     data_columns: Sequence[str],
+    secondary_index: str,
+    index_names: tuple[str, str],
 ) -> pd.DataFrame:
     if not entries:
         return pd.DataFrame()
 
-    rows: dict[str, list[Any]] = {col: [np.nan] * len(entries) for col in data_columns}
-    rows["run_id"] = [e.run_id for e in entries]
-    rows[_TIME_COL] = [pd.NaT] * len(entries)
+    rows: dict[str, Any] = {col: [np.nan] * len(entries) for col in data_columns}
+    rows[_RUN_ID_COL] = [e.run_id for e in entries]
+    rows[secondary_index] = [_SECONDARY_INDEX_MISSING[secondary_index]] * len(entries)
     rows[_STATUS_COL] = [e.status for e in entries]
 
     df = pd.DataFrame(rows)
-    df[_TIME_COL] = pd.to_datetime(df[_TIME_COL]).astype("datetime64[ns]")
-    return cast(pd.DataFrame, df.set_index(list(_INDEX_NAMES)))
+    df[secondary_index] = _coerce_secondary_index(df[secondary_index], secondary_index)
+    return cast(pd.DataFrame, df.set_index(list(index_names)))
 
 
-def _empty_frame() -> pd.DataFrame:
+def _empty_frame(*, secondary_index: str, index_names: tuple[str, str]) -> pd.DataFrame:
+    secondary_series = pd.Series([], dtype=_SECONDARY_INDEX_DTYPE[secondary_index])
     return pd.DataFrame(
         {_STATUS_COL: pd.Series([], dtype="object")},
         index=pd.MultiIndex.from_arrays(
-            [
-                pd.Series([], dtype="int64"),
-                pd.Series([], dtype="datetime64[ns]"),
-            ],
-            names=list(_INDEX_NAMES),
+            [pd.Series([], dtype="int64"), secondary_series],
+            names=list(index_names),
         ),
     )

--- a/src/gmat_sweep/sweep.py
+++ b/src/gmat_sweep/sweep.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Any
 
 from tqdm.auto import tqdm
 
-from gmat_sweep.aggregate import lazy_multiindex
+from gmat_sweep.aggregate import lazy_contacts, lazy_ephemerides, lazy_multiindex
 from gmat_sweep.manifest import Manifest, ManifestEntry, canonical_script_sha256
 
 if TYPE_CHECKING:
@@ -140,9 +140,29 @@ class Sweep:
             raise RuntimeError("Sweep.to_manifest requires Sweep.run() to have been called")
         return self._manifest
 
-    def to_dataframe(self) -> pd.DataFrame:
-        """Aggregate the sweep's per-run Parquet outputs into one DataFrame."""
-        return lazy_multiindex(self.to_manifest(), self._output_dir)
+    def to_dataframe(self, name: str | None = None) -> pd.DataFrame:
+        """Aggregate the sweep's ``ReportFile`` outputs into one DataFrame.
+
+        ``name`` selects which report to aggregate when the sweep produced
+        multiple ``ReportFile`` resources per run; ``None`` (default) picks
+        the sole report when exactly one was produced. See
+        :func:`gmat_sweep.aggregate.lazy_multiindex` for the full contract.
+        """
+        return lazy_multiindex(self.to_manifest(), self._output_dir, name=name)
+
+    def to_ephemerides(self, name: str | None = None) -> pd.DataFrame:
+        """Aggregate the sweep's ``EphemerisFile`` outputs into one DataFrame.
+
+        See :func:`gmat_sweep.aggregate.lazy_ephemerides` for the contract.
+        """
+        return lazy_ephemerides(self.to_manifest(), self._output_dir, name=name)
+
+    def to_contacts(self, name: str | None = None) -> pd.DataFrame:
+        """Aggregate the sweep's ``ContactLocator`` outputs into one DataFrame.
+
+        See :func:`gmat_sweep.aggregate.lazy_contacts` for the contract.
+        """
+        return lazy_contacts(self.to_manifest(), self._output_dir, name=name)
 
     def _build_manifest(self) -> Manifest:
         # Local import: gmat_sweep.__init__ sets __version__ as part of module

--- a/src/gmat_sweep/worker.py
+++ b/src/gmat_sweep/worker.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import logging
 import traceback
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 import pandas as pd
@@ -39,8 +40,11 @@ def run_one(spec: RunSpec) -> RunOutcome:
     Loads the script via :class:`gmat_run.Mission`, applies every override in
     ``spec.overrides`` through the dotted-path setter, executes the mission
     with ``working_dir=spec.output_dir`` plus ``**spec.run_options``, and
-    writes each ``ReportFile`` output as a Parquet file under
-    ``spec.output_dir``. Returns :meth:`RunOutcome.ok` on success.
+    writes each ``ReportFile`` / ``EphemerisFile`` / ``ContactLocator``
+    output as a Parquet file under ``spec.output_dir`` named
+    ``<kind>__<resource_name>.parquet``. ``RunOutcome.output_paths`` is
+    keyed on the same prefixed basename so the aggregator can dispatch by
+    output kind. Returns :meth:`RunOutcome.ok` on success.
 
     Any exception raised inside the function (bootstrap failure, override
     rejection, ``GmatRunError``, Parquet write failure, …) is caught and
@@ -79,13 +83,33 @@ def run_one(spec: RunSpec) -> RunOutcome:
             mission[key] = value
         results = mission.run(working_dir=spec.output_dir, **spec.run_options)
 
-        output_paths = {}
-        for name, df in results.reports.items():
-            df = _synthesize_time_column(df)
-            parquet_path = spec.output_dir / f"{name}.parquet"
-            df.to_parquet(parquet_path)
-            output_paths[name] = parquet_path
-            logger.info("wrote report %s -> %s (%d rows)", name, parquet_path, len(df))
+        output_paths: dict[str, Path] = {}
+        for name, report_df in results.reports.items():
+            output_paths[f"report__{name}"] = _write_one(
+                spec.output_dir,
+                kind="report",
+                name=name,
+                df=_synthesize_time_column(report_df),
+                logger=logger,
+            )
+        for name, eph_df in results.ephemerides.items():
+            output_paths[f"ephemeris__{name}"] = _write_one(
+                spec.output_dir,
+                kind="ephemeris",
+                name=name,
+                df=_synthesize_time_column(eph_df),
+                logger=logger,
+            )
+        for name, con_df in results.contacts.items():
+            con_df = con_df.reset_index(drop=True).copy()
+            con_df["interval_id"] = range(len(con_df))
+            output_paths[f"contact__{name}"] = _write_one(
+                spec.output_dir,
+                kind="contact",
+                name=name,
+                df=con_df,
+                logger=logger,
+            )
 
         if results.log:
             logger.info("--- GMAT engine log ---\n%s", results.log)
@@ -115,6 +139,20 @@ def run_one(spec: RunSpec) -> RunOutcome:
     finally:
         logger.removeHandler(handler)
         handler.close()
+
+
+def _write_one(
+    output_dir: Path,
+    *,
+    kind: str,
+    name: str,
+    df: pd.DataFrame,
+    logger: logging.Logger,
+) -> Path:
+    parquet_path = output_dir / f"{kind}__{name}.parquet"
+    df.to_parquet(parquet_path)
+    logger.info("wrote %s %s -> %s (%d rows)", kind, name, parquet_path, len(df))
+    return parquet_path
 
 
 def _synthesize_time_column(df: pd.DataFrame) -> pd.DataFrame:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,8 @@ class FakeResults:
     """Stand-in for :class:`gmat_run.results.Results` — only the bits the worker reads."""
 
     reports: Mapping[str, pd.DataFrame] = field(default_factory=dict)
+    ephemerides: Mapping[str, pd.DataFrame] = field(default_factory=dict)
+    contacts: Mapping[str, pd.DataFrame] = field(default_factory=dict)
     log: str = ""
 
 

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -8,7 +8,8 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from gmat_sweep.aggregate import lazy_multiindex
+from gmat_sweep.aggregate import lazy_contacts, lazy_ephemerides, lazy_multiindex
+from gmat_sweep.errors import SweepConfigError
 from gmat_sweep.manifest import Manifest, ManifestEntry
 
 
@@ -31,12 +32,21 @@ def _make_manifest(entries: list[ManifestEntry]) -> Manifest:
     )
 
 
-def _ok_entry(run_id: int, parquet_path: Path) -> ManifestEntry:
+def _ok_entry(
+    run_id: int,
+    parquet_path: Path,
+    *,
+    key: str = "report__ReportFile1",
+    extra_paths: dict[str, Path] | None = None,
+) -> ManifestEntry:
+    paths = {key: parquet_path}
+    if extra_paths:
+        paths.update(extra_paths)
     return ManifestEntry(
         run_id=run_id,
         overrides={},
         status="ok",
-        output_paths={"ReportFile1": parquet_path},
+        output_paths=paths,
         started_at=_utc(2026, 5, 4),
         ended_at=_utc(2026, 5, 4, 0, 0, 1),
         duration_s=1.0,
@@ -59,9 +69,15 @@ def _nonok_entry(run_id: int, status: str) -> ManifestEntry:
     )
 
 
-def _write_run_parquet(output_dir: Path, run_id: int, *, n_rows: int = 3) -> Path:
-    path = output_dir / f"run-{run_id}" / "ReportFile1.parquet"
-    path.parent.mkdir(parents=True)
+def _write_run_parquet(
+    output_dir: Path,
+    run_id: int,
+    *,
+    n_rows: int = 3,
+    basename: str = "report__ReportFile1",
+) -> Path:
+    path = output_dir / f"run-{run_id}" / f"{basename}.parquet"
+    path.parent.mkdir(parents=True, exist_ok=True)
     df = pd.DataFrame(
         {
             "time": pd.to_datetime(
@@ -69,6 +85,28 @@ def _write_run_parquet(output_dir: Path, run_id: int, *, n_rows: int = 3) -> Pat
             ),
             "x": [run_id * 10 + i for i in range(n_rows)],
             "y": [run_id * 100 + i * 2 for i in range(n_rows)],
+        }
+    )
+    df.to_parquet(path)
+    return path
+
+
+def _write_contact_parquet(
+    output_dir: Path,
+    run_id: int,
+    *,
+    n_intervals: int = 2,
+    basename: str = "contact__GroundContact",
+) -> Path:
+    path = output_dir / f"run-{run_id}" / f"{basename}.parquet"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df = pd.DataFrame(
+        {
+            "Start": pd.to_datetime(
+                [f"2026-05-04T00:0{i}:00" for i in range(n_intervals)],
+            ),
+            "Duration": [60.0 + i for i in range(n_intervals)],
+            "interval_id": list(range(n_intervals)),
         }
     )
     df.to_parquet(path)
@@ -136,7 +174,7 @@ def test_lazy_multiindex_relative_paths_resolve_against_output_dir(tmp_path: Pat
         run_id=0,
         overrides={},
         status="ok",
-        output_paths={"ReportFile1": rel_path},
+        output_paths={"report__ReportFile1": rel_path},
         started_at=_utc(2026, 5, 4),
         ended_at=_utc(2026, 5, 4, 0, 0, 1),
         duration_s=1.0,
@@ -173,25 +211,44 @@ def test_lazy_multiindex_all_failed(tmp_path: Path) -> None:
 # ---- error paths ---------------------------------------------------------
 
 
-def test_lazy_multiindex_multi_report_run_raises(tmp_path: Path) -> None:
-    p1 = _write_run_parquet(tmp_path, 0, n_rows=2)
-    p2 = tmp_path / "run-0" / "ReportFile2.parquet"
-    pd.DataFrame({"time": pd.to_datetime(["2026-05-04T00:00:00"]), "x": [0]}).to_parquet(p2)
+def test_lazy_multiindex_two_reports_dispatch_via_name(tmp_path: Path) -> None:
+    # Each of 4 runs produces ReportFile1 + ReportFile2 with different schemas.
+    entries: list[ManifestEntry] = []
+    for run_id in range(4):
+        p1 = _write_run_parquet(tmp_path, run_id, n_rows=2, basename="report__ReportFile1")
+        p2 = _write_run_parquet(tmp_path, run_id, n_rows=3, basename="report__ReportFile2")
+        entries.append(
+            _ok_entry(
+                run_id,
+                p1,
+                key="report__ReportFile1",
+                extra_paths={"report__ReportFile2": p2},
+            )
+        )
+    manifest = _make_manifest(entries)
 
-    entry = ManifestEntry(
-        run_id=0,
-        overrides={},
-        status="ok",
-        output_paths={"ReportFile1": p1, "ReportFile2": p2},
-        started_at=_utc(2026, 5, 4),
-        ended_at=_utc(2026, 5, 4, 0, 0, 1),
-        duration_s=1.0,
-        stderr=None,
-        log_path=None,
-    )
+    df_a = lazy_multiindex(manifest, tmp_path, name="ReportFile1")
+    df_b = lazy_multiindex(manifest, tmp_path, name="ReportFile2")
 
-    with pytest.raises(NotImplementedError, match=r"v0\.2"):
+    assert len(df_a) == 4 * 2
+    assert len(df_b) == 4 * 3
+    assert sorted(df_a.index.get_level_values("run_id").unique().tolist()) == [0, 1, 2, 3]
+    assert sorted(df_b.index.get_level_values("run_id").unique().tolist()) == [0, 1, 2, 3]
+
+
+def test_lazy_multiindex_two_reports_name_none_raises_listing_names(tmp_path: Path) -> None:
+    p1 = _write_run_parquet(tmp_path, 0, basename="report__ReportFile1")
+    p2 = _write_run_parquet(tmp_path, 0, basename="report__ReportFile2")
+    entry = _ok_entry(0, p1, key="report__ReportFile1", extra_paths={"report__ReportFile2": p2})
+
+    with pytest.raises(SweepConfigError, match=r"ReportFile1.*ReportFile2"):
         lazy_multiindex(_make_manifest([entry]), tmp_path)
+
+
+def test_lazy_multiindex_unknown_name_raises_listing_available(tmp_path: Path) -> None:
+    p = _write_run_parquet(tmp_path, 0)
+    with pytest.raises(SweepConfigError, match=r"no report output named 'Nope'"):
+        lazy_multiindex(_make_manifest([_ok_entry(0, p)]), tmp_path, name="Nope")
 
 
 def test_lazy_multiindex_ok_entry_with_no_outputs_raises(tmp_path: Path) -> None:
@@ -212,9 +269,159 @@ def test_lazy_multiindex_ok_entry_with_no_outputs_raises(tmp_path: Path) -> None
 
 
 def test_lazy_multiindex_missing_time_column_raises(tmp_path: Path) -> None:
-    path = tmp_path / "run-0" / "ReportFile1.parquet"
+    path = tmp_path / "run-0" / "report__ReportFile1.parquet"
     path.parent.mkdir(parents=True)
     pd.DataFrame({"x": [1, 2, 3]}).to_parquet(path)
 
     with pytest.raises(ValueError, match="time"):
         lazy_multiindex(_make_manifest([_ok_entry(0, path)]), tmp_path)
+
+
+# ---- ephemeris aggregation -----------------------------------------------
+#
+# lazy_ephemerides shares the (run_id, time) index machinery with
+# lazy_multiindex; tests focus on the dispatch contract (prefix filter,
+# name= selector) rather than re-pinning the index assembly.
+
+
+def test_lazy_ephemerides_single_ephemeris_picked_automatically(tmp_path: Path) -> None:
+    paths = [_write_run_parquet(tmp_path, i, basename="ephemeris__SatEphem") for i in range(4)]
+    entries = [_ok_entry(i, p, key="ephemeris__SatEphem") for i, p in enumerate(paths)]
+
+    df = lazy_ephemerides(_make_manifest(entries), tmp_path)
+
+    assert df.index.names == ["run_id", "time"]
+    assert sorted(df.index.get_level_values("run_id").unique().tolist()) == [0, 1, 2, 3]
+    assert (df["__status"] == "ok").all()
+
+
+def test_lazy_ephemerides_name_none_raises_when_two_present(tmp_path: Path) -> None:
+    p1 = _write_run_parquet(tmp_path, 0, basename="ephemeris__SatEphem")
+    p2 = _write_run_parquet(tmp_path, 0, basename="ephemeris__GroundEphem")
+    entry = _ok_entry(0, p1, key="ephemeris__SatEphem", extra_paths={"ephemeris__GroundEphem": p2})
+
+    with pytest.raises(SweepConfigError, match=r"GroundEphem.*SatEphem"):
+        lazy_ephemerides(_make_manifest([entry]), tmp_path)
+
+
+def test_lazy_ephemerides_failed_run_materialises_as_nan_row(tmp_path: Path) -> None:
+    # 3 ok runs (with both report and ephemeris outputs) + 1 failed run.
+    entries: list[ManifestEntry] = []
+    for run_id in range(3):
+        report = _write_run_parquet(tmp_path, run_id, basename="report__R")
+        eph = _write_run_parquet(tmp_path, run_id, n_rows=2, basename="ephemeris__SatEphem")
+        entries.append(
+            _ok_entry(
+                run_id,
+                report,
+                key="report__R",
+                extra_paths={"ephemeris__SatEphem": eph},
+            )
+        )
+    entries.append(_nonok_entry(3, "failed"))
+
+    df = lazy_ephemerides(_make_manifest(entries), tmp_path)
+
+    assert len(df) == 3 * 2 + 1
+    failed_rows = df.xs(3, level="run_id")
+    assert len(failed_rows) == 1
+    assert (failed_rows["__status"] == "failed").all()
+    assert failed_rows.drop(columns=["__status"]).isna().all().all()
+
+
+def test_lazy_ephemerides_ok_run_without_ephemeris_lands_as_status_ok_nan_row(
+    tmp_path: Path,
+) -> None:
+    # Run 0 produced a report only; run 1 produced both. lazy_ephemerides should
+    # surface run 0 as one "ok" NaN row (not failed) since the run itself was
+    # successful — it just didn't produce an ephemeris.
+    p_report = _write_run_parquet(tmp_path, 0, basename="report__R")
+    p_eph_1 = _write_run_parquet(tmp_path, 1, n_rows=2, basename="ephemeris__SatEphem")
+    p_report_1 = _write_run_parquet(tmp_path, 1, basename="report__R")
+    entries = [
+        _ok_entry(0, p_report, key="report__R"),
+        _ok_entry(1, p_report_1, key="report__R", extra_paths={"ephemeris__SatEphem": p_eph_1}),
+    ]
+
+    df = lazy_ephemerides(_make_manifest(entries), tmp_path)
+
+    run_0_rows = df.xs(0, level="run_id")
+    assert len(run_0_rows) == 1
+    assert (run_0_rows["__status"] == "ok").all()
+
+
+# ---- contact aggregation ------------------------------------------------
+
+
+def test_lazy_contacts_single_contact_picked_automatically(tmp_path: Path) -> None:
+    paths = [_write_contact_parquet(tmp_path, i, n_intervals=2) for i in range(3)]
+    entries = [_ok_entry(i, p, key="contact__GroundContact") for i, p in enumerate(paths)]
+
+    df = lazy_contacts(_make_manifest(entries), tmp_path)
+
+    assert df.index.names == ["run_id", "interval_id"]
+    assert len(df) == 3 * 2
+    assert sorted(df.index.get_level_values("run_id").unique().tolist()) == [0, 1, 2]
+    assert sorted(df.xs(0, level="run_id").index.tolist()) == [0, 1]
+    assert (df["__status"] == "ok").all()
+
+
+def test_lazy_contacts_name_none_raises_when_two_present(tmp_path: Path) -> None:
+    p1 = _write_contact_parquet(tmp_path, 0, basename="contact__Ground1")
+    p2 = _write_contact_parquet(tmp_path, 0, basename="contact__Ground2")
+    entry = _ok_entry(0, p1, key="contact__Ground1", extra_paths={"contact__Ground2": p2})
+
+    with pytest.raises(SweepConfigError, match=r"Ground1.*Ground2"):
+        lazy_contacts(_make_manifest([entry]), tmp_path)
+
+
+def test_lazy_contacts_failed_run_materialises_as_nan_row_with_na_interval(
+    tmp_path: Path,
+) -> None:
+    paths = [_write_contact_parquet(tmp_path, i, n_intervals=2) for i in range(3)]
+    entries: list[ManifestEntry] = [
+        _ok_entry(i, p, key="contact__GroundContact") for i, p in enumerate(paths)
+    ]
+    entries.append(_nonok_entry(3, "failed"))
+
+    df = lazy_contacts(_make_manifest(entries), tmp_path)
+
+    assert len(df) == 3 * 2 + 1
+    failed_rows = df.xs(3, level="run_id")
+    assert len(failed_rows) == 1
+    assert (failed_rows["__status"] == "failed").all()
+    # Failed-row interval_id is pd.NA in the nullable Int64 level.
+    assert bool(pd.isna(failed_rows.index[0]))
+
+
+def test_lazy_contacts_three_kinds_aggregate_independently(tmp_path: Path) -> None:
+    # End-to-end acceptance: a sweep producing report + ephemeris + contact
+    # yields three independent multi-indexed frames.
+    entries: list[ManifestEntry] = []
+    for run_id in range(4):
+        p_report = _write_run_parquet(tmp_path, run_id, basename="report__R")
+        p_eph = _write_run_parquet(tmp_path, run_id, basename="ephemeris__E")
+        p_contact = _write_contact_parquet(tmp_path, run_id, n_intervals=2)
+        entries.append(
+            _ok_entry(
+                run_id,
+                p_report,
+                key="report__R",
+                extra_paths={
+                    "ephemeris__E": p_eph,
+                    "contact__GroundContact": p_contact,
+                },
+            )
+        )
+    manifest = _make_manifest(entries)
+
+    reports_df = lazy_multiindex(manifest, tmp_path)
+    eph_df = lazy_ephemerides(manifest, tmp_path)
+    contacts_df = lazy_contacts(manifest, tmp_path)
+
+    assert reports_df.index.names == ["run_id", "time"]
+    assert eph_df.index.names == ["run_id", "time"]
+    assert contacts_df.index.names == ["run_id", "interval_id"]
+    assert len(reports_df) == 4 * 3
+    assert len(eph_df) == 4 * 3
+    assert len(contacts_df) == 4 * 2

--- a/tests/test_param_roundtrip.py
+++ b/tests/test_param_roundtrip.py
@@ -113,7 +113,7 @@ def test_worker_applies_overrides_before_run(leo_basic_script: Path, tmp_path: P
     outcome = run_one(spec)
     assert outcome.status == "ok", outcome.stderr
 
-    df = pd.read_parquet(outcome.output_paths["RF"])
+    df = pd.read_parquet(outcome.output_paths["report__RF"])
     # The first ReportFile row is the epoch state — Sat.Earth.SMA there
     # must equal the override exactly. If the worker dropped the override
     # (e.g. applied it after run() instead of before), the value would be

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -60,11 +60,11 @@ def test_run_one_ok_writes_parquet_and_returns_ok(
     assert outcome.stderr is None
     assert outcome.duration_s >= 0
     assert outcome.started_at <= outcome.ended_at
-    assert set(outcome.output_paths) == {"R1", "R2"}
+    assert set(outcome.output_paths) == {"report__R1", "report__R2"}
 
     # Parquet round-trip.
-    pd.testing.assert_frame_equal(pd.read_parquet(outcome.output_paths["R1"]), df_a)
-    pd.testing.assert_frame_equal(pd.read_parquet(outcome.output_paths["R2"]), df_b)
+    pd.testing.assert_frame_equal(pd.read_parquet(outcome.output_paths["report__R1"]), df_a)
+    pd.testing.assert_frame_equal(pd.read_parquet(outcome.output_paths["report__R2"]), df_b)
 
     # Worker log present and contains override + engine-log lines.
     log_text = (out_dir / "worker.log").read_text(encoding="utf-8")
@@ -201,9 +201,10 @@ def test_run_one_failed_when_parquet_write_fails(
 
     out_dir = tmp_path / "run-0"
     out_dir.mkdir()
-    # Block the parquet write by pre-creating R1.parquet as a *directory* —
-    # df.to_parquet then fails with IsADirectoryError / PermissionError.
-    (out_dir / "R1.parquet").mkdir()
+    # Block the parquet write by pre-creating report__R1.parquet as a
+    # *directory* — df.to_parquet then fails with
+    # IsADirectoryError / PermissionError.
+    (out_dir / "report__R1.parquet").mkdir()
 
     outcome = run_one(_make_spec(output_dir=out_dir))
 
@@ -286,7 +287,7 @@ def test_run_one_synthesizes_time_column_from_first_datetime(
     outcome = run_one(_make_spec(output_dir=out_dir))
 
     assert outcome.status == "ok"
-    written = pd.read_parquet(outcome.output_paths["R"])
+    written = pd.read_parquet(outcome.output_paths["report__R"])
     assert "time" in written.columns
     assert "Sat.UTCGregorian" in written.columns
     pd.testing.assert_series_equal(written["time"], written["Sat.UTCGregorian"], check_names=False)
@@ -305,7 +306,7 @@ def test_run_one_leaves_existing_time_column_untouched(
     fake_gmat_run.install_loader(run_hook=_run)
     outcome = run_one(_make_spec(output_dir=tmp_path / "run-0"))
 
-    written = pd.read_parquet(outcome.output_paths["R"])
+    written = pd.read_parquet(outcome.output_paths["report__R"])
     pd.testing.assert_series_equal(
         written["time"], pd.Series(explicit_time, name="time"), check_names=False
     )
@@ -325,9 +326,92 @@ def test_run_one_with_no_datetime_columns_writes_unchanged(
     fake_gmat_run.install_loader(run_hook=_run)
     outcome = run_one(_make_spec(output_dir=tmp_path / "run-0"))
 
-    written = pd.read_parquet(outcome.output_paths["R"])
+    written = pd.read_parquet(outcome.output_paths["report__R"])
     assert "time" not in written.columns
     pd.testing.assert_frame_equal(written, df)
+
+
+# ---- ephemeris writes ---------------------------------------------------
+#
+# EphemerisFile DataFrames carry their epoch in a column named "Epoch" (OEM,
+# STK, and SPK parsers all surface it that way). The worker reuses
+# _synthesize_time_column so the same (run_id, time) aggregator works against
+# ephemeris parquets without renaming the user's columns.
+
+
+def test_run_one_writes_ephemeris_parquet_with_synthesized_time(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    eph = pd.DataFrame(
+        {
+            "Epoch": pd.to_datetime(["2026-05-04T00:00:00", "2026-05-04T00:01:00"]),
+            "X": [7000.0, 7001.0],
+        }
+    )
+
+    def _run(**_: Any) -> FakeResults:
+        return FakeResults(ephemerides={"SatEphem": eph})
+
+    fake_gmat_run.install_loader(run_hook=_run)
+    out_dir = tmp_path / "run-0"
+    outcome = run_one(_make_spec(output_dir=out_dir))
+
+    assert outcome.status == "ok"
+    assert set(outcome.output_paths) == {"ephemeris__SatEphem"}
+    written = pd.read_parquet(outcome.output_paths["ephemeris__SatEphem"])
+    assert "time" in written.columns
+    assert "Epoch" in written.columns
+    pd.testing.assert_series_equal(written["time"], written["Epoch"], check_names=False)
+
+
+# ---- contact writes -----------------------------------------------------
+#
+# ContactLocator DataFrames have variable schemas (Legacy vs. five tabular
+# variants) and are intervals, not point samples. The worker assigns a fresh
+# integer interval_id column so the contacts aggregator can use
+# (run_id, interval_id) as the MultiIndex.
+
+
+def test_run_one_writes_contact_parquet_with_interval_id(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    starts = pd.to_datetime(["2026-05-04T00:00:00", "2026-05-04T01:00:00"])
+    stops = pd.to_datetime(["2026-05-04T00:05:00", "2026-05-04T01:08:00"])
+    contact = pd.DataFrame({"Start": starts, "Stop": stops, "Observer": ["GS1", "GS1"]})
+
+    def _run(**_: Any) -> FakeResults:
+        return FakeResults(contacts={"GroundContact": contact})
+
+    fake_gmat_run.install_loader(run_hook=_run)
+    out_dir = tmp_path / "run-0"
+    outcome = run_one(_make_spec(output_dir=out_dir))
+
+    assert outcome.status == "ok"
+    assert set(outcome.output_paths) == {"contact__GroundContact"}
+    written = pd.read_parquet(outcome.output_paths["contact__GroundContact"])
+    assert list(written["interval_id"]) == [0, 1]
+    assert list(written.columns) == ["Start", "Stop", "Observer", "interval_id"]
+
+
+def test_run_one_writes_all_three_kinds_side_by_side(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    report = pd.DataFrame({"time": pd.to_datetime(["2026-05-04T00:00:00"]), "x": [1.0]})
+    eph = pd.DataFrame({"Epoch": pd.to_datetime(["2026-05-04T00:00:00"]), "X": [7000.0]})
+    contact = pd.DataFrame({"Start": pd.to_datetime(["2026-05-04T00:00:00"]), "Duration": [60.0]})
+
+    def _run(**_: Any) -> FakeResults:
+        return FakeResults(reports={"R": report}, ephemerides={"E": eph}, contacts={"C": contact})
+
+    fake_gmat_run.install_loader(run_hook=_run)
+    out_dir = tmp_path / "run-0"
+    outcome = run_one(_make_spec(output_dir=out_dir))
+
+    assert outcome.status == "ok"
+    assert set(outcome.output_paths) == {"report__R", "ephemeris__E", "contact__C"}
+    assert (out_dir / "report__R.parquet").exists()
+    assert (out_dir / "ephemeris__E.parquet").exists()
+    assert (out_dir / "contact__C.parquet").exists()
 
 
 # ---- defensive: a stale handler on the same logger does not bleed across runs ----


### PR DESCRIPTION
## Summary

- Lift the v0.1 single-Parquet-per-run guard so a sweep can produce multiple `ReportFile`, `EphemerisFile`, and `ContactLocator` outputs side by side. The worker prefixes each on-disk basename with its kind (`report__` / `ephemeris__` / `contact__`) and keys `output_paths` the same way so the aggregator can dispatch by output kind without reading the file.
- New entry points `lazy_ephemerides` and `lazy_contacts` mirror `lazy_multiindex` against the new prefixes and a parameterised secondary index level — `(run_id, time)` for reports and ephemerides, `(run_id, interval_id)` for contacts. Each accepts `name=None` when the sweep produced exactly one output of that kind, else raises `SweepConfigError` listing the available names. Failed/skipped runs (and ok runs that did not produce the requested kind) still surface as one NaN row per run carrying `__status`.
- `Sweep.to_dataframe(name=...)`, `Sweep.to_ephemerides(name=...)`, and `Sweep.to_contacts(name=...)` thread the manifest binding for the common case.

**Breaking change**: v0.1 manifests are not readable by v0.2 aggregators (the on-disk per-run filename layout changed). Re-run any sweep you need to re-aggregate. Documented in `docs/aggregation.md`.

## Test plan

- [x] `uv run pytest` — 246 passed, 19 deselected
- [x] `uv run ruff check`
- [x] `uv run ruff format --check`
- [x] `uv run mypy`
- [x] `uv run coverage report --include='src/gmat_sweep/aggregate.py' --fail-under=95` — aggregate.py at 100%; worker.py at 100%
- [ ] CI integration suite (real GMAT) — needs the runner; not exercised locally

Closes #32