### PR TITLE
Add monte_carlo() and latin_hypercube() public APIs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -8,6 +8,10 @@ auto-generated from docstrings via
 
 ::: gmat_sweep.sweep
 
+::: gmat_sweep.monte_carlo
+
+::: gmat_sweep.latin_hypercube
+
 ::: gmat_sweep.Sweep
 
 ## Execution backend

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,12 +28,34 @@ GMAT subprocess per run, and returns a `(run_id, time)`-MultiIndexed
 DataFrame with one row per (run, time-step) pair plus a `__status` column
 flagging `ok` / `failed` / `skipped` runs.
 
+For stochastic studies — launch dispersions, sensitivity analyses,
+margin sweeps — reach for [`monte_carlo()`][gmat_sweep.monte_carlo] or
+[`latin_hypercube()`][gmat_sweep.latin_hypercube]. They take the same
+mission script and a `perturb` mapping of named distributions, and
+return the same DataFrame shape:
+
+```python
+from gmat_sweep import monte_carlo
+
+df = monte_carlo(
+    "mission.script",
+    n=500,
+    perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
+    seed=42,
+)
+```
+
+See [Monte Carlo](monte-carlo.md) for the determinism and
+order-independence contracts.
+
 ## Where to go next
 
 - **[Getting started](getting-started.md)** — install and the four-line
   vision snippet.
 - **[Parameter spec](parameter-spec.md)** — how grids, dotted-path overrides,
   and the CLI's mini-grammar work.
+- **[Monte Carlo](monte-carlo.md)** — stochastic dispersion sweeps with
+  named distributions and a determinism contract.
 - **[Manifest schema](manifest-schema.md)** — the JSON Lines manifest each
   sweep writes alongside its outputs.
 - **[Supported versions](supported-versions.md)** — GMAT × Python × OS matrix.

--- a/docs/monte-carlo.md
+++ b/docs/monte-carlo.md
@@ -1,0 +1,148 @@
+# Monte Carlo
+
+[`monte_carlo()`][gmat_sweep.monte_carlo] runs a stochastic dispersion sweep
+over a GMAT mission: each parameter is drawn from its own distribution, and
+the same `(n, perturb, seed)` reproduces the same draws bit-for-bit on any
+machine.
+
+```python
+from gmat_sweep import monte_carlo
+
+df = monte_carlo(
+    "mission.script",
+    n=100,
+    perturb={
+        "Sat.SMA": ("normal", 7100.0, 50.0),
+        "Sat.INC": ("uniform", 0.0, 90.0),
+    },
+    seed=42,
+)
+```
+
+That call spawns 100 runs, samples one value per `perturb` entry per run,
+and returns a `(run_id, time)`-MultiIndexed DataFrame containing every
+run's `ReportFile` rows plus a `__status` column flagging
+`ok` / `failed` / `skipped`.
+
+## Distribution specs
+
+The `perturb` mapping accepts the same shapes as the rest of the
+stochastic-sweep surface — see
+[Parameter spec → Stochastic specs](parameter-spec.md#stochastic-specs)
+for the full table. The shorthands cover the cases that come up day-to-day
+in dispersion analyses; reach for a pre-frozen
+[`scipy.stats`](https://docs.scipy.org/doc/scipy/reference/stats.html) rv
+when you need a different shape:
+
+```python
+import math
+from scipy import stats
+
+monte_carlo(
+    "mission.script",
+    n=500,
+    perturb={
+        "Sat.SMA":      ("normal", 7100.0, 50.0),
+        "Sat.DryMass":  ("lognormal", math.log(100.0), 0.05),
+        "Sat.RAAN":     ("uniform", 0.0, 360.0),
+        "Sat.INC":      stats.truncnorm(a=-2, b=2, loc=0.0, scale=10.0),
+    },
+    seed=42,
+)
+```
+
+## Determinism contract
+
+Two `monte_carlo(..., seed=42)` calls with the same `n`, the same
+`perturb`, and the same script produce DataFrames whose recorded per-run
+overrides are identical at every `run_id`. Two calls at `seed=42` and
+`seed=43` produce different draws.
+
+The contract is process-independent — the per-run sub-seeds come from
+[`numpy.random.SeedSequence`][gmat_sweep.distributions.derive_run_seeds],
+so a fresh Python process given the same inputs reconstructs the same
+draws.
+
+`seed=None` falls back to OS entropy and is **not** reproducible.
+
+## Order independence
+
+Adding a perturbed parameter to an existing `perturb` dict does not change
+the draws of any other parameter at any `run_id` — regardless of where
+the new parameter falls in lexicographic order. Per-parameter sub-seeds
+are derived from the parameter *name*, not its position in the mapping:
+
+```python
+# First sweep: one perturbed axis.
+df_one = monte_carlo("mission.script", n=20, seed=42, perturb={
+    "Sat.SMA": ("normal", 7100.0, 50.0),
+})
+
+# Add a second axis whose name sorts BEFORE Sat.SMA.
+df_two = monte_carlo("mission.script", n=20, seed=42, perturb={
+    "Aaa.X":   ("uniform", 0.0, 1.0),
+    "Sat.SMA": ("normal", 7100.0, 50.0),
+})
+
+# Sat.SMA's draw at every run_id is unchanged.
+```
+
+This matters when an analysis grows: extending a 1-D `perturb` to a 4-D
+one mid-investigation should not invalidate the 1-D results.
+
+## Worked example: launch dispersion
+
+A typical injection-error analysis perturbs the post-burn state vector
+around its nominal value and asks how the final orbit's miss distance
+distributes:
+
+```python
+import math
+import pandas as pd
+
+from gmat_sweep import monte_carlo
+
+df = monte_carlo(
+    "transfer_porkchop.script",
+    n=500,
+    perturb={
+        "Sat.SMA":     ("normal", 24500.0, 25.0),    # ±25 km 1-σ
+        "Sat.ECC":     ("normal", 0.7300, 1e-4),     # ±0.0001 1-σ
+        "Sat.INC":     ("normal", 28.5, 0.05),       # ±0.05° 1-σ
+        "Sat.RAAN":    ("normal", 0.0, 0.5),         # ±0.5° 1-σ
+        "Sat.DryMass": ("lognormal", math.log(1200.0), 0.02),
+    },
+    seed=20260504,
+    workers=8,
+    out="./launch-dispersion",
+)
+
+# Final-step rows of every run, joined with status.
+final = df.groupby("run_id").tail(1).reset_index()
+print(final[["run_id", "MissDistance", "__status"]].describe())
+```
+
+The manifest at `./launch-dispersion/manifest.jsonl` records the seed and
+the `perturb` dict, so the analysis is reproducible from disk alone — see
+[Manifest schema](manifest-schema.md) for the full header layout.
+
+## Failed runs
+
+A run that raises during override application or mission execution lands
+as a single NaN-filled row with `__status="failed"` and the captured
+worker stderr in the manifest entry — same contract as
+[`sweep()`][gmat_sweep.sweep]. A bad draw never aborts the sweep:
+
+```python
+ok = df[df["__status"] == "ok"]
+failed = df[df["__status"] == "failed"]
+```
+
+## See also
+
+- [Parameter spec → Stochastic specs](parameter-spec.md#stochastic-specs)
+  — distribution shorthand surface and validation rules.
+- [API reference: `monte_carlo`](api.md#gmat_sweep.monte_carlo)
+- [API reference: `latin_hypercube`](api.md#gmat_sweep.latin_hypercube)
+  — stratified-sampling alternative for low-`n`, higher-dimensional
+  studies.

--- a/docs/monte-carlo.md
+++ b/docs/monte-carlo.md
@@ -59,9 +59,8 @@ overrides are identical at every `run_id`. Two calls at `seed=42` and
 `seed=43` produce different draws.
 
 The contract is process-independent — the per-run sub-seeds come from
-[`numpy.random.SeedSequence`][gmat_sweep.distributions.derive_run_seeds],
-so a fresh Python process given the same inputs reconstructs the same
-draws.
+`numpy.random.SeedSequence`, so a fresh Python process given the same
+inputs reconstructs the same draws.
 
 `seed=None` falls back to OS entropy and is **not** reproducible.
 

--- a/docs/parameter-spec.md
+++ b/docs/parameter-spec.md
@@ -110,8 +110,8 @@ from each distribution; the empirical coverage of any single axis is only
 as good as the law of large numbers makes it for the chosen `n`.
 
 [`latin_hypercube()`][gmat_sweep.latin_hypercube] uses
-[`scipy.stats.qmc.LatinHypercube`][scipy.stats.qmc.LatinHypercube] to
-stratify each axis into `n` equal-probability bins before transforming
+[`scipy.stats.qmc.LatinHypercube`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.qmc.LatinHypercube.html)
+to stratify each axis into `n` equal-probability bins before transforming
 through the distribution's quantile function. One sample per bin per axis
 is guaranteed by construction, so the marginal coverage of every axis is
 uniform at any `n`.

--- a/docs/parameter-spec.md
+++ b/docs/parameter-spec.md
@@ -103,6 +103,28 @@ Validation is strict and happens up front:
 Any violation raises [`SweepConfigError`][gmat_sweep.SweepConfigError]
 before any run starts.
 
+### Monte Carlo vs Latin hypercube
+
+[`monte_carlo()`][gmat_sweep.monte_carlo] draws each sample independently
+from each distribution; the empirical coverage of any single axis is only
+as good as the law of large numbers makes it for the chosen `n`.
+
+[`latin_hypercube()`][gmat_sweep.latin_hypercube] uses
+[`scipy.stats.qmc.LatinHypercube`][scipy.stats.qmc.LatinHypercube] to
+stratify each axis into `n` equal-probability bins before transforming
+through the distribution's quantile function. One sample per bin per axis
+is guaranteed by construction, so the marginal coverage of every axis is
+uniform at any `n`.
+
+The rule of thumb: prefer LH when `n` is small relative to the number of
+perturbed parameters (so each axis only gets a handful of samples and the
+stratification visibly improves coverage). Plain Monte Carlo is the
+right call when `n` is large, when you want the joint distribution to
+match the product of marginals exactly (no LH-induced anti-correlation),
+or when you intend to extend the sample count incrementally — LH samples
+do not append cleanly across runs the way independent Monte Carlo draws
+do.
+
 ## Full-factorial expansion
 
 [`sweep()`][gmat_sweep.sweep] uses the full-factorial expansion in
@@ -160,17 +182,40 @@ df = sweep("mission.script", samples=samples)
 [`SweepConfigError`][gmat_sweep.SweepConfigError], and so does passing
 neither.
 
-This is the underlying primitive the upcoming `monte_carlo` and
-`latin_hypercube` wrappers build on. Until those land in v0.2 you can
-construct any sampling design yourself with
-[`scipy.stats.qmc`](https://docs.scipy.org/doc/scipy/reference/stats.qmc.html)
-and hand the result in directly.
+This is the underlying primitive the [`monte_carlo`][gmat_sweep.monte_carlo]
+and [`latin_hypercube`][gmat_sweep.latin_hypercube] wrappers build on. Use
+those when you want stochastic draws from named distributions; reach for
+`samples=` directly when you have already built a custom design (Halton,
+Sobol, a hand-curated edge-case grid) and want to hand it in unchanged.
 
 ### Worked example: a 64-point Latin hypercube
 
-`scipy.stats.qmc.LatinHypercube` returns unit-cube samples; scale each
-column to its physical range with `qmc.scale`, wrap in a DataFrame, and
-pass through:
+For Latin hypercube sampling against named distributions, reach for
+[`latin_hypercube()`][gmat_sweep.latin_hypercube] directly — it builds the
+unit-cube design, maps each axis through the user's distribution, and
+delegates to the same explicit-row primitive:
+
+```python
+from gmat_sweep import latin_hypercube
+
+df = latin_hypercube(
+    "mission.script",
+    n=64,
+    perturb={
+        "Sat.SMA": ("uniform", 6900.0, 7400.0),
+        "Sat.ECC": ("uniform", 0.0005, 0.005),
+    },
+    seed=42,
+    out="./lhs-sweep",
+)
+```
+
+The wrapper records `{"_kind": "latin_hypercube", "perturb": ..., "n": ...,
+"seed": ...}` on the manifest header so the design is reproducible from
+the seed alone.
+
+If you want a different stratified design (Halton, Sobol, a custom-built
+DataFrame) hand it in via `samples=` and bypass the wrapper:
 
 ```python
 import pandas as pd
@@ -178,20 +223,11 @@ from scipy.stats import qmc
 
 from gmat_sweep import sweep
 
-# 1. Build the unit-cube design.
-sampler = qmc.LatinHypercube(d=2, seed=42)
-unit = sampler.random(n=64)  # shape (64, 2), each column ∈ [0, 1)
-
-# 2. Scale each column to its physical range.
-scaled = qmc.scale(
-    unit,
-    l_bounds=[6900.0, 0.0005],
-    u_bounds=[7400.0, 0.005],
-)
-
-# 3. Hand to sweep().
+sampler = qmc.Halton(d=2, seed=42)
+unit = sampler.random(n=64)
+scaled = qmc.scale(unit, l_bounds=[6900.0, 0.0005], u_bounds=[7400.0, 0.005])
 samples = pd.DataFrame(scaled, columns=["Sat.SMA", "Sat.ECC"])
-df = sweep("mission.script", samples=samples, out="./lhs-sweep")
+df = sweep("mission.script", samples=samples, out="./halton-sweep")
 ```
 
 The DataFrame must have:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
   - Home: index.md
   - Getting started: getting-started.md
   - Parameter spec: parameter-spec.md
+  - Monte Carlo: monte-carlo.md
   - Aggregation: aggregation.md
   - Manifest schema: manifest-schema.md
   - Supported versions: supported-versions.md

--- a/src/gmat_sweep/__init__.py
+++ b/src/gmat_sweep/__init__.py
@@ -4,7 +4,7 @@ import logging
 from importlib.metadata import PackageNotFoundError, version
 
 from gmat_sweep.aggregate import lazy_contacts, lazy_ephemerides, lazy_multiindex
-from gmat_sweep.api import sweep
+from gmat_sweep.api import latin_hypercube, monte_carlo, sweep
 from gmat_sweep.backends import Pool
 from gmat_sweep.errors import (
     BackendError,
@@ -15,8 +15,11 @@ from gmat_sweep.errors import (
 )
 from gmat_sweep.grids import (
     expand_grid_to_run_specs,
+    expand_latin_hypercube_to_run_specs,
+    expand_monte_carlo_to_run_specs,
     expand_samples_to_run_specs,
     full_factorial,
+    latin_hypercube_samples,
 )
 from gmat_sweep.manifest import Manifest, ManifestEntry, canonical_script_sha256
 from gmat_sweep.spec import RunOutcome, RunSpec, SweepSpec
@@ -52,10 +55,15 @@ __all__ = [
     "__version__",
     "canonical_script_sha256",
     "expand_grid_to_run_specs",
+    "expand_latin_hypercube_to_run_specs",
+    "expand_monte_carlo_to_run_specs",
     "expand_samples_to_run_specs",
     "full_factorial",
+    "latin_hypercube",
+    "latin_hypercube_samples",
     "lazy_contacts",
     "lazy_ephemerides",
     "lazy_multiindex",
+    "monte_carlo",
     "sweep",
 ]

--- a/src/gmat_sweep/api.py
+++ b/src/gmat_sweep/api.py
@@ -4,19 +4,26 @@ from __future__ import annotations
 
 import tempfile
 import weakref
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from gmat_sweep.backends.joblib import LocalJoblibPool
+from gmat_sweep.distributions import DistSpec, _serialise_perturb
 from gmat_sweep.errors import SweepConfigError
-from gmat_sweep.grids import expand_grid_to_run_specs, expand_samples_to_run_specs
+from gmat_sweep.grids import (
+    expand_grid_to_run_specs,
+    expand_latin_hypercube_to_run_specs,
+    expand_monte_carlo_to_run_specs,
+    expand_samples_to_run_specs,
+)
+from gmat_sweep.spec import RunSpec
 from gmat_sweep.sweep import Sweep
 
 if TYPE_CHECKING:
     import pandas as pd
 
-__all__ = ["sweep"]
+__all__ = ["latin_hypercube", "monte_carlo", "sweep"]
 
 # Manifest filename inside the sweep's output directory. Picked to match the
 # JSON Lines format suffix for grep-friendliness; downstream consumers
@@ -71,8 +78,11 @@ def sweep(
         trick. Pass an explicit path to keep the per-run Parquet files and
         the manifest after the call returns.
     seed:
-        Optional integer recorded on the manifest header. v0.1 does not
-        consume it; reserved for v0.2 Monte Carlo runs.
+        Optional integer recorded on the manifest header. ``sweep()`` itself
+        does not consume it for grid or explicit-row sweeps; the value lives
+        on the manifest for round-trip introspection. :func:`monte_carlo`
+        and :func:`latin_hypercube` are the wrappers that consume a seed to
+        derive their per-run draws.
     progress:
         ``True`` (default) draws a :mod:`tqdm` progress bar on stderr as
         runs complete. Set to ``False`` for non-interactive use (CI logs,
@@ -100,27 +110,20 @@ def sweep(
 
     mission_path = Path(mission)
 
-    tempdir: tempfile.TemporaryDirectory[str] | None
-    if out is None:
-        tempdir = tempfile.TemporaryDirectory(prefix="gmat-sweep-")
-        output_dir = Path(tempdir.name)
-    else:
-        tempdir = None
-        output_dir = Path(out)
-        output_dir.mkdir(parents=True, exist_ok=True)
-
     parameter_spec: dict[str, Any]
+    build_runs: Callable[[Path], list[RunSpec]]
     if grid is not None:
         # Materialise grid values once: expand_grid_to_run_specs would do it
         # for the cartesian product, but we also need the materialised dict
         # for the manifest header (generators don't survive json.dumps), so
         # do it up front and reuse the same object.
         materialised_grid: dict[str, list[Any]] = {k: list(v) for k, v in grid.items()}
-        runs = expand_grid_to_run_specs(materialised_grid, mission_path, output_dir)
         parameter_spec = materialised_grid
+
+        def build_runs(output_dir: Path) -> list[RunSpec]:
+            return expand_grid_to_run_specs(materialised_grid, mission_path, output_dir)
     else:
         assert samples is not None  # narrowed by the XOR check above
-        runs = expand_samples_to_run_specs(samples, mission_path, output_dir)
         # Tagged shape lets Manifest.load distinguish explicit-row sweeps from
         # untagged grid headers without breaking back-compat with v0.1 grid
         # manifests already on disk. ``rows`` is a list-of-lists in column
@@ -131,6 +134,205 @@ def sweep(
             "rows": samples.values.tolist(),
         }
 
+        def build_runs(output_dir: Path) -> list[RunSpec]:
+            return expand_samples_to_run_specs(samples, mission_path, output_dir)
+
+    return _run_sweep(
+        mission_path=mission_path,
+        build_runs=build_runs,
+        parameter_spec=parameter_spec,
+        sweep_seed=seed,
+        workers=workers,
+        out=out,
+        progress=progress,
+    )
+
+
+def monte_carlo(
+    mission: str | Path,
+    *,
+    n: int,
+    perturb: Mapping[str, DistSpec],
+    seed: int | None = None,
+    workers: int = -1,
+    out: Path | None = None,
+    progress: bool = True,
+) -> pd.DataFrame:
+    """Run a Monte Carlo dispersion sweep over a GMAT mission.
+
+    Builds an explicit-row run set of ``n`` runs by independently sampling
+    each ``perturb`` parameter from its own distribution. Per-parameter
+    sub-seeds are derived from the parameter *name* via
+    :func:`derive_param_seed <gmat_sweep.distributions.derive_param_seed>`,
+    so adding a perturbed parameter to an existing sweep does not change
+    the draws of any other parameter at any ``run_id``.
+
+    Parameters
+    ----------
+    mission:
+        Path to the GMAT ``.script`` file every run loads.
+    n:
+        Number of stochastic runs. Must be ``>= 1``.
+    perturb:
+        Mapping from dotted-path field name to a distribution spec. Each
+        value is one of the three shorthand tuples (``("normal", mu,
+        sigma)``, ``("uniform", lo, hi)``, ``("lognormal", mu, sigma)``) or
+        any pre-frozen :class:`scipy.stats._distn_infrastructure.rv_frozen`.
+        See :data:`gmat_sweep.distributions.DistSpec` for the full surface.
+    seed:
+        Optional integer parent seed. ``None`` falls back to OS entropy and
+        is **not** reproducible. With an integer seed two calls at the same
+        ``(mission, n, perturb, seed)`` produce bit-equal DataFrames.
+    workers:
+        Number of subprocess workers; same semantics as :func:`sweep`.
+    out:
+        Sweep output directory; same semantics as :func:`sweep`.
+    progress:
+        Whether to draw the :mod:`tqdm` progress bar; same semantics as
+        :func:`sweep`.
+
+    Returns
+    -------
+    pandas.DataFrame
+        ``(run_id, time)``-MultiIndexed frame, one row per (run, time-step)
+        pair, with ``run_id`` cardinality ``n``. A failed run lands as one
+        NaN row with ``__status="failed"`` — same contract as :func:`sweep`.
+
+    Raises
+    ------
+    SweepConfigError
+        If ``perturb`` is empty, ``n < 1``, or any parameter spec is
+        ill-formed.
+    """
+    mission_path = Path(mission)
+    parameter_spec: dict[str, Any] = {
+        "_kind": "monte_carlo",
+        "perturb": _serialise_perturb(perturb),
+        "n": n,
+        "seed": seed,
+    }
+
+    def build_runs(output_dir: Path) -> list[RunSpec]:
+        return expand_monte_carlo_to_run_specs(
+            perturb, n=n, seed=seed, script_path=mission_path, output_dir=output_dir
+        )
+
+    return _run_sweep(
+        mission_path=mission_path,
+        build_runs=build_runs,
+        parameter_spec=parameter_spec,
+        sweep_seed=seed,
+        workers=workers,
+        out=out,
+        progress=progress,
+    )
+
+
+def latin_hypercube(
+    mission: str | Path,
+    *,
+    n: int,
+    perturb: Mapping[str, DistSpec],
+    seed: int | None = None,
+    workers: int = -1,
+    out: Path | None = None,
+    progress: bool = True,
+) -> pd.DataFrame:
+    """Run a Latin hypercube sweep over a GMAT mission.
+
+    Backed by :class:`scipy.stats.qmc.LatinHypercube`: draws ``n`` unit-cube
+    points stratified across each of ``len(perturb)`` axes and maps each
+    column through the user's distribution via ``rv.ppf(...)``. Latin
+    hypercube sampling typically beats plain Monte Carlo when ``n`` is
+    small relative to the problem's dimensionality, because the coverage
+    of each axis is enforced by construction.
+
+    Parameters
+    ----------
+    mission:
+        Path to the GMAT ``.script`` file every run loads.
+    n:
+        Number of Latin hypercube points. Must be ``>= 1``.
+    perturb:
+        Mapping from dotted-path field name to a distribution spec — same
+        accepted shapes as :func:`monte_carlo`.
+    seed:
+        Optional integer seed forwarded to
+        :class:`scipy.stats.qmc.LatinHypercube`. ``None`` falls back to OS
+        entropy and is **not** reproducible. With an integer seed two calls
+        at the same ``(mission, n, perturb, seed)`` produce bit-equal
+        DataFrames.
+    workers:
+        Same semantics as :func:`sweep`.
+    out:
+        Same semantics as :func:`sweep`.
+    progress:
+        Same semantics as :func:`sweep`.
+
+    Returns
+    -------
+    pandas.DataFrame
+        ``(run_id, time)``-MultiIndexed frame with ``run_id`` cardinality
+        ``n``. Same failure-as-row contract as :func:`sweep`.
+
+    Raises
+    ------
+    SweepConfigError
+        If ``perturb`` is empty, ``n < 1``, or any parameter spec is
+        ill-formed.
+    """
+    mission_path = Path(mission)
+    parameter_spec: dict[str, Any] = {
+        "_kind": "latin_hypercube",
+        "perturb": _serialise_perturb(perturb),
+        "n": n,
+        "seed": seed,
+    }
+
+    def build_runs(output_dir: Path) -> list[RunSpec]:
+        return expand_latin_hypercube_to_run_specs(
+            perturb, n=n, seed=seed, script_path=mission_path, output_dir=output_dir
+        )
+
+    return _run_sweep(
+        mission_path=mission_path,
+        build_runs=build_runs,
+        parameter_spec=parameter_spec,
+        sweep_seed=seed,
+        workers=workers,
+        out=out,
+        progress=progress,
+    )
+
+
+def _run_sweep(
+    *,
+    mission_path: Path,
+    build_runs: Callable[[Path], list[RunSpec]],
+    parameter_spec: dict[str, Any],
+    sweep_seed: int | None,
+    workers: int,
+    out: Path | None,
+    progress: bool,
+) -> pd.DataFrame:
+    """Shared orchestration for the public entry points.
+
+    Resolves the output directory (creating a sweep-scoped temp dir when
+    ``out`` is ``None``), builds the run set against that directory, runs
+    them through a fresh :class:`LocalJoblibPool`, and returns the
+    aggregated DataFrame. When a temp dir was created its cleanup is
+    deferred to the moment the returned DataFrame is garbage-collected.
+    """
+    tempdir: tempfile.TemporaryDirectory[str] | None
+    if out is None:
+        tempdir = tempfile.TemporaryDirectory(prefix="gmat-sweep-")
+        output_dir = Path(tempdir.name)
+    else:
+        tempdir = None
+        output_dir = Path(out)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+    runs = build_runs(output_dir)
     manifest_path = output_dir / _MANIFEST_FILENAME
 
     with LocalJoblibPool(workers=workers) as pool:
@@ -142,7 +344,7 @@ def sweep(
                 output_dir=output_dir,
                 script_path=mission_path,
                 parameter_spec=parameter_spec,
-                sweep_seed=seed,
+                sweep_seed=sweep_seed,
                 progress=progress,
             )
             .run()

--- a/src/gmat_sweep/distributions.py
+++ b/src/gmat_sweep/distributions.py
@@ -15,7 +15,9 @@ lets a Monte Carlo sweep be replayed run-by-run from its manifest alone.
 
 from __future__ import annotations
 
+import hashlib
 import math
+from collections.abc import Mapping
 from typing import Any, Literal, TypeAlias, cast
 
 import numpy as np
@@ -26,6 +28,7 @@ from gmat_sweep.errors import SweepConfigError
 
 __all__ = [
     "DistSpec",
+    "derive_param_seed",
     "derive_run_seeds",
     "sample",
     "to_rv_frozen",
@@ -150,3 +153,47 @@ def sample(spec: DistSpec, seed: int) -> float:
     rv = to_rv_frozen(spec)
     rng = np.random.default_rng(seed)
     return float(rv.rvs(size=1, random_state=rng)[0])
+
+
+def derive_param_seed(run_seed: int, param_name: str) -> int:
+    """Derive a per-parameter sub-seed from a run-level seed and a parameter name.
+
+    The sub-seed depends on the parameter's *name*, not its position inside
+    a ``perturb`` mapping, so adding a parameter to an existing Monte Carlo
+    sweep does not perturb the draws of any other parameter at any
+    ``run_id``. Reproducible across processes — uses
+    :class:`numpy.random.SeedSequence` mixed with a stable SHA-256 digest of
+    the parameter name (avoids :func:`hash`, which is salt-randomised
+    per-process).
+    """
+    name_hash = int.from_bytes(hashlib.sha256(param_name.encode("utf-8")).digest()[:4], "big")
+    seq = np.random.SeedSequence([run_seed, name_hash])
+    return int(seq.generate_state(1)[0])
+
+
+def _serialise_perturb(perturb: Mapping[str, DistSpec]) -> dict[str, Any]:
+    """Serialise a ``perturb`` mapping into a JSON-encodable dict.
+
+    Shorthand tuples become lists (JSON has no tuple type). Pre-frozen
+    :class:`scipy.stats._distn_infrastructure.rv_frozen` instances become
+    ``{"name": dist.name, "args": [...], "kwds": {...}}`` so the original
+    distribution can be reconstructed downstream. Anything else raises
+    :class:`SweepConfigError` — same surface as :func:`to_rv_frozen`, but
+    surfaced up front rather than at first sample.
+    """
+    out: dict[str, Any] = {}
+    for k, v in perturb.items():
+        if isinstance(v, rv_frozen):
+            out[k] = {
+                "name": v.dist.name,
+                "args": list(v.args),
+                "kwds": dict(v.kwds),
+            }
+        elif isinstance(v, tuple):
+            out[k] = list(v)
+        else:
+            raise SweepConfigError(
+                f"perturb value for {k!r} must be a shorthand tuple or scipy rv_frozen, "
+                f"got {type(v).__name__}"
+            )
+    return out

--- a/src/gmat_sweep/grids.py
+++ b/src/gmat_sweep/grids.py
@@ -15,6 +15,13 @@ from itertools import product
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from gmat_sweep.distributions import (
+    DistSpec,
+    derive_param_seed,
+    derive_run_seeds,
+    sample,
+    to_rv_frozen,
+)
 from gmat_sweep.errors import SweepConfigError
 from gmat_sweep.spec import RunSpec
 
@@ -23,8 +30,11 @@ if TYPE_CHECKING:
 
 __all__ = [
     "expand_grid_to_run_specs",
+    "expand_latin_hypercube_to_run_specs",
+    "expand_monte_carlo_to_run_specs",
     "expand_samples_to_run_specs",
     "full_factorial",
+    "latin_hypercube_samples",
 ]
 
 
@@ -168,3 +178,132 @@ def expand_samples_to_run_specs(
         )
         for run_id, record in enumerate(records)
     ]
+
+
+def expand_monte_carlo_to_run_specs(
+    perturb: Mapping[str, DistSpec],
+    n: int,
+    seed: int | None,
+    script_path: str | Path,
+    output_dir: str | Path,
+) -> list[RunSpec]:
+    """Build :class:`RunSpec` instances for a Monte Carlo dispersion sweep.
+
+    For each ``run_id`` ``i in range(n)``:
+
+    1. Derive the run-level seed via :func:`derive_run_seeds(seed, n)[i]
+       <gmat_sweep.distributions.derive_run_seeds>` — recorded on
+       :attr:`RunSpec.seed`.
+    2. For each parameter ``k`` in lexicographically-sorted ``perturb``:
+       derive a per-parameter sub-seed via
+       :func:`derive_param_seed(run_seed, k)
+       <gmat_sweep.distributions.derive_param_seed>` and sample one float
+       through :func:`sample(perturb[k], sub_seed)
+       <gmat_sweep.distributions.sample>`.
+
+    Per-parameter sub-seeds are derived from the parameter *name*, not its
+    position in the mapping, so adding a perturbed parameter to an existing
+    sweep does not change the draws of any other parameter at any
+    ``run_id``. Two calls at the same ``(perturb, n, seed, script_path)``
+    return identical specs.
+
+    Raises :class:`SweepConfigError` if ``perturb`` is empty, ``n < 1``, or
+    any parameter spec fails its own validation in
+    :func:`to_rv_frozen <gmat_sweep.distributions.to_rv_frozen>`.
+    """
+    if not perturb:
+        raise SweepConfigError("monte_carlo requires a non-empty perturb mapping")
+    if n < 1:
+        raise SweepConfigError(f"monte_carlo requires n >= 1, got {n}")
+
+    sorted_keys = sorted(perturb)
+    # Validate every spec up front so the failure is reported before any
+    # work — matches full_factorial's "validation runs before any
+    # combination is yielded" contract.
+    for k in sorted_keys:
+        to_rv_frozen(perturb[k])
+
+    run_seeds = derive_run_seeds(seed, n)
+    script_path_obj = Path(script_path)
+    base_output_dir = Path(output_dir)
+
+    specs: list[RunSpec] = []
+    for run_id, run_seed in enumerate(run_seeds):
+        overrides: dict[str, Any] = {}
+        for k in sorted_keys:
+            sub_seed = derive_param_seed(run_seed, k)
+            overrides[k] = sample(perturb[k], sub_seed)
+        specs.append(
+            RunSpec(
+                script_path=script_path_obj,
+                overrides=overrides,
+                output_dir=base_output_dir / f"run-{run_id}",
+                run_id=run_id,
+                seed=run_seed,
+                run_options={},
+            )
+        )
+    return specs
+
+
+def latin_hypercube_samples(
+    perturb: Mapping[str, DistSpec],
+    n: int,
+    seed: int | None,
+) -> pd.DataFrame:
+    """Build the Latin hypercube samples DataFrame for a stochastic sweep.
+
+    Builds a :class:`scipy.stats.qmc.LatinHypercube` sampler with
+    ``d = len(perturb)`` and ``seed = seed``, draws ``n`` unit-cube points,
+    then maps each column through ``to_rv_frozen(perturb[k]).ppf(...)`` to
+    leave the unit cube.
+
+    Columns are emitted in lexicographic order so the run set is stable
+    under ``perturb``-dict reordering. The returned DataFrame has a default
+    :class:`pandas.RangeIndex` and is suitable input to
+    :func:`expand_samples_to_run_specs`.
+
+    Determinism: two calls with the same ``(perturb, n, seed)`` produce
+    bit-equal DataFrames.
+
+    Raises :class:`SweepConfigError` if ``perturb`` is empty, ``n < 1``, or
+    any parameter spec fails its own validation in
+    :func:`to_rv_frozen <gmat_sweep.distributions.to_rv_frozen>`.
+    """
+    import pandas as pd
+    from scipy.stats import qmc
+
+    if not perturb:
+        raise SweepConfigError("latin_hypercube requires a non-empty perturb mapping")
+    if n < 1:
+        raise SweepConfigError(f"latin_hypercube requires n >= 1, got {n}")
+
+    sorted_keys = sorted(perturb)
+    rvs = [to_rv_frozen(perturb[k]) for k in sorted_keys]
+
+    sampler = qmc.LatinHypercube(d=len(sorted_keys), seed=seed)
+    unit = sampler.random(n=n)  # shape (n, d), each entry in [0, 1)
+
+    columns: dict[str, Any] = {}
+    for col_idx, key in enumerate(sorted_keys):
+        columns[key] = rvs[col_idx].ppf(unit[:, col_idx])
+    return pd.DataFrame(columns)
+
+
+def expand_latin_hypercube_to_run_specs(
+    perturb: Mapping[str, DistSpec],
+    n: int,
+    seed: int | None,
+    script_path: str | Path,
+    output_dir: str | Path,
+) -> list[RunSpec]:
+    """Build :class:`RunSpec` instances for a Latin hypercube sweep.
+
+    Convenience wrapper that builds the samples DataFrame via
+    :func:`latin_hypercube_samples` and forwards to
+    :func:`expand_samples_to_run_specs`. Per-run seeds are not populated:
+    the draw set is fully determined by ``(perturb, n, seed)`` so
+    individual runs do not need their own RNG state.
+    """
+    samples = latin_hypercube_samples(perturb, n=n, seed=seed)
+    return expand_samples_to_run_specs(samples, script_path, output_dir)

--- a/src/gmat_sweep/sweep.py
+++ b/src/gmat_sweep/sweep.py
@@ -64,8 +64,9 @@ class Sweep:
         The original sweep parameterisation (e.g. the materialised grid) —
         recorded verbatim in the manifest header for reproducibility.
     sweep_seed:
-        Optional integer seed recorded on the manifest. v0.1 does not consume
-        it; reserved for v0.2 Monte Carlo runs.
+        Optional integer seed recorded on the manifest. ``Sweep`` does not
+        consume it directly; the Monte Carlo and Latin hypercube wrappers
+        in :mod:`gmat_sweep.api` use it to derive their per-run draws.
     progress:
         ``True`` (default) wraps the drain loop in a :mod:`tqdm` bar.
         Set to ``False`` for non-interactive use (tests, CI logs).

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,7 +9,7 @@ from typing import Any
 import pandas as pd
 import pytest
 
-from gmat_sweep.api import sweep
+from gmat_sweep.api import latin_hypercube, monte_carlo, sweep
 from gmat_sweep.errors import SweepConfigError
 from gmat_sweep.manifest import Manifest
 from tests.conftest import FakeGmatRun, FakeResults
@@ -355,3 +355,343 @@ def test_sweep_with_samples_manifest_round_trips_to_dataframe(
     spec = manifest.parameter_spec
     reconstructed = pd.DataFrame(spec["rows"], columns=spec["columns"])
     pd.testing.assert_frame_equal(reconstructed, samples)
+
+
+# ---- monte_carlo ---------------------------------------------------------
+
+
+def test_monte_carlo_returns_n_run_dataframe(tmp_path: Path, fake_gmat_run: FakeGmatRun) -> None:
+    """Issue #33 headline: ``monte_carlo(n=100, perturb=..., seed=42)``
+    returns a ``(run_id, time)``-indexed DataFrame with run_id cardinality
+    100."""
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    df = monte_carlo(
+        script,
+        n=100,
+        perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
+        seed=42,
+        workers=1,
+        out=out,
+    )
+
+    assert df.index.names == ["run_id", "time"]
+    run_ids = sorted(df.index.get_level_values("run_id").unique().tolist())
+    assert run_ids == list(range(100))
+
+
+def test_monte_carlo_two_calls_at_same_seed_produce_equal_overrides(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    """Determinism contract: two calls at the same ``(n, perturb, seed)``
+    produce manifests whose recorded per-run overrides are identical at
+    every run_id."""
+    script = _write_script(tmp_path)
+    out_a = tmp_path / "out-a"
+    out_b = tmp_path / "out-b"
+
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    monte_carlo(
+        script,
+        n=20,
+        perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
+        seed=42,
+        workers=1,
+        out=out_a,
+    )
+    monte_carlo(
+        script,
+        n=20,
+        perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
+        seed=42,
+        workers=1,
+        out=out_b,
+    )
+
+    a = {e.run_id: e.overrides for e in Manifest.load(out_a / "manifest.jsonl").entries}
+    b = {e.run_id: e.overrides for e in Manifest.load(out_b / "manifest.jsonl").entries}
+    assert a == b
+
+
+def test_monte_carlo_different_seed_produces_different_overrides(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    script = _write_script(tmp_path)
+    out_a = tmp_path / "out-a"
+    out_b = tmp_path / "out-b"
+
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    monte_carlo(
+        script,
+        n=20,
+        perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
+        seed=42,
+        workers=1,
+        out=out_a,
+    )
+    monte_carlo(
+        script,
+        n=20,
+        perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
+        seed=43,
+        workers=1,
+        out=out_b,
+    )
+
+    a = {e.run_id: e.overrides for e in Manifest.load(out_a / "manifest.jsonl").entries}
+    b = {e.run_id: e.overrides for e in Manifest.load(out_b / "manifest.jsonl").entries}
+    assert a != b
+
+
+def test_monte_carlo_adding_a_perturbed_parameter_preserves_other_draws(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    """Issue #33 order-independence contract: adding a second perturbed
+    parameter to an existing perturb dict does not change the draws of the
+    first parameter at any run_id."""
+    script = _write_script(tmp_path)
+    out_one = tmp_path / "out-one"
+    out_two = tmp_path / "out-two"
+
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    monte_carlo(
+        script,
+        n=20,
+        perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
+        seed=42,
+        workers=1,
+        out=out_one,
+    )
+    monte_carlo(
+        script,
+        n=20,
+        perturb={
+            "Sat.SMA": ("normal", 7100.0, 50.0),
+            "Sat.INC": ("uniform", 0.0, 90.0),
+        },
+        seed=42,
+        workers=1,
+        out=out_two,
+    )
+
+    one = {
+        e.run_id: e.overrides["Sat.SMA"] for e in Manifest.load(out_one / "manifest.jsonl").entries
+    }
+    two = {
+        e.run_id: e.overrides["Sat.SMA"] for e in Manifest.load(out_two / "manifest.jsonl").entries
+    }
+    assert one == two
+
+
+def test_monte_carlo_accepts_pre_frozen_rv(tmp_path: Path, fake_gmat_run: FakeGmatRun) -> None:
+    from scipy import stats
+
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    df = monte_carlo(
+        script,
+        n=10,
+        perturb={"x": stats.beta(2, 5)},
+        seed=42,
+        workers=1,
+        out=out,
+    )
+    assert sorted(df.index.get_level_values("run_id").unique().tolist()) == list(range(10))
+
+
+def test_monte_carlo_failed_run_lands_as_nan_row(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    """A worker exception inside an MC sweep surfaces as a NaN row with
+    ``__status="failed"`` — same contract as the grid path."""
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+
+    call_count = {"n": 0}
+
+    def _setitem(_key: str, _value: Any) -> None:
+        call_count["n"] += 1
+        # Fail every other run.
+        if call_count["n"] % 2 == 0:
+            raise ValueError("rejected")
+
+    fake_gmat_run.install_loader(setitem_hook=_setitem, run_hook=_payload_run_hook())
+
+    df = monte_carlo(
+        script,
+        n=8,
+        perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
+        seed=42,
+        workers=1,
+        out=out,
+    )
+
+    statuses = set(df["__status"].unique())
+    assert "failed" in statuses
+
+
+def test_monte_carlo_writes_tagged_parameter_spec(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    """The manifest header carries a tagged ``parameter_spec`` so a later
+    loader can reproduce the same draws from the seed alone."""
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    monte_carlo(
+        script,
+        n=10,
+        perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
+        seed=42,
+        workers=1,
+        out=out,
+    )
+
+    manifest = Manifest.load(out / "manifest.jsonl")
+    spec = manifest.parameter_spec
+    assert spec["_kind"] == "monte_carlo"
+    assert spec["n"] == 10
+    assert spec["seed"] == 42
+    assert spec["perturb"] == {"Sat.SMA": ["normal", 7100.0, 50.0]}
+    assert manifest.sweep_seed == 42
+
+
+def test_monte_carlo_rejects_empty_perturb(tmp_path: Path, fake_gmat_run: FakeGmatRun) -> None:
+    script = _write_script(tmp_path)
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    with pytest.raises(SweepConfigError, match="non-empty perturb"):
+        monte_carlo(script, n=10, perturb={}, seed=42, workers=1, out=tmp_path / "out")
+
+
+def test_monte_carlo_rejects_n_less_than_one(tmp_path: Path, fake_gmat_run: FakeGmatRun) -> None:
+    script = _write_script(tmp_path)
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    with pytest.raises(SweepConfigError, match="requires n >= 1"):
+        monte_carlo(
+            script,
+            n=0,
+            perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
+            seed=42,
+            workers=1,
+            out=tmp_path / "out",
+        )
+
+
+# ---- latin_hypercube -----------------------------------------------------
+
+
+def test_latin_hypercube_returns_n_run_dataframe(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    """Issue #35 headline: ``latin_hypercube(n=64, perturb=..., seed=42)``
+    returns a ``(run_id, time)``-indexed DataFrame with run_id cardinality
+    64."""
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    df = latin_hypercube(
+        script,
+        n=64,
+        perturb={
+            "Sat.SMA": ("normal", 7100.0, 50.0),
+            "Sat.INC": ("uniform", 0.0, 90.0),
+        },
+        seed=42,
+        workers=1,
+        out=out,
+    )
+
+    assert df.index.names == ["run_id", "time"]
+    run_ids = sorted(df.index.get_level_values("run_id").unique().tolist())
+    assert run_ids == list(range(64))
+
+
+def test_latin_hypercube_two_calls_at_same_seed_produce_equal_overrides(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    script = _write_script(tmp_path)
+    out_a = tmp_path / "out-a"
+    out_b = tmp_path / "out-b"
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    perturb = {
+        "Sat.SMA": ("normal", 7100.0, 50.0),
+        "Sat.INC": ("uniform", 0.0, 90.0),
+    }
+    latin_hypercube(script, n=16, perturb=perturb, seed=42, workers=1, out=out_a)
+    latin_hypercube(script, n=16, perturb=perturb, seed=42, workers=1, out=out_b)
+
+    a = {e.run_id: e.overrides for e in Manifest.load(out_a / "manifest.jsonl").entries}
+    b = {e.run_id: e.overrides for e in Manifest.load(out_b / "manifest.jsonl").entries}
+    assert a == b
+
+
+def test_latin_hypercube_writes_tagged_parameter_spec(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    """Issue #35: manifest header records ``{"_kind": "latin_hypercube",
+    "perturb": <serialised>, "n": n, "seed": seed}`` so the seed plus the
+    spec is enough to reproduce the LH samples DataFrame."""
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    latin_hypercube(
+        script,
+        n=16,
+        perturb={
+            "Sat.SMA": ("normal", 7100.0, 50.0),
+            "Sat.INC": ("uniform", 0.0, 90.0),
+        },
+        seed=42,
+        workers=1,
+        out=out,
+    )
+
+    manifest = Manifest.load(out / "manifest.jsonl")
+    spec = manifest.parameter_spec
+    assert spec["_kind"] == "latin_hypercube"
+    assert spec["n"] == 16
+    assert spec["seed"] == 42
+    assert spec["perturb"] == {
+        "Sat.SMA": ["normal", 7100.0, 50.0],
+        "Sat.INC": ["uniform", 0.0, 90.0],
+    }
+    assert manifest.sweep_seed == 42
+
+
+def test_latin_hypercube_rejects_empty_perturb(tmp_path: Path, fake_gmat_run: FakeGmatRun) -> None:
+    script = _write_script(tmp_path)
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    with pytest.raises(SweepConfigError, match="non-empty perturb"):
+        latin_hypercube(script, n=10, perturb={}, seed=42, workers=1, out=tmp_path / "out")
+
+
+def test_latin_hypercube_rejects_n_less_than_one(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    script = _write_script(tmp_path)
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    with pytest.raises(SweepConfigError, match="requires n >= 1"):
+        latin_hypercube(
+            script,
+            n=0,
+            perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
+            seed=42,
+            workers=1,
+            out=tmp_path / "out",
+        )

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -12,7 +12,13 @@ import pytest
 from scipy import stats
 from scipy.stats._distn_infrastructure import rv_frozen
 
-from gmat_sweep.distributions import derive_run_seeds, sample, to_rv_frozen
+from gmat_sweep.distributions import (
+    _serialise_perturb,
+    derive_param_seed,
+    derive_run_seeds,
+    sample,
+    to_rv_frozen,
+)
 from gmat_sweep.errors import SweepConfigError
 
 # ---- to_rv_frozen: shorthand mapping --------------------------------------
@@ -262,3 +268,81 @@ def test_sample_works_with_pre_frozen_rv() -> None:
     b = sample(pre, seed=99)
     assert a == b
     assert isinstance(a, float)
+
+
+# ---- derive_param_seed ----------------------------------------------------
+
+
+def test_derive_param_seed_in_process_reproducible() -> None:
+    a = derive_param_seed(12345, "Sat.SMA")
+    b = derive_param_seed(12345, "Sat.SMA")
+    assert a == b
+
+
+def test_derive_param_seed_cross_process_reproducible() -> None:
+    code = (
+        "from gmat_sweep.distributions import derive_param_seed; "
+        "print(derive_param_seed(12345, 'Sat.SMA'))"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    cross_proc = int(result.stdout.strip())
+    assert cross_proc == derive_param_seed(12345, "Sat.SMA")
+
+
+def test_derive_param_seed_distinct_names_give_distinct_seeds() -> None:
+    seeds = {derive_param_seed(7, name) for name in ["Sat.SMA", "Sat.INC", "Sat.RAAN"]}
+    assert len(seeds) == 3
+
+
+def test_derive_param_seed_distinct_run_seeds_give_distinct_param_seeds() -> None:
+    a = derive_param_seed(1, "Sat.SMA")
+    b = derive_param_seed(2, "Sat.SMA")
+    assert a != b
+
+
+def test_derive_param_seed_returns_python_int() -> None:
+    out = derive_param_seed(42, "Sat.SMA")
+    assert isinstance(out, int)
+
+
+# ---- _serialise_perturb ---------------------------------------------------
+
+
+def test_serialise_perturb_shorthand_tuples_become_lists() -> None:
+    out = _serialise_perturb({"x": ("normal", 1.0, 2.0), "y": ("uniform", 0.0, 10.0)})
+    assert out == {"x": ["normal", 1.0, 2.0], "y": ["uniform", 0.0, 10.0]}
+
+
+def test_serialise_perturb_rv_frozen_serialises_name_args_kwds() -> None:
+    out = _serialise_perturb({"x": stats.norm(loc=3.0, scale=2.0)})
+    assert out == {"x": {"name": "norm", "args": [], "kwds": {"loc": 3.0, "scale": 2.0}}}
+
+
+def test_serialise_perturb_rv_frozen_with_positional_args_round_trips() -> None:
+    """`stats.beta(2, 5)` carries shape parameters as positional args, not kwds."""
+    out = _serialise_perturb({"x": stats.beta(2, 5)})
+    payload = out["x"]
+    assert payload["name"] == "beta"
+    assert payload["args"] == [2, 5]
+    assert payload["kwds"] == {}
+
+
+def test_serialise_perturb_is_json_encodable() -> None:
+    perturb = {
+        "Sat.SMA": ("normal", 7100.0, 50.0),
+        "Sat.ECC": stats.uniform(loc=0.0, scale=0.05),
+    }
+    out = _serialise_perturb(perturb)
+    # Round-trip through json.dumps to confirm everything is JSON-encodable.
+    encoded = json.dumps(out, sort_keys=True)
+    assert json.loads(encoded) == out
+
+
+def test_serialise_perturb_rejects_non_tuple_non_rv() -> None:
+    with pytest.raises(SweepConfigError, match="must be a shorthand tuple or scipy rv_frozen"):
+        _serialise_perturb({"x": [1, 2, 3]})

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -13,8 +13,11 @@ import pytest
 from gmat_sweep.errors import SweepConfigError
 from gmat_sweep.grids import (
     expand_grid_to_run_specs,
+    expand_latin_hypercube_to_run_specs,
+    expand_monte_carlo_to_run_specs,
     expand_samples_to_run_specs,
     full_factorial,
+    latin_hypercube_samples,
 )
 from gmat_sweep.spec import RunSpec
 
@@ -328,3 +331,237 @@ def test_expand_samples_runspec_round_trips_through_to_dict() -> None:
     serialised = json.dumps([s.to_dict() for s in specs], sort_keys=True)
     restored = [RunSpec.from_dict(d) for d in json.loads(serialised)]
     assert restored == specs
+
+
+# ---- expand_monte_carlo_to_run_specs --------------------------------------
+
+
+def test_expand_monte_carlo_returns_n_specs_with_per_run_seeds() -> None:
+    specs = expand_monte_carlo_to_run_specs(
+        perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
+        n=10,
+        seed=42,
+        script_path="/m.script",
+        output_dir="/o",
+    )
+    assert [s.run_id for s in specs] == list(range(10))
+    assert all(isinstance(s.seed, int) for s in specs)
+    # Per-run seeds are distinct (the `derive_run_seeds` contract).
+    assert len({s.seed for s in specs}) == 10
+    assert all(set(s.overrides.keys()) == {"Sat.SMA"} for s in specs)
+
+
+def test_expand_monte_carlo_deterministic_per_seed() -> None:
+    a = expand_monte_carlo_to_run_specs(
+        perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
+        n=20,
+        seed=42,
+        script_path="/m.script",
+        output_dir="/o",
+    )
+    b = expand_monte_carlo_to_run_specs(
+        perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
+        n=20,
+        seed=42,
+        script_path="/m.script",
+        output_dir="/o",
+    )
+    assert [s.overrides for s in a] == [s.overrides for s in b]
+    assert [s.seed for s in a] == [s.seed for s in b]
+
+
+def test_expand_monte_carlo_different_seed_different_draws() -> None:
+    a = expand_monte_carlo_to_run_specs(
+        perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
+        n=20,
+        seed=42,
+        script_path="/m.script",
+        output_dir="/o",
+    )
+    b = expand_monte_carlo_to_run_specs(
+        perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
+        n=20,
+        seed=43,
+        script_path="/m.script",
+        output_dir="/o",
+    )
+    assert [s.overrides for s in a] != [s.overrides for s in b]
+
+
+def test_expand_monte_carlo_per_param_seed_is_name_stable() -> None:
+    """Adding a perturbed parameter must not change the draws of any other
+    parameter at any run_id, regardless of where the new parameter falls
+    in lexicographic order. This is the headline order-independence
+    contract from issue #33."""
+    one = expand_monte_carlo_to_run_specs(
+        perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
+        n=20,
+        seed=42,
+        script_path="/m.script",
+        output_dir="/o",
+    )
+    # New param "Aaa.X" sorts BEFORE Sat.SMA — positional spawning would
+    # have shifted Sat.SMA's draws. The name-derived sub-seed leaves them
+    # intact.
+    two = expand_monte_carlo_to_run_specs(
+        perturb={
+            "Aaa.X": ("uniform", 0.0, 1.0),
+            "Sat.SMA": ("normal", 7100.0, 50.0),
+        },
+        n=20,
+        seed=42,
+        script_path="/m.script",
+        output_dir="/o",
+    )
+    sma_one = [s.overrides["Sat.SMA"] for s in one]
+    sma_two = [s.overrides["Sat.SMA"] for s in two]
+    assert sma_one == sma_two
+
+
+def test_expand_monte_carlo_accepts_pre_frozen_rv() -> None:
+    from scipy import stats
+
+    specs = expand_monte_carlo_to_run_specs(
+        perturb={"x": stats.beta(2, 5)},
+        n=5,
+        seed=42,
+        script_path="/m.script",
+        output_dir="/o",
+    )
+    assert len(specs) == 5
+    # beta(2, 5) is bounded on [0, 1].
+    for s in specs:
+        v = s.overrides["x"]
+        assert 0.0 <= v <= 1.0
+
+
+def test_expand_monte_carlo_rejects_empty_perturb() -> None:
+    with pytest.raises(SweepConfigError, match="non-empty perturb"):
+        expand_monte_carlo_to_run_specs(
+            perturb={}, n=5, seed=42, script_path="/m.script", output_dir="/o"
+        )
+
+
+def test_expand_monte_carlo_rejects_n_less_than_one() -> None:
+    with pytest.raises(SweepConfigError, match="requires n >= 1"):
+        expand_monte_carlo_to_run_specs(
+            perturb={"x": ("normal", 0, 1)},
+            n=0,
+            seed=42,
+            script_path="/m.script",
+            output_dir="/o",
+        )
+
+
+def test_expand_monte_carlo_propagates_distribution_validation() -> None:
+    with pytest.raises(SweepConfigError, match="sigma must be > 0"):
+        expand_monte_carlo_to_run_specs(
+            perturb={"x": ("normal", 0.0, -1.0)},
+            n=5,
+            seed=42,
+            script_path="/m.script",
+            output_dir="/o",
+        )
+
+
+# ---- latin_hypercube_samples ----------------------------------------------
+
+
+def test_latin_hypercube_samples_returns_n_rows_and_lex_sorted_columns() -> None:
+    samples = latin_hypercube_samples(
+        perturb={
+            "Sat.SMA": ("uniform", 7000.0, 7400.0),
+            "Sat.INC": ("uniform", 0.0, 90.0),
+        },
+        n=64,
+        seed=42,
+    )
+    assert isinstance(samples, pd.DataFrame)
+    assert len(samples) == 64
+    assert list(samples.columns) == ["Sat.INC", "Sat.SMA"]
+
+
+def test_latin_hypercube_samples_deterministic_per_seed() -> None:
+    a = latin_hypercube_samples(perturb={"x": ("uniform", 0.0, 1.0)}, n=64, seed=42)
+    b = latin_hypercube_samples(perturb={"x": ("uniform", 0.0, 1.0)}, n=64, seed=42)
+    pd.testing.assert_frame_equal(a, b)
+
+
+def test_latin_hypercube_samples_different_seed_different_draws() -> None:
+    a = latin_hypercube_samples(perturb={"x": ("uniform", 0.0, 1.0)}, n=64, seed=42)
+    b = latin_hypercube_samples(perturb={"x": ("uniform", 0.0, 1.0)}, n=64, seed=43)
+    assert not a.equals(b)
+
+
+def test_latin_hypercube_samples_stratification_one_per_n_tile() -> None:
+    """The stratification guarantee: after sorting, sample i (out of n) lies
+    in the unit-cube stratum [i/n, (i+1)/n). For a uniform(0, 1)
+    distribution the cdf is the identity, so the sample values themselves
+    must obey the stratum bounds."""
+    n = 1000
+    samples = latin_hypercube_samples(perturb={"x": ("uniform", 0.0, 1.0)}, n=n, seed=42)
+    sorted_vals = samples["x"].sort_values().to_numpy()
+    for i, v in enumerate(sorted_vals):
+        assert i / n <= v < (i + 1) / n, f"sample {i}={v} outside stratum [{i / n}, {(i + 1) / n})"
+
+
+def test_latin_hypercube_samples_ppf_transform_respects_user_distribution() -> None:
+    """Mapping uniform[0, 5] should give samples in [0, 5] exactly — the
+    LH-on-the-unit-cube strata composed with `uniform(loc=0, scale=5).ppf`
+    keep the sample range pinned to the requested distribution support."""
+    samples = latin_hypercube_samples(perturb={"x": ("uniform", 0.0, 5.0)}, n=200, seed=42)
+    assert samples["x"].min() >= 0.0
+    assert samples["x"].max() <= 5.0
+
+
+def test_latin_hypercube_samples_rejects_empty_perturb() -> None:
+    with pytest.raises(SweepConfigError, match="non-empty perturb"):
+        latin_hypercube_samples(perturb={}, n=10, seed=42)
+
+
+def test_latin_hypercube_samples_rejects_n_less_than_one() -> None:
+    with pytest.raises(SweepConfigError, match="requires n >= 1"):
+        latin_hypercube_samples(perturb={"x": ("uniform", 0, 1)}, n=0, seed=42)
+
+
+def test_latin_hypercube_samples_propagates_distribution_validation() -> None:
+    with pytest.raises(SweepConfigError, match="requires hi > lo"):
+        latin_hypercube_samples(perturb={"x": ("uniform", 5.0, 1.0)}, n=10, seed=42)
+
+
+# ---- expand_latin_hypercube_to_run_specs ---------------------------------
+
+
+def test_expand_latin_hypercube_returns_n_specs_in_lex_column_order() -> None:
+    specs = expand_latin_hypercube_to_run_specs(
+        perturb={
+            "Sat.SMA": ("uniform", 7000.0, 7400.0),
+            "Sat.INC": ("uniform", 0.0, 90.0),
+        },
+        n=8,
+        seed=42,
+        script_path="/m.script",
+        output_dir="/o",
+    )
+    assert [s.run_id for s in specs] == list(range(8))
+    # Lex-sorted columns: Sat.INC before Sat.SMA.
+    for s in specs:
+        assert list(s.overrides.keys()) == ["Sat.INC", "Sat.SMA"]
+
+
+def test_expand_latin_hypercube_deterministic_per_seed() -> None:
+    a = expand_latin_hypercube_to_run_specs(
+        perturb={"x": ("uniform", 0.0, 1.0)},
+        n=16,
+        seed=42,
+        script_path="/m.script",
+        output_dir="/o",
+    )
+    b = expand_latin_hypercube_to_run_specs(
+        perturb={"x": ("uniform", 0.0, 1.0)},
+        n=16,
+        seed=42,
+        script_path="/m.script",
+        output_dir="/o",
+    )
+    assert [s.overrides for s in a] == [s.overrides for s in b]


### PR DESCRIPTION
## Summary

- `monte_carlo(mission, *, n, perturb, seed=...)` — stochastic dispersion sweep with per-parameter sub-seeds derived from the parameter *name*, so adding a perturbed parameter to an existing sweep does not change the draws of any other parameter at any `run_id`.
- `latin_hypercube(mission, *, n, perturb, seed=...)` — stratified sampling backed by `scipy.stats.qmc.LatinHypercube`, ppf-transformed through each user-supplied distribution.
- Each wrapper records a tagged `parameter_spec` on the manifest header (`{"_kind": "monte_carlo", "perturb": ..., "n": ..., "seed": ...}` and the LH analogue) so any sweep is reproducible from the seed alone.
- Internal: factored the existing orchestrator boilerplate in `api.py` into `_run_sweep(...)` so all three public entry points share temp-dir lifetime, pool, and manifest setup; added `derive_param_seed` and `_serialise_perturb` to `distributions.py`; added `expand_monte_carlo_to_run_specs`, `latin_hypercube_samples`, and `expand_latin_hypercube_to_run_specs` to `grids.py`.
- Docs: new `docs/monte-carlo.md` covering shorthand specs, the determinism and order-independence contracts, and a worked launch-dispersion example; an "MC vs LH" subsection added to `docs/parameter-spec.md`; quickstart callout added to `docs/index.md`; nav and API reference updated.

## Test plan

- [x] `uv run pytest` — 307 unit tests pass.
- [x] `uv run ruff check` and `uv run ruff format --check` clean.
- [x] `uv run mypy --strict` clean.
- [x] Coverage: `api.py` 100%, `grids.py` 100%, `distributions.py` 100%; overall 99%.
- [x] CI matrix (Ubuntu + Windows × 3.10/3.11/3.12 × R2025a/R2026a) — runs on push.
- [ ] Integration tests gated behind the `integration` marker — exercised on CI against a real GMAT install; not run locally.

Closes #33
Closes #35