### PR TITLE
Add Sweep.from_manifest()/.resume() for partial-failure recovery

### DIFF
--- a/docs/manifest-schema.md
+++ b/docs/manifest-schema.md
@@ -149,3 +149,15 @@ every entry that returned successfully from `append_entry` is durable.
 torn last line; anything more corrupted raises
 [`ManifestCorruptError`][gmat_sweep.ManifestCorruptError] with the offending
 file's path attached.
+
+## Last-wins merge on load
+
+A resumed run appends a new entry with the same `run_id` as the
+original failed entry, so the on-disk file may carry two (or more)
+lines for that `run_id`. [`Manifest.load`][gmat_sweep.Manifest.load]
+folds duplicate `run_id`s last-wins: the latest entry's content
+survives, kept in the position of the first occurrence. The
+in-memory `entries` list therefore has exactly one entry per
+`run_id`, and [`find_failed`][gmat_sweep.Manifest.find_failed] reflects
+the latest status. See [Resume](resume.md) for the resume flow that
+relies on this.

--- a/docs/resume.md
+++ b/docs/resume.md
@@ -1,0 +1,134 @@
+# Resume
+
+A long sweep may produce a few failed runs (a flaky GMAT setting, an OS
+hiccup, a `Ctrl-C` halfway through the queue). Rather than re-running
+everything, point [`Sweep.from_manifest`][gmat_sweep.Sweep.from_manifest]
+at the existing `manifest.jsonl` and call
+[`Sweep.resume`][gmat_sweep.Sweep.resume] — only the failed and
+never-recorded runs are re-submitted. Successful runs' Parquet files are
+read from disk as-is.
+
+## When to use it
+
+- The original sweep was killed with `Ctrl-C` partway through. Some runs
+  finished cleanly and their entries are on disk; the rest never started.
+- A handful of runs failed for a reason you've now fixed (a setting in
+  the script, a perturb bound, an environmental issue) and you want to
+  rerun only those without re-doing the successful ones.
+- The original Monte Carlo or Latin hypercube draw set should remain
+  unchanged: resumed runs **must** sample bit-equal values to the
+  originals. The resume flow re-derives per-run sub-seeds from the
+  manifest's `sweep_seed`, so this is true by construction.
+
+If the script's canonical hash has changed since the original sweep,
+resume refuses by default — the old successful runs and the reruns
+would have loaded different scripts and the aggregated DataFrame would
+mix them. See [Script drift](#script-drift) below for the escape
+hatch.
+
+## How to use it
+
+```python
+from pathlib import Path
+from gmat_sweep import Sweep
+from gmat_sweep.backends.joblib import LocalJoblibPool
+
+with LocalJoblibPool(workers=4) as pool:
+    df = (
+        Sweep.from_manifest(
+            "./sweep/manifest.jsonl",
+            "mission.script",
+            backend=pool,
+        )
+        .resume()
+        .to_dataframe()
+    )
+```
+
+The returned DataFrame has the same shape as a fresh
+[`sweep()`][gmat_sweep.sweep] call: `(run_id, time)`-MultiIndexed, with
+one row per `(run, time-step)` pair, plus a `__status` column.
+
+`from_manifest` requires:
+
+- An existing `manifest.jsonl` whose parent directory still exists on
+  disk — the successful runs' Parquet files are read from there.
+- The original `.script`, whose canonical SHA-256 must match the
+  manifest's `script_sha256` (see [Script drift](#script-drift)).
+- A backend (a constructed [`Pool`][gmat_sweep.Pool]) — same
+  contract as the regular [`Sweep`][gmat_sweep.Sweep] constructor.
+
+## Last-wins entry semantics
+
+The manifest is **append-only with `fsync` after every entry** (see
+[Manifest schema](manifest-schema.md#append-only-invariant)). A resumed
+run appends a new entry with the **same `run_id`** as the original
+failed entry. The on-disk file then carries two lines for that
+`run_id` — one `failed`, one `ok`.
+
+[`Manifest.load`][gmat_sweep.Manifest.load] folds these last-wins:
+when multiple entries share a `run_id`, the **last** occurrence's
+content survives, kept in the position of the first occurrence. So:
+
+- The in-memory `entries` list contains exactly one entry per `run_id`.
+- [`find_failed`][gmat_sweep.Manifest.find_failed] only returns
+  `run_id`s whose latest entry is `failed`.
+- The on-disk file remains append-only — older entries are never
+  rewritten or deleted, so a `Ctrl-C` during resume still leaves a
+  parseable file.
+
+A manifest from a sweep that never resumed has unique `run_id`s per
+entry, so the dedup is a no-op there.
+
+## Script drift
+
+`from_manifest` recomputes
+[`canonical_script_sha256`][gmat_sweep.canonical_script_sha256] over the
+script you point it at and compares against the manifest's
+`script_sha256`. A mismatch raises
+[`SweepConfigError`][gmat_sweep.SweepConfigError] by default — silently
+mixing old outputs with reruns that loaded a different script would
+poison the aggregated DataFrame.
+
+If you know the change is benign (e.g. a comment-only edit that the
+canonical hash does *not* normalise) and you want to proceed anyway:
+
+```python
+Sweep.from_manifest(
+    "./sweep/manifest.jsonl",
+    "mission.script",
+    backend=pool,
+    allow_script_drift=True,
+)
+```
+
+This produces a `RuntimeWarning` with both hashes and proceeds.
+
+The canonical hash already normalises line endings and trailing
+newlines (see
+[Manifest schema § canonical script hash](manifest-schema.md#canonical-script-hash)),
+so it does **not** trigger on whitespace-only diffs from a fresh
+checkout.
+
+## What runs and what doesn't
+
+[`resume()`][gmat_sweep.Sweep.resume] submits the union of:
+
+- `manifest.find_failed()` — entries whose latest status is `failed`.
+- `manifest.find_missing(expected_run_ids)` — `run_id`s the rebuilt
+  run iterable carries that have no entry on disk yet (the tail of a
+  `Ctrl-C`'d sweep).
+
+Successful runs are skipped; their Parquet outputs are reused from
+their original `output_paths`. `skipped` runs (worker contract: the
+worker explicitly chose not to execute) are also left alone — they
+are not rerun.
+
+## Limitations
+
+- **Single-machine.** `script_path` and per-run `output_dir` are
+  recorded as absolute paths in the manifest, so a manifest written on
+  one machine cannot be resumed on another.
+- **Python-only entry point today.** A `gmat-sweep resume` CLI
+  subcommand is planned; the Python API above is the supported way in
+  the meantime.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
   - Parameter spec: parameter-spec.md
   - Monte Carlo: monte-carlo.md
   - Aggregation: aggregation.md
+  - Resume: resume.md
   - Manifest schema: manifest-schema.md
   - Supported versions: supported-versions.md
   - Examples:

--- a/src/gmat_sweep/distributions.py
+++ b/src/gmat_sweep/distributions.py
@@ -197,3 +197,39 @@ def _serialise_perturb(perturb: Mapping[str, DistSpec]) -> dict[str, Any]:
                 f"got {type(v).__name__}"
             )
     return out
+
+
+def _deserialise_perturb(serialised: Mapping[str, Any]) -> dict[str, DistSpec]:
+    """Inverse of :func:`_serialise_perturb` — used by the resume flow.
+
+    A list value is treated as a shorthand tuple (JSON has no tuple type, so
+    :func:`_serialise_perturb` writes ``["normal", mu, sigma]``). A dict
+    value with a ``"name"`` key is reconstructed as
+    ``getattr(scipy.stats, name)(*args, **kwds)`` — the round-trip for
+    pre-frozen :class:`scipy.stats._distn_infrastructure.rv_frozen` inputs.
+
+    Raises :class:`SweepConfigError` when an entry's shape is neither of the
+    above, or when the rv_frozen factory name is not a member of
+    :mod:`scipy.stats`. The result is suitable input to
+    :func:`expand_monte_carlo_to_run_specs` and
+    :func:`expand_latin_hypercube_to_run_specs`; the per-parameter draws are
+    bit-equal to the original sweep when those wrappers are called with the
+    same ``n`` and ``seed``.
+    """
+    out: dict[str, DistSpec] = {}
+    for k, v in serialised.items():
+        if isinstance(v, list):
+            out[k] = cast(DistSpec, tuple(v))
+        elif isinstance(v, dict) and "name" in v:
+            name = v["name"]
+            factory = getattr(stats, name, None)
+            if factory is None:
+                raise SweepConfigError(
+                    f"perturb entry {k!r} references unknown scipy.stats distribution {name!r}"
+                )
+            args = list(v.get("args", []))
+            kwds = dict(v.get("kwds", {}))
+            out[k] = cast(rv_frozen, factory(*args, **kwds))
+        else:
+            raise SweepConfigError(f"perturb entry {k!r} has unrecognised serialised shape: {v!r}")
+    return out

--- a/src/gmat_sweep/manifest.py
+++ b/src/gmat_sweep/manifest.py
@@ -6,6 +6,13 @@ by :meth:`Manifest.save` and is never rewritten — :meth:`Manifest.append_entry
 only appends, and ``run_count`` on disk may therefore lag the entries below
 it. This is by design: a torn last line costs that one entry, the header
 stays valid, and a mid-sweep ``Ctrl-C`` leaves a parseable file.
+
+Resume merges entries last-wins per ``run_id``. The on-disk file is
+append-only — a resumed run writes a new entry with the same ``run_id`` as
+the original failed entry, so the file may carry two (or more) entries for
+that ``run_id``. :meth:`Manifest.load` keeps only the *last* occurrence per
+``run_id`` (preserving the position of the *first* occurrence), so the
+in-memory ``entries`` list is deduplicated and the resumed status wins.
 """
 
 from __future__ import annotations
@@ -200,6 +207,11 @@ class Manifest:
         except (KeyError, TypeError, ValueError) as exc:
             raise ManifestCorruptError(f"manifest header is missing fields: {exc}", path) from exc
 
+        # Last-wins per run_id: a resumed run appends a new entry with the
+        # same run_id as the original failed entry. We keep only the last
+        # occurrence's content but preserve the position of the first
+        # occurrence so unique-run_id manifests load in file order unchanged.
+        by_run_id: dict[int, ManifestEntry] = {}
         for i, line in enumerate(complete_lines[1:], start=2):
             try:
                 entry_data = json.loads(line)
@@ -208,7 +220,8 @@ class Manifest:
                 raise ManifestCorruptError(
                     f"manifest entry on line {i} is malformed: {exc}", path
                 ) from exc
-            manifest.entries.append(entry)
+            by_run_id[entry.run_id] = entry
+        manifest.entries.extend(by_run_id.values())
 
         manifest._path = path
         return manifest

--- a/src/gmat_sweep/sweep.py
+++ b/src/gmat_sweep/sweep.py
@@ -15,6 +15,7 @@ wrapper takes care of this for the common case.
 from __future__ import annotations
 
 import platform
+import warnings
 from collections.abc import Mapping, Sequence
 from concurrent.futures import Future
 from pathlib import Path
@@ -23,6 +24,7 @@ from typing import TYPE_CHECKING, Any
 from tqdm.auto import tqdm
 
 from gmat_sweep.aggregate import lazy_contacts, lazy_ephemerides, lazy_multiindex
+from gmat_sweep.errors import SweepConfigError
 from gmat_sweep.manifest import Manifest, ManifestEntry, canonical_script_sha256
 
 if TYPE_CHECKING:
@@ -93,6 +95,9 @@ class Sweep:
         self._sweep_seed = sweep_seed
         self._progress = progress
         self._manifest: Manifest | None = None
+        # Set by :meth:`from_manifest`. Gates :meth:`resume` so a freshly-
+        # constructed Sweep can't accidentally append onto an unrelated file.
+        self._loaded_from_manifest: bool = False
 
     def run(self) -> Sweep:
         """Submit every run, drain outcomes in completion order, return ``self``.
@@ -133,6 +138,144 @@ class Sweep:
         finally:
             progress_bar.close()
 
+        return self
+
+    @classmethod
+    def from_manifest(
+        cls,
+        manifest_path: str | Path,
+        script_path: str | Path,
+        *,
+        backend: Pool,
+        allow_script_drift: bool = False,
+        progress: bool = True,
+    ) -> Sweep:
+        """Rebuild a :class:`Sweep` from a manifest written by a prior run.
+
+        Reads ``manifest_path``, validates that the on-disk script still
+        matches the manifest's recorded ``script_sha256``, reconstructs the
+        run iterable from the manifest's ``parameter_spec``, and returns a
+        :class:`Sweep` whose manifest is pre-bound to the loaded one. The
+        returned sweep is suitable input to :meth:`resume`; calling
+        :meth:`run` on it would re-execute every run from scratch and is
+        not the intended flow.
+
+        Parameters
+        ----------
+        manifest_path:
+            Path to the existing ``manifest.jsonl``. Its parent is treated
+            as the sweep's ``output_dir`` and must still exist on disk —
+            successful runs' Parquet files are read from there as-is.
+        script_path:
+            Path to the GMAT ``.script`` to load. The file's canonical
+            SHA-256 must equal the manifest's ``script_sha256`` unless
+            ``allow_script_drift`` is set.
+        backend:
+            A constructed :class:`Pool`. The caller owns its lifecycle —
+            same contract as the regular constructor.
+        allow_script_drift:
+            ``False`` (default) raises :class:`SweepConfigError` on a hash
+            mismatch with both hashes in the message. ``True`` proceeds
+            anyway and emits a :class:`RuntimeWarning`.
+        progress:
+            Forwarded to the constructor — controls the :mod:`tqdm` bar in
+            :meth:`resume`.
+
+        Raises
+        ------
+        SweepConfigError
+            If ``manifest_path``'s parent directory does not exist, the
+            script hash drifted and ``allow_script_drift`` is ``False``, or
+            the manifest's ``parameter_spec`` carries an unknown ``_kind``.
+        """
+        manifest_path_obj = Path(manifest_path)
+        script_path_obj = Path(script_path)
+        output_dir = manifest_path_obj.parent
+        if not output_dir.exists():
+            raise SweepConfigError(
+                f"manifest output directory does not exist: {output_dir} — "
+                f"successful runs' Parquet files must still be on disk to be reused"
+            )
+
+        manifest = Manifest.load(manifest_path_obj)
+
+        current_sha = canonical_script_sha256(script_path_obj)
+        if current_sha != manifest.script_sha256:
+            msg = (
+                f"script hash mismatch for {script_path_obj}: "
+                f"manifest={manifest.script_sha256}, current={current_sha}"
+            )
+            if not allow_script_drift:
+                raise SweepConfigError(msg)
+            warnings.warn(msg, RuntimeWarning, stacklevel=2)
+
+        runs = _build_runs_from_parameter_spec(
+            manifest.parameter_spec,
+            script_path=script_path_obj,
+            output_dir=output_dir,
+        )
+
+        sweep = cls(
+            runs=runs,
+            backend=backend,
+            manifest_path=manifest_path_obj,
+            output_dir=output_dir,
+            script_path=script_path_obj,
+            parameter_spec=manifest.parameter_spec,
+            sweep_seed=manifest.sweep_seed,
+            progress=progress,
+        )
+        sweep._manifest = manifest
+        sweep._loaded_from_manifest = True
+        return sweep
+
+    def resume(self) -> Sweep:
+        """Re-run only the failed and missing runs from the loaded manifest.
+
+        Submits specs for the union of ``manifest.find_failed()`` and ``manifest.find_missing(...)``
+        through the bound backend, appends one new :class:`ManifestEntry`
+        per outcome (with the same ``run_id`` as the original), and reloads
+        the manifest so the in-memory ``entries`` reflect the last-wins
+        merge. Returns ``self`` for chaining.
+
+        Raises :exc:`RuntimeError` when called on a :class:`Sweep` not
+        produced by :meth:`from_manifest`.
+        """
+        if not self._loaded_from_manifest or self._manifest is None:
+            raise RuntimeError("Sweep.resume requires a Sweep built via Sweep.from_manifest")
+        manifest = self._manifest
+
+        expected_run_ids = [s.run_id for s in self._runs]
+        to_retry: set[int] = set(manifest.find_failed()) | set(
+            manifest.find_missing(expected_run_ids)
+        )
+        specs_by_run_id: dict[int, RunSpec] = {s.run_id: s for s in self._runs}
+        runs_to_submit: list[RunSpec] = [specs_by_run_id[rid] for rid in sorted(to_retry)]
+
+        futures: list[Future[RunOutcome]] = [self._backend.submit(s) for s in runs_to_submit]
+
+        progress_bar = tqdm(
+            total=len(runs_to_submit),
+            disable=not self._progress,
+            desc="gmat-sweep resume",
+            unit="run",
+        )
+        try:
+            for outcome in self._backend.as_completed(futures):
+                spec = specs_by_run_id[outcome.run_id]
+                entry = ManifestEntry.from_outcome(
+                    outcome,
+                    overrides=spec.overrides,
+                    log_path=spec.output_dir / _WORKER_LOG_NAME,
+                )
+                manifest.append_entry(entry)
+                progress_bar.update(1)
+        finally:
+            progress_bar.close()
+
+        # Reload so the in-memory entries list is deduplicated last-wins.
+        # append_entry leaves duplicates in memory; load() folds them.
+        self._manifest = Manifest.load(self._manifest_path)
         return self
 
     def to_manifest(self) -> Manifest:
@@ -182,6 +325,69 @@ class Sweep:
             parameter_spec=self._parameter_spec,
             run_count=len(self._runs),
         )
+
+
+def _build_runs_from_parameter_spec(
+    parameter_spec: Mapping[str, Any],
+    *,
+    script_path: Path,
+    output_dir: Path,
+) -> list[RunSpec]:
+    """Reconstruct the run iterable a manifest's ``parameter_spec`` describes.
+
+    Dispatches on ``parameter_spec["_kind"]``: ``None`` (no key) is the
+    v0.1 grid manifest shape, kept for backwards compatibility; the four
+    explicit kinds round-trip through their matching expander. Resumed
+    Monte Carlo and Latin hypercube runs draw bit-equal values to the
+    original sweep because the expanders are deterministic in
+    ``(perturb, n, seed)``.
+    """
+    # Local imports keep gmat_sweep.sweep cycle-free at import time —
+    # gmat_sweep.grids depends on gmat_sweep.distributions, which pulls in
+    # scipy, and we only pay that cost on resume.
+    from gmat_sweep.distributions import _deserialise_perturb
+    from gmat_sweep.grids import (
+        expand_grid_to_run_specs,
+        expand_latin_hypercube_to_run_specs,
+        expand_monte_carlo_to_run_specs,
+        expand_samples_to_run_specs,
+    )
+
+    kind = parameter_spec.get("_kind")
+    if kind is None:
+        # Untagged → v0.1 grid manifest. The mapping is the materialised
+        # grid: {dotted-path: [values]}.
+        grid = {k: v for k, v in parameter_spec.items() if k != "_kind"}
+        return expand_grid_to_run_specs(grid, script_path, output_dir)
+    if kind == "explicit":
+        import pandas as pd
+
+        samples = pd.DataFrame(parameter_spec["rows"], columns=list(parameter_spec["columns"]))
+        return expand_samples_to_run_specs(samples, script_path, output_dir)
+    if kind == "monte_carlo":
+        perturb = _deserialise_perturb(parameter_spec["perturb"])
+        seed = parameter_spec.get("seed")
+        return expand_monte_carlo_to_run_specs(
+            perturb,
+            n=int(parameter_spec["n"]),
+            seed=None if seed is None else int(seed),
+            script_path=script_path,
+            output_dir=output_dir,
+        )
+    if kind == "latin_hypercube":
+        perturb = _deserialise_perturb(parameter_spec["perturb"])
+        seed = parameter_spec.get("seed")
+        return expand_latin_hypercube_to_run_specs(
+            perturb,
+            n=int(parameter_spec["n"]),
+            seed=None if seed is None else int(seed),
+            script_path=script_path,
+            output_dir=output_dir,
+        )
+    raise SweepConfigError(
+        f"unknown parameter_spec _kind: {kind!r} — "
+        f"expected one of None (grid), 'explicit', 'monte_carlo', 'latin_hypercube'"
+    )
 
 
 def _gmat_run_version() -> str:

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -13,6 +13,7 @@ from scipy import stats
 from scipy.stats._distn_infrastructure import rv_frozen
 
 from gmat_sweep.distributions import (
+    _deserialise_perturb,
     _serialise_perturb,
     derive_param_seed,
     derive_run_seeds,
@@ -346,3 +347,42 @@ def test_serialise_perturb_is_json_encodable() -> None:
 def test_serialise_perturb_rejects_non_tuple_non_rv() -> None:
     with pytest.raises(SweepConfigError, match="must be a shorthand tuple or scipy rv_frozen"):
         _serialise_perturb({"x": [1, 2, 3]})
+
+
+# ---- _deserialise_perturb -------------------------------------------------
+
+
+def test_deserialise_perturb_inverts_serialise_for_shorthand_tuples() -> None:
+    original = {"x": ("normal", 1.0, 2.0), "y": ("uniform", 0.0, 10.0)}
+    round_tripped = _deserialise_perturb(_serialise_perturb(original))
+    assert round_tripped == original
+
+
+def test_deserialise_perturb_inverts_serialise_for_rv_frozen() -> None:
+    """rv_frozen reconstruction goes through scipy.stats by name; the
+    reconstructed distribution samples bit-equal to the original at the
+    same seed."""
+    original = stats.norm(loc=3.0, scale=2.0)
+    serialised = _serialise_perturb({"x": original})
+    deserialised = _deserialise_perturb(serialised)
+    rv = deserialised["x"]
+    assert isinstance(rv, rv_frozen)
+    # Sampling at the same seed produces identical draws, which is the
+    # contract resumed Monte Carlo replays rely on.
+    assert sample(rv, 42) == sample(original, 42)
+
+
+def test_deserialise_perturb_rv_frozen_with_positional_args_round_trips() -> None:
+    original = stats.beta(2, 5)
+    deserialised = _deserialise_perturb(_serialise_perturb({"x": original}))
+    assert sample(deserialised["x"], 7) == sample(original, 7)
+
+
+def test_deserialise_perturb_unknown_scipy_name_raises() -> None:
+    with pytest.raises(SweepConfigError, match=r"unknown scipy\.stats distribution"):
+        _deserialise_perturb({"x": {"name": "not_a_real_distribution", "args": [], "kwds": {}}})
+
+
+def test_deserialise_perturb_unrecognised_shape_raises() -> None:
+    with pytest.raises(SweepConfigError, match="unrecognised serialised shape"):
+        _deserialise_perturb({"x": 42})  # neither list nor name-keyed dict

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -394,6 +394,67 @@ def test_load_complete_entry_with_missing_field_raises(tmp_path: Path) -> None:
 # ---- find_failed / find_missing -----------------------------------------
 
 
+def test_load_dedupes_duplicate_run_ids_last_wins(tmp_path: Path) -> None:
+    """Resume appends a fresh entry with the same run_id as the failed one;
+    Manifest.load merges them last-wins so the resumed status survives."""
+    m = _make_manifest()
+    path = tmp_path / "manifest.jsonl"
+    m.save(path)
+
+    failed = _make_entry(run_id=1, status="failed")
+    retried = _make_entry(run_id=1, status="ok")
+    m.append_entry(failed)
+    m.append_entry(retried)
+
+    reloaded = Manifest.load(path)
+    by_run_id = {e.run_id: e for e in reloaded.entries}
+    assert by_run_id[1].status == "ok"
+    assert by_run_id[1].output_paths != {}
+    # Only the resumed entry survives — there are no two run_id=1 entries.
+    assert sum(1 for e in reloaded.entries if e.run_id == 1) == 1
+
+
+def test_load_dedup_preserves_first_occurrence_position(tmp_path: Path) -> None:
+    """For unique run_ids load() must preserve file order. For a duplicated
+    run_id the entry stays at the position of its FIRST appearance — the
+    resumed entry rides the original's slot, not the tail."""
+    m = _make_manifest()
+    path = tmp_path / "manifest.jsonl"
+    m.save(path)
+    m.append_entry(_make_entry(run_id=0, status="ok"))
+    m.append_entry(_make_entry(run_id=1, status="failed"))
+    m.append_entry(_make_entry(run_id=2, status="ok"))
+    m.append_entry(_make_entry(run_id=1, status="ok"))  # resumed retry
+
+    reloaded = Manifest.load(path)
+    assert [e.run_id for e in reloaded.entries] == [0, 1, 2]
+    by_run_id = {e.run_id: e for e in reloaded.entries}
+    assert by_run_id[1].status == "ok"
+
+
+def test_load_dedup_no_op_when_run_ids_unique(tmp_path: Path) -> None:
+    """Manifests without resume duplicates must round-trip unchanged."""
+    m = _make_manifest(n_entries=3)
+    path = tmp_path / "manifest.jsonl"
+    m.save(path)
+
+    reloaded = Manifest.load(path)
+    assert reloaded.entries == m.entries
+
+
+def test_find_failed_after_resume_excludes_recovered_run_ids(tmp_path: Path) -> None:
+    """After dedup, find_failed only surfaces run_ids whose LAST entry is failed."""
+    m = _make_manifest()
+    path = tmp_path / "manifest.jsonl"
+    m.save(path)
+    m.append_entry(_make_entry(run_id=0, status="failed"))
+    m.append_entry(_make_entry(run_id=1, status="failed"))
+    m.append_entry(_make_entry(run_id=0, status="ok"))  # recovered on resume
+
+    reloaded = Manifest.load(path)
+    assert reloaded.find_failed() == [1]
+
+
 def test_find_failed_returns_failed_run_ids_in_order() -> None:
     m = _make_manifest()
     m.entries = [

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -13,6 +13,7 @@ import pytest
 
 from gmat_sweep.backends.base import Pool
 from gmat_sweep.backends.joblib import LocalJoblibPool
+from gmat_sweep.errors import SweepConfigError
 from gmat_sweep.manifest import Manifest, canonical_script_sha256
 from gmat_sweep.spec import RunOutcome, RunSpec
 from gmat_sweep.sweep import Sweep
@@ -322,3 +323,344 @@ def test_sweep_keyboard_interrupt_leaves_parsable_partial_manifest(
     reloaded = Manifest.load(output_dir / "manifest.jsonl")
     assert len(reloaded.entries) == 2
     assert {e.run_id for e in reloaded.entries} == {0, 1}
+
+
+# ---- from_manifest --------------------------------------------------------
+
+
+def _build_grid_manifest(
+    tmp_path: Path,
+    fake_gmat_run: FakeGmatRun,
+    *,
+    n: int = 4,
+    failing_value: float | None = None,
+) -> tuple[Path, Path]:
+    """Run a grid sweep, optionally failing on a specific override value.
+
+    Returns ``(script_path, output_dir)`` so a follow-up resume can point at
+    the same script and manifest.
+    """
+    script = _write_script(tmp_path)
+    output_dir = tmp_path / "out"
+    runs = _make_runs(script, output_dir, n=n)
+
+    if failing_value is not None:
+
+        def _setitem(_key: str, value: Any) -> None:
+            if value == failing_value:
+                raise ValueError("rejected by GMAT")
+
+        fake_gmat_run.install_loader(setitem_hook=_setitem, run_hook=_payload_run_hook(rows=1))
+    else:
+        fake_gmat_run.install_loader(run_hook=_payload_run_hook(rows=1))
+
+    with LocalJoblibPool(workers=1) as pool:
+        Sweep(
+            runs=runs,
+            backend=pool,
+            manifest_path=output_dir / "manifest.jsonl",
+            output_dir=output_dir,
+            script_path=script,
+            parameter_spec={"Sat.SMA": [7000.0 + i for i in range(n)]},
+            progress=False,
+        ).run()
+
+    return script, output_dir
+
+
+def test_from_manifest_grid_rebuilds_runs(tmp_path: Path, fake_gmat_run: FakeGmatRun) -> None:
+    script, output_dir = _build_grid_manifest(tmp_path, fake_gmat_run, n=4)
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook(rows=1))
+
+    with LocalJoblibPool(workers=1) as pool:
+        sweep = Sweep.from_manifest(
+            output_dir / "manifest.jsonl",
+            script,
+            backend=pool,
+            progress=False,
+        )
+
+    assert [s.run_id for s in sweep._runs] == [0, 1, 2, 3]
+    assert [s.overrides for s in sweep._runs] == [{"Sat.SMA": 7000.0 + i} for i in range(4)]
+
+
+def test_from_manifest_explicit_kind_rebuilds_runs(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    """An explicit-row sweep round-trips through from_manifest's _kind dispatch."""
+    from gmat_sweep import sweep as sweep_api
+
+    script = _write_script(tmp_path)
+    output_dir = tmp_path / "out"
+    samples = pd.DataFrame({"Sat.SMA": [7000.0, 7100.0, 7200.0], "Sat.ECC": [0.001, 0.002, 0.003]})
+
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook(rows=1))
+    sweep_api(script, samples=samples, workers=1, out=output_dir)
+
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook(rows=1))
+    with LocalJoblibPool(workers=1) as pool:
+        rebuilt = Sweep.from_manifest(
+            output_dir / "manifest.jsonl",
+            script,
+            backend=pool,
+            progress=False,
+        )
+
+    assert [s.overrides for s in rebuilt._runs] == [
+        {"Sat.SMA": 7000.0, "Sat.ECC": 0.001},
+        {"Sat.SMA": 7100.0, "Sat.ECC": 0.002},
+        {"Sat.SMA": 7200.0, "Sat.ECC": 0.003},
+    ]
+
+
+def test_from_manifest_monte_carlo_rebuilds_bit_equal_overrides(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    """The acceptance criterion: a resumed Monte Carlo sweep produces
+    bit-equal draws because expand_monte_carlo_to_run_specs is deterministic
+    in (perturb, n, seed)."""
+    from gmat_sweep import monte_carlo
+
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook(rows=1))
+    monte_carlo(
+        script,
+        n=8,
+        perturb={"Sat.SMA": ("normal", 7100.0, 50.0), "Sat.INC": ("uniform", 0.0, 90.0)},
+        seed=1729,
+        workers=1,
+        out=out,
+    )
+
+    original_overrides = {
+        e.run_id: e.overrides for e in Manifest.load(out / "manifest.jsonl").entries
+    }
+
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook(rows=1))
+    with LocalJoblibPool(workers=1) as pool:
+        rebuilt = Sweep.from_manifest(out / "manifest.jsonl", script, backend=pool, progress=False)
+
+    rebuilt_overrides = {s.run_id: s.overrides for s in rebuilt._runs}
+    assert rebuilt_overrides == original_overrides
+
+
+def test_from_manifest_latin_hypercube_rebuilds_bit_equal_overrides(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    from gmat_sweep import latin_hypercube
+
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook(rows=1))
+    latin_hypercube(
+        script,
+        n=8,
+        perturb={"Sat.SMA": ("normal", 7100.0, 50.0), "Sat.INC": ("uniform", 0.0, 90.0)},
+        seed=1729,
+        workers=1,
+        out=out,
+    )
+
+    original = {e.run_id: e.overrides for e in Manifest.load(out / "manifest.jsonl").entries}
+
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook(rows=1))
+    with LocalJoblibPool(workers=1) as pool:
+        rebuilt = Sweep.from_manifest(out / "manifest.jsonl", script, backend=pool, progress=False)
+
+    assert {s.run_id: s.overrides for s in rebuilt._runs} == original
+
+
+def test_from_manifest_script_drift_raises(tmp_path: Path, fake_gmat_run: FakeGmatRun) -> None:
+    script, output_dir = _build_grid_manifest(tmp_path, fake_gmat_run, n=2)
+    # Mutate the script: same path, different bytes ⇒ different canonical hash.
+    script.write_text("% GMAT script v2\nCreate Spacecraft Sat;\n", encoding="utf-8")
+
+    with LocalJoblibPool(workers=1) as pool:  # noqa: SIM117 — context manager scope is intentional
+        with pytest.raises(SweepConfigError, match="script hash mismatch"):
+            Sweep.from_manifest(output_dir / "manifest.jsonl", script, backend=pool, progress=False)
+
+
+def test_from_manifest_script_drift_allowed_warns_and_proceeds(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    script, output_dir = _build_grid_manifest(tmp_path, fake_gmat_run, n=2)
+    script.write_text("% GMAT script v2\nCreate Spacecraft Sat;\n", encoding="utf-8")
+
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook(rows=1))
+    with (
+        LocalJoblibPool(workers=1) as pool,
+        pytest.warns(RuntimeWarning, match="script hash mismatch"),
+    ):
+        sweep = Sweep.from_manifest(
+            output_dir / "manifest.jsonl",
+            script,
+            backend=pool,
+            allow_script_drift=True,
+            progress=False,
+        )
+    assert len(sweep._runs) == 2
+
+
+def test_from_manifest_missing_output_dir_raises(tmp_path: Path) -> None:
+    """If the parent of manifest_path no longer exists, succeeded runs'
+    Parquet files are gone — raise rather than silently produce a sweep
+    that would re-execute everything."""
+    fake_path = tmp_path / "vanished" / "manifest.jsonl"
+    with LocalJoblibPool(workers=1) as pool:  # noqa: SIM117
+        with pytest.raises(SweepConfigError, match="output directory does not exist"):
+            Sweep.from_manifest(
+                fake_path, tmp_path / "mission.script", backend=pool, progress=False
+            )
+
+
+def test_from_manifest_unknown_kind_raises(tmp_path: Path, fake_gmat_run: FakeGmatRun) -> None:
+    script, output_dir = _build_grid_manifest(tmp_path, fake_gmat_run, n=1)
+    # Hand-corrupt the header to introduce an unknown _kind.
+    manifest_path = output_dir / "manifest.jsonl"
+    raw = manifest_path.read_text(encoding="utf-8").splitlines(keepends=True)
+    import json as _json
+
+    header = _json.loads(raw[0])
+    header["parameter_spec"] = {"_kind": "halton", "n": 1}
+    raw[0] = _json.dumps(header, sort_keys=True) + "\n"
+    manifest_path.write_text("".join(raw), encoding="utf-8")
+
+    with LocalJoblibPool(workers=1) as pool:  # noqa: SIM117
+        with pytest.raises(SweepConfigError, match="unknown parameter_spec _kind"):
+            Sweep.from_manifest(manifest_path, script, backend=pool, progress=False)
+
+
+# ---- resume ---------------------------------------------------------------
+
+
+def test_resume_requires_from_manifest(tmp_path: Path, fake_gmat_run: FakeGmatRun) -> None:
+    """A sweep produced by the regular constructor cannot resume — the
+    manifest header on disk hasn't been validated against this Sweep's
+    parameters, so appending would silently mix two unrelated runs."""
+    script = _write_script(tmp_path)
+    output_dir = tmp_path / "out"
+    runs = _make_runs(script, output_dir, n=1)
+    with LocalJoblibPool(workers=1) as pool:
+        sweep = Sweep(
+            runs=runs,
+            backend=pool,
+            manifest_path=output_dir / "manifest.jsonl",
+            output_dir=output_dir,
+            script_path=script,
+            parameter_spec={"Sat.SMA": [7000.0]},
+            progress=False,
+        )
+        with pytest.raises(RuntimeError, match="from_manifest"):
+            sweep.resume()
+
+
+def test_resume_only_runs_failed_and_missing_run_ids(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    """After a sweep with one failed run, resume should re-submit only that
+    run_id (plus any never-recorded run_ids)."""
+    script, output_dir = _build_grid_manifest(tmp_path, fake_gmat_run, n=4, failing_value=7001.0)
+
+    # Record which overrides the resumed pass passes through __setitem__.
+    second_pass_overrides: list[Any] = []
+
+    def _setitem(_key: str, value: Any) -> None:
+        second_pass_overrides.append(value)
+
+    fake_gmat_run.install_loader(setitem_hook=_setitem, run_hook=_payload_run_hook(rows=1))
+    with LocalJoblibPool(workers=1) as pool:
+        Sweep.from_manifest(
+            output_dir / "manifest.jsonl", script, backend=pool, progress=False
+        ).resume()
+
+    # Only the originally-failed run (Sat.SMA=7001.0) was re-attempted.
+    assert second_pass_overrides == [7001.0]
+
+    reloaded = Manifest.load(output_dir / "manifest.jsonl")
+    assert {e.run_id for e in reloaded.entries} == {0, 1, 2, 3}
+    assert all(e.status == "ok" for e in reloaded.entries)
+
+
+def test_resume_acceptance_16_runs_with_3_failures(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    """The headline acceptance criterion: 16-run sweep with 3 deliberately
+    failing runs, resumed with the override-rejection patched out, lands a
+    DataFrame with run_id cardinality 16 and __status=='ok' for all 16."""
+    script = _write_script(tmp_path)
+    output_dir = tmp_path / "out"
+    n = 16
+    runs = _make_runs(script, output_dir, n=n)
+    failing = {7003.0, 7007.0, 7011.0}
+
+    def _setitem(_key: str, value: Any) -> None:
+        if value in failing:
+            raise ValueError("rejected by GMAT")
+
+    fake_gmat_run.install_loader(setitem_hook=_setitem, run_hook=_payload_run_hook(rows=1))
+    with LocalJoblibPool(workers=1) as pool:
+        Sweep(
+            runs=runs,
+            backend=pool,
+            manifest_path=output_dir / "manifest.jsonl",
+            output_dir=output_dir,
+            script_path=script,
+            parameter_spec={"Sat.SMA": [7000.0 + i for i in range(n)]},
+            progress=False,
+        ).run()
+
+    # Sanity: 3 failed in the first pass.
+    first_pass = Manifest.load(output_dir / "manifest.jsonl")
+    assert sorted(first_pass.find_failed()) == [3, 7, 11]
+
+    # Patch the override out, resume.
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook(rows=1))
+    with LocalJoblibPool(workers=1) as pool:
+        df = (
+            Sweep.from_manifest(output_dir / "manifest.jsonl", script, backend=pool, progress=False)
+            .resume()
+            .to_dataframe()
+        )
+
+    run_ids = sorted(df.index.get_level_values("run_id").unique().tolist())
+    assert run_ids == list(range(n))
+    assert (df["__status"] == "ok").all()
+
+
+def test_resume_writes_duplicate_lines_but_load_dedups(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    """The append-only file gains a second line for the resumed run_id; the
+    in-memory entries list (after load) carries only the resumed entry."""
+    script, output_dir = _build_grid_manifest(tmp_path, fake_gmat_run, n=3, failing_value=7001.0)
+    manifest_path = output_dir / "manifest.jsonl"
+    raw_lines_before = manifest_path.read_text(encoding="utf-8").splitlines()
+
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook(rows=1))
+    with LocalJoblibPool(workers=1) as pool:
+        Sweep.from_manifest(manifest_path, script, backend=pool, progress=False).resume()
+
+    raw_lines_after = manifest_path.read_text(encoding="utf-8").splitlines()
+    assert len(raw_lines_after) == len(raw_lines_before) + 1  # one new entry line
+
+    reloaded = Manifest.load(manifest_path)
+    by_run_id = {e.run_id: e for e in reloaded.entries}
+    assert by_run_id[1].status == "ok"
+    assert sum(1 for e in reloaded.entries if e.run_id == 1) == 1
+
+
+def test_resume_with_no_failures_or_missing_is_a_noop(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    """All runs already ok ⇒ resume submits nothing and the manifest is
+    unchanged byte-for-byte."""
+    script, output_dir = _build_grid_manifest(tmp_path, fake_gmat_run, n=3)
+    manifest_path = output_dir / "manifest.jsonl"
+    bytes_before = manifest_path.read_bytes()
+
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook(rows=1))
+    with LocalJoblibPool(workers=1) as pool:
+        Sweep.from_manifest(manifest_path, script, backend=pool, progress=False).resume()
+
+    assert manifest_path.read_bytes() == bytes_before


### PR DESCRIPTION
## Summary

- `Sweep.from_manifest(manifest_path, script_path, *, backend, allow_script_drift=False)` rebuilds a Sweep from an existing manifest. Dispatches on `parameter_spec[\"_kind\"]` (grid / explicit / monte_carlo / latin_hypercube), validates `canonical_script_sha256(script_path)` against the recorded hash, and binds the loaded manifest so `resume()` appends rather than rewriting the header.
- `Sweep.resume()` re-submits only the union of `manifest.find_failed()` and `manifest.find_missing(...)`, appends new entries with the same `run_id` as the original failed entry, and reloads so the in-memory list reflects the merged state. Monte Carlo and Latin hypercube resumes draw bit-equal values to the original sweep because `expand_*_to_run_specs` is deterministic in `(perturb, n, seed)`.
- `Manifest.load` now folds duplicate `run_id`s last-wins; the on-disk file remains append-only.
- Adds `_deserialise_perturb` as the inverse of `_serialise_perturb` (lists ↔ shorthand tuples; `{name, args, kwds}` dict ↔ `getattr(scipy.stats, name)(*args, **kwds)`).
- New `docs/resume.md` (linked from the manifest-schema page and from the mkdocs nav). The forward-compat contract test in `tests/test_manifest_replay_contract.py` still passes — no header-format change.

## Test plan

- [x] `uv run pytest` — 329 passed, 19 deselected (integration).
- [x] `uv run ruff check` / `uv run ruff format --check` / `uv run mypy` clean.
- [x] Coverage: `manifest.py` 100%, `distributions.py` 100%, new `sweep.py` lines covered (file-level 96%; uncovered lines are pre-existing aggregator helpers and ImportError fallbacks).
- [x] `uv run mkdocs build --strict` builds clean.
- [ ] CI green on Ubuntu and Windows.

Closes #36