### PR TITLE
Add explicit-row sweep variant (samples=DataFrame)

### DIFF
--- a/docs/manifest-schema.md
+++ b/docs/manifest-schema.md
@@ -54,7 +54,7 @@ report more runs than the file actually contains during and after a
 | `python_version`       | `platform.python_version()`.                                                                     |
 | `os_platform`          | `platform.platform()` — same string `gmat-run` records.                                          |
 | `sweep_seed`           | The seed passed to [`sweep(seed=...)`][gmat_sweep.sweep], or `null`. Reserved for v0.2 Monte Carlo runs. |
-| `parameter_spec`       | The materialised grid: every iterable expanded to a list, keys preserved verbatim.               |
+| `parameter_spec`       | The materialised grid for grid sweeps (every iterable expanded to a list, keys preserved verbatim) or a tagged `{"_kind": "explicit", "columns": [...], "rows": [[...]]}` object for explicit-row sweeps. See [Parameter spec](parameter-spec.md#explicit-row-sweeps). |
 | `run_count`            | The number of runs in the sweep at launch.                                                       |
 
 ### Canonical script hash

--- a/docs/parameter-spec.md
+++ b/docs/parameter-spec.md
@@ -135,6 +135,105 @@ overrides — the cartesian product of nothing has one element. Empty
 *values* (e.g. `{"a": []}`) are rejected with
 [`SweepConfigError`][gmat_sweep.SweepConfigError].
 
+## Explicit-row sweeps
+
+Pass a pre-built `pandas.DataFrame` as `samples=` instead of `grid=` when you
+want full control over which rows run. The DataFrame's columns are
+dotted-path field names, its rows are the run set, and its
+`pd.RangeIndex(start=0, …)` becomes the `run_id` axis on the result frame.
+
+```python
+import pandas as pd
+from gmat_sweep import sweep
+
+samples = pd.DataFrame(
+    {
+        "Sat.SMA": [7000.0, 7100.0, 7200.0, 7300.0],
+        "Sat.ECC": [0.001, 0.002, 0.003, 0.004],
+    }
+)
+df = sweep("mission.script", samples=samples)
+# 4 runs, run_ids 0..3, one per DataFrame row
+```
+
+`grid=` and `samples=` are **mutually exclusive** — passing both raises
+[`SweepConfigError`][gmat_sweep.SweepConfigError], and so does passing
+neither.
+
+This is the underlying primitive the upcoming `monte_carlo` and
+`latin_hypercube` wrappers build on. Until those land in v0.2 you can
+construct any sampling design yourself with
+[`scipy.stats.qmc`](https://docs.scipy.org/doc/scipy/reference/stats.qmc.html)
+and hand the result in directly.
+
+### Worked example: a 64-point Latin hypercube
+
+`scipy.stats.qmc.LatinHypercube` returns unit-cube samples; scale each
+column to its physical range with `qmc.scale`, wrap in a DataFrame, and
+pass through:
+
+```python
+import pandas as pd
+from scipy.stats import qmc
+
+from gmat_sweep import sweep
+
+# 1. Build the unit-cube design.
+sampler = qmc.LatinHypercube(d=2, seed=42)
+unit = sampler.random(n=64)  # shape (64, 2), each column ∈ [0, 1)
+
+# 2. Scale each column to its physical range.
+scaled = qmc.scale(
+    unit,
+    l_bounds=[6900.0, 0.0005],
+    u_bounds=[7400.0, 0.005],
+)
+
+# 3. Hand to sweep().
+samples = pd.DataFrame(scaled, columns=["Sat.SMA", "Sat.ECC"])
+df = sweep("mission.script", samples=samples, out="./lhs-sweep")
+```
+
+The DataFrame must have:
+
+- A default `pd.RangeIndex(start=0, stop=N)` — call `samples.reset_index(drop=True)`
+  if you sliced or filtered rows. A non-default index raises
+  [`SweepConfigError`][gmat_sweep.SweepConfigError].
+- Unique, all-`str` column names — duplicate columns would silently lose
+  data when each row is converted to an override dict.
+- No fully-NaN columns. A NaN inside a single cell is fine and is
+  forwarded to `gmat-run` as-is — `gmat-run` decides whether NaN is a
+  valid value for a given dotted path.
+
+### Manifest serialisation
+
+The manifest header records `samples` under `parameter_spec` with a
+discriminator tag so a later loader can tell sample-based sweeps apart
+from untagged grid headers:
+
+```json
+{
+  "parameter_spec": {
+    "_kind":   "explicit",
+    "columns": ["Sat.SMA", "Sat.ECC"],
+    "rows":    [[7000.0, 0.001], [7100.0, 0.002], …]
+  }
+}
+```
+
+Reconstructing the DataFrame after the fact is one line:
+
+```python
+from gmat_sweep import Manifest
+
+m = Manifest.load("./lhs-sweep/manifest.jsonl")
+samples = pd.DataFrame(m.parameter_spec["rows"], columns=m.parameter_spec["columns"])
+```
+
+Grid sweeps continue to use the untagged
+`{"<dotted-path>": [values, …], …}` header shape — the discriminator only
+appears on explicit-row sweeps.
+
 ## CLI mini-grammar
 
 The `gmat-sweep run` CLI accepts the same grids via repeated `--grid`

--- a/src/gmat_sweep/__init__.py
+++ b/src/gmat_sweep/__init__.py
@@ -13,7 +13,11 @@ from gmat_sweep.errors import (
     RunFailed,
     SweepConfigError,
 )
-from gmat_sweep.grids import expand_grid_to_run_specs, full_factorial
+from gmat_sweep.grids import (
+    expand_grid_to_run_specs,
+    expand_samples_to_run_specs,
+    full_factorial,
+)
 from gmat_sweep.manifest import Manifest, ManifestEntry, canonical_script_sha256
 from gmat_sweep.spec import RunOutcome, RunSpec, SweepSpec
 from gmat_sweep.sweep import Sweep
@@ -48,6 +52,7 @@ __all__ = [
     "__version__",
     "canonical_script_sha256",
     "expand_grid_to_run_specs",
+    "expand_samples_to_run_specs",
     "full_factorial",
     "lazy_contacts",
     "lazy_ephemerides",

--- a/src/gmat_sweep/api.py
+++ b/src/gmat_sweep/api.py
@@ -1,9 +1,4 @@
-"""Public entry points: sweep, monte_carlo, latin_hypercube.
-
-v0.1 ships :func:`sweep` only — the full-factorial grid path and the
-explicit-row DataFrame path. The Monte Carlo and Latin hypercube wrappers
-land in v0.2 alongside :mod:`gmat_sweep.distributions`.
-"""
+"""Public entry points: sweep, monte_carlo, latin_hypercube."""
 
 from __future__ import annotations
 

--- a/src/gmat_sweep/api.py
+++ b/src/gmat_sweep/api.py
@@ -1,8 +1,8 @@
 """Public entry points: sweep, monte_carlo, latin_hypercube.
 
-v0.1 ships :func:`sweep` only — the full-factorial parameter-grid path. The
-Monte Carlo and Latin hypercube wrappers land in v0.2 alongside
-:mod:`gmat_sweep.distributions`.
+v0.1 ships :func:`sweep` only — the full-factorial grid path and the
+explicit-row DataFrame path. The Monte Carlo and Latin hypercube wrappers
+land in v0.2 alongside :mod:`gmat_sweep.distributions`.
 """
 
 from __future__ import annotations
@@ -14,7 +14,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from gmat_sweep.backends.joblib import LocalJoblibPool
-from gmat_sweep.grids import expand_grid_to_run_specs
+from gmat_sweep.errors import SweepConfigError
+from gmat_sweep.grids import expand_grid_to_run_specs, expand_samples_to_run_specs
 from gmat_sweep.sweep import Sweep
 
 if TYPE_CHECKING:
@@ -31,19 +32,22 @@ _MANIFEST_FILENAME = "manifest.jsonl"
 def sweep(
     mission: str | Path,
     *,
-    grid: Mapping[str, Iterable[Any]],
+    grid: Mapping[str, Iterable[Any]] | None = None,
+    samples: pd.DataFrame | None = None,
     workers: int = -1,
     out: Path | None = None,
     seed: int | None = None,
     progress: bool = True,
 ) -> pd.DataFrame:
-    """Run a full-factorial parameter sweep over a GMAT mission.
+    """Run a parameter sweep over a GMAT mission.
 
-    Builds the cartesian product of ``grid`` into one :class:`RunSpec` per
-    combination, dispatches them through a fresh :class:`LocalJoblibPool`,
-    appends each completion to a JSON Lines manifest under ``out``, and
-    returns the aggregated ``(run_id, time)``-MultiIndexed
-    :class:`pandas.DataFrame`.
+    Two mutually exclusive run-set shapes are accepted: pass ``grid=`` for a
+    full-factorial cartesian product, or ``samples=`` for an explicit
+    pre-built DataFrame (one run per row, columns are dotted-path field
+    names). Exactly one must be provided. The expanded run set is dispatched
+    through a fresh :class:`LocalJoblibPool`, each completion is appended to
+    a JSON Lines manifest under ``out``, and the aggregated
+    ``(run_id, time)``-MultiIndexed :class:`pandas.DataFrame` is returned.
 
     Parameters
     ----------
@@ -52,7 +56,14 @@ def sweep(
     grid:
         Mapping from dotted-path field name (e.g. ``"Sat.SMA"``) to the
         sequence of values to sweep. Iterables are materialised once at call
-        time so callers may pass generators.
+        time so callers may pass generators. Mutually exclusive with
+        ``samples``.
+    samples:
+        :class:`pandas.DataFrame` whose columns are dotted-path field names
+        and whose rows are the run set. The default :class:`pandas.RangeIndex`
+        becomes ``run_id``; non-default indices raise. Mutually exclusive with
+        ``grid``. Use this when you have already built a sample design (Latin
+        hypercube, Halton/Sobol, custom) and want to hand it in directly.
     workers:
         Number of subprocess workers. ``-1`` (default) uses every available
         core; positive integers cap the pool. Forwarded to
@@ -80,14 +91,19 @@ def sweep(
         :func:`gmat_sweep.aggregate.lazy_multiindex`. Failed and skipped runs
         appear as one NaN-filled row with ``__status`` set accordingly — a
         single bad run does not abort the sweep or raise from this call.
-    """
-    mission_path = Path(mission)
 
-    # Materialise grid values once: expand_grid_to_run_specs would do it for
-    # the cartesian product, but we also need the materialised dict for the
-    # manifest header (generators don't survive json.dumps), so do it up
-    # front and reuse the same object.
-    materialised_grid: dict[str, list[Any]] = {k: list(v) for k, v in grid.items()}
+    Raises
+    ------
+    SweepConfigError
+        If both ``grid`` and ``samples`` are passed, if neither is passed, or
+        if either argument fails its own structural validation.
+    """
+    if grid is not None and samples is not None:
+        raise SweepConfigError("sweep() accepts either grid= or samples=, not both")
+    if grid is None and samples is None:
+        raise SweepConfigError("sweep() requires one of grid= or samples=")
+
+    mission_path = Path(mission)
 
     tempdir: tempfile.TemporaryDirectory[str] | None
     if out is None:
@@ -98,7 +114,28 @@ def sweep(
         output_dir = Path(out)
         output_dir.mkdir(parents=True, exist_ok=True)
 
-    runs = expand_grid_to_run_specs(materialised_grid, mission_path, output_dir)
+    parameter_spec: dict[str, Any]
+    if grid is not None:
+        # Materialise grid values once: expand_grid_to_run_specs would do it
+        # for the cartesian product, but we also need the materialised dict
+        # for the manifest header (generators don't survive json.dumps), so
+        # do it up front and reuse the same object.
+        materialised_grid: dict[str, list[Any]] = {k: list(v) for k, v in grid.items()}
+        runs = expand_grid_to_run_specs(materialised_grid, mission_path, output_dir)
+        parameter_spec = materialised_grid
+    else:
+        assert samples is not None  # narrowed by the XOR check above
+        runs = expand_samples_to_run_specs(samples, mission_path, output_dir)
+        # Tagged shape lets Manifest.load distinguish explicit-row sweeps from
+        # untagged grid headers without breaking back-compat with v0.1 grid
+        # manifests already on disk. ``rows`` is a list-of-lists in column
+        # order so the round-trip is a one-line pd.DataFrame(...) call.
+        parameter_spec = {
+            "_kind": "explicit",
+            "columns": [str(c) for c in samples.columns],
+            "rows": samples.values.tolist(),
+        }
+
     manifest_path = output_dir / _MANIFEST_FILENAME
 
     with LocalJoblibPool(workers=workers) as pool:
@@ -109,7 +146,7 @@ def sweep(
                 manifest_path=manifest_path,
                 output_dir=output_dir,
                 script_path=mission_path,
-                parameter_spec=materialised_grid,
+                parameter_spec=parameter_spec,
                 sweep_seed=seed,
                 progress=progress,
             )

--- a/src/gmat_sweep/grids.py
+++ b/src/gmat_sweep/grids.py
@@ -1,8 +1,5 @@
 """Full-factorial, explicit-row, Latin hypercube, and quasi-Monte-Carlo run generators.
 
-v0.1 ships the full-factorial generator and the explicit-row expander; Latin
-hypercube and quasi-Monte-Carlo samplers land in v0.2.
-
 The output of :func:`full_factorial` is byte-for-byte deterministic: keys are
 emitted in sorted (lexicographic) order and combinations enumerate in
 :func:`itertools.product` order over the materialised input iterables. This is

--- a/src/gmat_sweep/grids.py
+++ b/src/gmat_sweep/grids.py
@@ -1,7 +1,7 @@
 """Full-factorial, explicit-row, Latin hypercube, and quasi-Monte-Carlo run generators.
 
-v0.1 ships the full-factorial generator only; explicit-row and Latin hypercube
-land in v0.2.
+v0.1 ships the full-factorial generator and the explicit-row expander; Latin
+hypercube and quasi-Monte-Carlo samplers land in v0.2.
 
 The output of :func:`full_factorial` is byte-for-byte deterministic: keys are
 emitted in sorted (lexicographic) order and combinations enumerate in
@@ -16,12 +16,19 @@ from __future__ import annotations
 from collections.abc import Iterable, Iterator, Mapping
 from itertools import product
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from gmat_sweep.errors import SweepConfigError
 from gmat_sweep.spec import RunSpec
 
-__all__ = ["expand_grid_to_run_specs", "full_factorial"]
+if TYPE_CHECKING:
+    import pandas as pd
+
+__all__ = [
+    "expand_grid_to_run_specs",
+    "expand_samples_to_run_specs",
+    "full_factorial",
+]
 
 
 def full_factorial(grid: Mapping[str, Iterable[Any]]) -> Iterator[dict[str, Any]]:
@@ -85,4 +92,82 @@ def expand_grid_to_run_specs(
             run_options={},
         )
         for run_id, overrides in enumerate(full_factorial(grid))
+    ]
+
+
+def expand_samples_to_run_specs(
+    samples: pd.DataFrame,
+    script_path: str | Path,
+    output_dir: str | Path,
+) -> list[RunSpec]:
+    """Build a list of :class:`RunSpec` from an explicit-row sample DataFrame.
+
+    Each row becomes one :class:`RunSpec` with ``overrides = row.to_dict()``,
+    ``run_id`` equal to the row's positional index, ``output_dir`` set to
+    ``<output_dir>/run-<run_id>``, ``seed=None``, and ``run_options={}``. The
+    DataFrame's column names are dotted-path field names — the same shape
+    :func:`expand_grid_to_run_specs` already produces — so analysts may
+    pre-build any sampling design (Latin hypercube, Halton/Sobol, custom)
+    themselves and hand the result in directly.
+
+    Per-cell NaN is forwarded as-is. ``gmat-run`` is the line that decides
+    whether NaN is a valid value for a given dotted path; this expander does
+    not second-guess it.
+
+    Validation is strict and runs before any spec is built:
+
+    - ``samples`` must be a :class:`pandas.DataFrame`.
+    - All column names must be :class:`str` instances.
+    - Column names must be unique — duplicates would silently lose data when
+      :meth:`pandas.Series.to_dict` collapses them into a single key.
+    - The DataFrame index must equal :class:`pandas.RangeIndex(start=0,
+      stop=len(samples))` so ``run_id`` and the row's positional index agree.
+    - No column may be entirely NaN (an all-NaN axis carries no signal).
+
+    Any violation raises :class:`SweepConfigError` with a message naming the
+    offending column or index.
+    """
+    import pandas as pd
+
+    if not isinstance(samples, pd.DataFrame):
+        raise SweepConfigError(f"samples must be a pandas.DataFrame, got {type(samples).__name__}")
+
+    non_string_cols = [c for c in samples.columns if not isinstance(c, str)]
+    if non_string_cols:
+        raise SweepConfigError(
+            f"samples column names must be strings, got non-string columns: {non_string_cols!r}"
+        )
+
+    duplicates = samples.columns[samples.columns.duplicated()].unique().tolist()
+    if duplicates:
+        raise SweepConfigError(f"samples has duplicate column names: {duplicates!r}")
+
+    expected_index = pd.RangeIndex(start=0, stop=len(samples))
+    if not samples.index.equals(expected_index):
+        raise SweepConfigError(
+            "samples index must be a default RangeIndex starting at 0; "
+            f"got {samples.index!r}. Call .reset_index(drop=True) first."
+        )
+
+    # Guard the all-NaN check on len > 0: .isna().all() is vacuously True on
+    # zero-length columns, which would reject every empty DataFrame with a
+    # misleading message.
+    if len(samples) > 0:
+        all_nan_cols = [c for c in samples.columns if samples[c].isna().all()]
+        if all_nan_cols:
+            raise SweepConfigError(f"samples has all-NaN columns: {all_nan_cols!r}")
+
+    script_path_obj = Path(script_path)
+    base_output_dir = Path(output_dir)
+    records = samples.to_dict(orient="records")
+    return [
+        RunSpec(
+            script_path=script_path_obj,
+            overrides={str(k): v for k, v in record.items()},
+            output_dir=base_output_dir / f"run-{run_id}",
+            run_id=run_id,
+            seed=None,
+            run_options={},
+        )
+        for run_id, record in enumerate(records)
     ]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,6 +10,7 @@ import pandas as pd
 import pytest
 
 from gmat_sweep.api import sweep
+from gmat_sweep.errors import SweepConfigError
 from gmat_sweep.manifest import Manifest
 from tests.conftest import FakeGmatRun, FakeResults
 
@@ -232,3 +233,125 @@ def test_gmat_sweep_logger_default_level_is_warning() -> None:
     import logging
 
     assert logging.getLogger("gmat_sweep").level == logging.WARNING
+
+
+# ---- explicit-row sweep (samples=DataFrame) ------------------------------
+
+
+def test_sweep_with_samples_returns_one_run_per_row(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    """Issue #34 headline acceptance: a 4-row DataFrame produces a sweep
+    result whose ``run_id`` cardinality is 4 and whose per-row override is
+    applied (verified by reading the override back via the fake setitem
+    hook)."""
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+
+    seen: list[tuple[str, Any]] = []
+
+    def _setitem(key: str, value: Any) -> None:
+        seen.append((key, value))
+
+    fake_gmat_run.install_loader(setitem_hook=_setitem, run_hook=_payload_run_hook())
+
+    samples = pd.DataFrame({"Sat.SMA": [7000, 7100, 7200, 7300]})
+    df = sweep(script, samples=samples, workers=1, out=out)
+
+    run_ids = sorted(df.index.get_level_values("run_id").unique().tolist())
+    assert run_ids == [0, 1, 2, 3]
+    # Worker side saw the per-row override applied to the live mission.
+    assert ("Sat.SMA", 7000) in seen
+    assert ("Sat.SMA", 7100) in seen
+    assert ("Sat.SMA", 7200) in seen
+    assert ("Sat.SMA", 7300) in seen
+
+
+def test_sweep_with_both_grid_and_samples_raises(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    script = _write_script(tmp_path)
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    with pytest.raises(SweepConfigError, match="not both"):
+        sweep(
+            script,
+            grid={"Sat.SMA": [7000.0]},
+            samples=pd.DataFrame({"Sat.SMA": [7000.0]}),
+            workers=1,
+            out=tmp_path / "out",
+        )
+
+
+def test_sweep_with_neither_grid_nor_samples_raises(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    script = _write_script(tmp_path)
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    with pytest.raises(SweepConfigError, match="one of grid= or samples="):
+        sweep(script, workers=1, out=tmp_path / "out")
+
+
+def test_sweep_with_samples_non_default_index_raises(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    script = _write_script(tmp_path)
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    samples = pd.DataFrame(
+        {"Sat.SMA": [7000.0, 7100.0, 7200.0, 7300.0]},
+        index=pd.RangeIndex(10, 14),
+    )
+    with pytest.raises(SweepConfigError, match="default RangeIndex"):
+        sweep(script, samples=samples, workers=1, out=tmp_path / "out")
+
+
+def test_sweep_with_samples_writes_explicit_kind_in_manifest(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    """Manifest tags the parameter_spec with ``_kind: "explicit"`` so a
+    later loader can distinguish a sample-based sweep from an untagged grid
+    header."""
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    samples = pd.DataFrame(
+        {
+            "Sat.SMA": [7000.0, 7100.0],
+            "Sat.ECC": [0.001, 0.002],
+        }
+    )
+    sweep(script, samples=samples, workers=1, out=out)
+
+    manifest = Manifest.load(out / "manifest.jsonl")
+    spec = manifest.parameter_spec
+    assert spec["_kind"] == "explicit"
+    assert spec["columns"] == ["Sat.SMA", "Sat.ECC"]
+    assert spec["rows"] == [[7000.0, 0.001], [7100.0, 0.002]]
+
+
+def test_sweep_with_samples_manifest_round_trips_to_dataframe(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    """Manifest.load(saved).parameter_spec reconstructs a DataFrame whose
+    contents equal the input — the round-trip acceptance criterion."""
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    samples = pd.DataFrame(
+        {
+            "Sat.SMA": [7000.0, 7100.0, 7200.0],
+            "Sat.ECC": [0.001, 0.002, 0.003],
+        }
+    )
+    sweep(script, samples=samples, workers=1, out=out)
+
+    manifest = Manifest.load(out / "manifest.jsonl")
+    spec = manifest.parameter_spec
+    reconstructed = pd.DataFrame(spec["rows"], columns=spec["columns"])
+    pd.testing.assert_frame_equal(reconstructed, samples)

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -1,15 +1,21 @@
-"""Tests for gmat_sweep.grids — full-factorial cartesian-product expansion."""
+"""Tests for gmat_sweep.grids — full-factorial and explicit-row run-spec expansion."""
 
 from __future__ import annotations
 
 import json
+import math
 from pathlib import Path
 from typing import Any
 
+import pandas as pd
 import pytest
 
 from gmat_sweep.errors import SweepConfigError
-from gmat_sweep.grids import expand_grid_to_run_specs, full_factorial
+from gmat_sweep.grids import (
+    expand_grid_to_run_specs,
+    expand_samples_to_run_specs,
+    full_factorial,
+)
 from gmat_sweep.spec import RunSpec
 
 # ---- full_factorial -------------------------------------------------------
@@ -183,6 +189,142 @@ def test_expand_output_round_trips_through_runspec_to_dict() -> None:
         script_path="/m.script",
         output_dir="/o",
     )
+    serialised = json.dumps([s.to_dict() for s in specs], sort_keys=True)
+    restored = [RunSpec.from_dict(d) for d in json.loads(serialised)]
+    assert restored == specs
+
+
+# ---- expand_samples_to_run_specs -----------------------------------------
+
+
+def test_expand_samples_acceptance_four_row_dataframe() -> None:
+    """The issue's headline acceptance: a 4-row DataFrame yields 4 specs with
+    sequential run_ids and the per-row override applied."""
+    samples = pd.DataFrame({"Sat.SMA": [7000, 7100, 7200, 7300]})
+    specs = expand_samples_to_run_specs(
+        samples,
+        script_path="/m.script",
+        output_dir="/o",
+    )
+    assert [s.run_id for s in specs] == [0, 1, 2, 3]
+    assert [s.overrides for s in specs] == [
+        {"Sat.SMA": 7000},
+        {"Sat.SMA": 7100},
+        {"Sat.SMA": 7200},
+        {"Sat.SMA": 7300},
+    ]
+
+
+def test_expand_samples_packs_script_path_output_dir_seed_and_run_options() -> None:
+    samples = pd.DataFrame({"x": [1, 2]})
+    specs = expand_samples_to_run_specs(
+        samples,
+        script_path=Path("/missions/m.script"),
+        output_dir=Path("/sweep-out"),
+    )
+    assert len(specs) == 2
+    for spec, expected_id in zip(specs, (0, 1), strict=True):
+        assert isinstance(spec, RunSpec)
+        assert spec.script_path == Path("/missions/m.script")
+        assert spec.output_dir == Path(f"/sweep-out/run-{expected_id}")
+        assert spec.seed is None
+        assert spec.run_options == {}
+
+
+def test_expand_samples_accepts_string_paths() -> None:
+    samples = pd.DataFrame({"x": [1]})
+    specs = expand_samples_to_run_specs(
+        samples,
+        script_path="/missions/m.script",
+        output_dir="/out",
+    )
+    assert specs[0].script_path == Path("/missions/m.script")
+    assert specs[0].output_dir == Path("/out/run-0")
+
+
+def test_expand_samples_multiple_columns_preserves_row_overrides() -> None:
+    samples = pd.DataFrame(
+        {
+            "Sat.SMA": [7000.0, 7100.0],
+            "Sat.ECC": [0.001, 0.002],
+        }
+    )
+    specs = expand_samples_to_run_specs(samples, "/m.script", "/o")
+    assert specs[0].overrides == {"Sat.SMA": 7000.0, "Sat.ECC": 0.001}
+    assert specs[1].overrides == {"Sat.SMA": 7100.0, "Sat.ECC": 0.002}
+
+
+def test_expand_samples_empty_dataframe_yields_zero_specs() -> None:
+    """Empty DataFrame is degenerate but valid: 0 rows → 0 specs. The
+    all-NaN check is skipped because ``.isna().all()`` is vacuously true
+    on a zero-length column."""
+    samples = pd.DataFrame({"x": pd.Series([], dtype=float)})
+    specs = expand_samples_to_run_specs(samples, "/m.script", "/o")
+    assert specs == []
+
+
+def test_expand_samples_rejects_non_dataframe() -> None:
+    with pytest.raises(SweepConfigError, match=r"must be a pandas\.DataFrame"):
+        expand_samples_to_run_specs(
+            {"x": [1, 2]},  # type: ignore[arg-type]
+            "/m.script",
+            "/o",
+        )
+
+
+def test_expand_samples_rejects_non_string_columns() -> None:
+    samples = pd.DataFrame([[1, 2]], columns=[0, 1])
+    with pytest.raises(SweepConfigError, match="column names must be strings"):
+        expand_samples_to_run_specs(samples, "/m.script", "/o")
+
+
+def test_expand_samples_rejects_duplicate_columns() -> None:
+    samples = pd.DataFrame([[1, 2], [3, 4]], columns=["a", "a"])
+    with pytest.raises(SweepConfigError, match="duplicate column names"):
+        expand_samples_to_run_specs(samples, "/m.script", "/o")
+
+
+def test_expand_samples_rejects_non_default_index() -> None:
+    samples = pd.DataFrame({"x": [1, 2, 3, 4]}, index=pd.RangeIndex(10, 14))
+    with pytest.raises(SweepConfigError, match="default RangeIndex"):
+        expand_samples_to_run_specs(samples, "/m.script", "/o")
+
+
+def test_expand_samples_rejects_string_index() -> None:
+    samples = pd.DataFrame({"x": [1, 2]}, index=["a", "b"])
+    with pytest.raises(SweepConfigError, match="default RangeIndex"):
+        expand_samples_to_run_specs(samples, "/m.script", "/o")
+
+
+def test_expand_samples_rejects_all_nan_column() -> None:
+    samples = pd.DataFrame(
+        {
+            "Sat.SMA": [7000.0, 7100.0],
+            "Sat.Dead": [float("nan"), float("nan")],
+        }
+    )
+    with pytest.raises(SweepConfigError, match="all-NaN columns"):
+        expand_samples_to_run_specs(samples, "/m.script", "/o")
+
+
+def test_expand_samples_per_cell_nan_is_forwarded() -> None:
+    """Per-cell NaN passes through unchanged — gmat-run is the line that
+    decides whether NaN is a valid value for a given dotted path. The
+    expander stays out of the way."""
+    samples = pd.DataFrame(
+        {
+            "Sat.SMA": [7000.0, float("nan"), 7200.0],
+        }
+    )
+    specs = expand_samples_to_run_specs(samples, "/m.script", "/o")
+    assert specs[0].overrides == {"Sat.SMA": 7000.0}
+    assert math.isnan(specs[1].overrides["Sat.SMA"])
+    assert specs[2].overrides == {"Sat.SMA": 7200.0}
+
+
+def test_expand_samples_runspec_round_trips_through_to_dict() -> None:
+    samples = pd.DataFrame({"a": [1, 2], "b": [10.0, 20.0]})
+    specs = expand_samples_to_run_specs(samples, "/m.script", "/o")
     serialised = json.dumps([s.to_dict() for s in specs], sort_keys=True)
     restored = [RunSpec.from_dict(d) for d in json.loads(serialised)]
     assert restored == specs


### PR DESCRIPTION
## Summary

- Adds a `sweep(samples=DataFrame)` path next to the existing `grid=` path. The DataFrame's columns are dotted-path parameter names; one row per run, `run_id` = row index position. This is the primitive `monte_carlo` (#33) and `latin_hypercube` (#35) will sit on top of.
- New `expand_samples_to_run_specs()` in `grids.py` does strict up-front validation (DataFrame-typed, `str` column names, unique columns, default `RangeIndex`, no all-NaN columns). Per-cell NaN passes through unchanged — `gmat-run` is the line that decides whether NaN is valid for a given dotted path.
- `grid=` and `samples=` are mutually exclusive: both → `SweepConfigError`, neither → `SweepConfigError`.
- Manifest `parameter_spec` gains a discriminator: explicit-row sweeps emit `{"_kind": "explicit", "columns": [...], "rows": [[...]]}`; grid sweeps keep the existing untagged shape, so v0.1 manifests already on disk still load with no migration.
- `docs/parameter-spec.md` gets an "Explicit-row sweeps" section with a worked `scipy.stats.qmc.LatinHypercube` example and a manifest round-trip note.

## Test plan

- [x] `uv run pytest` — 265 passed, 19 deselected (integration).
- [x] `uv run ruff check` — clean.
- [x] `uv run ruff format --check` — clean.
- [x] `uv run mypy` — clean.
- [x] Coverage: `api.py` 100%, `grids.py` 100% (issue's ≥90% bar; CONTRIBUTING's ≥95% on `grids.py`).
- [x] CI on Ubuntu + Windows × 3.10 / 3.11 / 3.12 × R2025a / R2026a.

Closes #34