### PR TITLE
Add CLI subcommands: monte-carlo, latin-hypercube, explicit, resume

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -141,9 +141,10 @@ gmat-sweep explicit \
 
 `--samples PATH` accepts `.csv` (loaded via `pandas.read_csv`) and `.parquet`
 (loaded via `pandas.read_parquet`). Other suffixes exit with code `2`. The
-DataFrame must use a default `RangeIndex(start=0)` and unique string column
-names — see [`expand_samples_to_run_specs`][gmat_sweep.expand_samples_to_run_specs]
-for the full validation surface.
+loaded DataFrame must use a default `RangeIndex(start=0)`, have unique string
+column names, and contain no all-NaN columns — any violation surfaces as a
+[`SweepConfigError`][gmat_sweep.SweepConfigError] (exit code `2`) before any
+runs start.
 
 Use `explicit` when you have already built a sampling design (Halton, Sobol,
 custom optimisation results) and want to hand it in directly.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,182 @@
+# CLI reference
+
+`gmat-sweep` ships a `gmat-sweep` console script. Every Python entry point on
+the public surface has a matching subcommand, so you can drive a sweep,
+inspect a manifest, or resume a partial run without writing Python.
+
+```text
+gmat-sweep <subcommand> [options] [SCRIPT]
+```
+
+The subcommands:
+
+- [`run`](#run) — full-factorial grid sweep.
+- [`monte-carlo`](#monte-carlo) — stochastic dispersion sweep.
+- [`latin-hypercube`](#latin-hypercube) — Latin hypercube sweep.
+- [`explicit`](#explicit) — explicit-row sweep from a CSV or Parquet design.
+- [`resume`](#resume) — re-run only the failed and missing entries from a
+  prior manifest.
+- [`show`](#show) — print a one-line summary of a manifest.
+
+`gmat-sweep --help` lists them. Each subcommand has its own `--help`.
+
+## Common options
+
+The sweep-running subcommands (`run`, `monte-carlo`, `latin-hypercube`,
+`explicit`) share three flags:
+
+| Flag         | Default | Meaning                                                                      |
+|--------------|---------|------------------------------------------------------------------------------|
+| `--workers N`| `-1`    | Number of subprocess workers. `-1` uses every available core.                |
+| `--out PATH` | —       | Required. Output directory for per-run artefacts and `manifest.jsonl`.       |
+| `SCRIPT`     | —       | Required positional. Path to the GMAT `.script` every run loads.             |
+
+Each of those four subcommands writes a `manifest.jsonl` under `--out` and
+prints a one-line summary to stdout when the sweep finishes:
+
+```text
+N runs (A ok[, B failed][, C skipped]) in T.TT s — output: PATH
+```
+
+## Exit codes
+
+| Code | Meaning                                                                        |
+|------|--------------------------------------------------------------------------------|
+| `0`  | success                                                                        |
+| `1`  | any other [`GmatSweepError`][gmat_sweep.GmatSweepError]                        |
+| `2`  | [`SweepConfigError`][gmat_sweep.SweepConfigError] or argparse usage error      |
+| `3`  | [`ManifestCorruptError`][gmat_sweep.ManifestCorruptError] or missing manifest  |
+| `4`  | [`BackendError`][gmat_sweep.BackendError]                                      |
+
+## `run`
+
+Run a full-factorial grid sweep. Each `--grid` flag adds one axis; multiple
+flags combine into the cartesian product.
+
+```bash
+gmat-sweep run \
+    --grid 'Sat.SMA=7000:8000:5' \
+    --grid 'Sat.DryMass=100,200,300' \
+    --workers 4 \
+    --out ./sweep-out \
+    mission.script
+```
+
+`--grid SPEC` accepts two forms:
+
+- `name=lo:hi:count` — `count` evenly-spaced points from `lo` to `hi`
+  inclusive (numpy linspace). `count` must be ≥ 2.
+- `name=v1,v2,v3` — explicit comma-separated values, each coerced via
+  int → float → str fallback.
+
+Repeated `--grid` flags for the same axis name exit with code `2`.
+
+## `monte-carlo`
+
+Run `n` independent stochastic samples by sampling each `--perturb`
+parameter from its own distribution. With `--seed` set, the run set is
+reproducible across machines.
+
+```bash
+gmat-sweep monte-carlo \
+    --n 1000 \
+    --perturb 'Sat.SMA=normal:7100:50' \
+    --perturb 'Sat.INC=uniform:0:90' \
+    --seed 42 \
+    --workers 8 \
+    --out ./mc-out \
+    mission.script
+```
+
+`--perturb SPEC` takes one of three shorthands:
+
+| Form                         | scipy equivalent                            |
+|------------------------------|---------------------------------------------|
+| `name=normal:mu:sigma`       | `scipy.stats.norm(loc=mu, scale=sigma)`     |
+| `name=uniform:lo:hi`         | `scipy.stats.uniform(loc=lo, scale=hi-lo)`  |
+| `name=lognormal:mu:sigma`    | `scipy.stats.lognorm(s=sigma, scale=exp(mu))`|
+
+Per-parameter sub-seeds are derived from the parameter's *name*, so adding a
+`--perturb` flag to an existing sweep does not change the draws of any other
+parameter at any `run_id` — see [Monte Carlo](monte-carlo.md) for the full
+determinism contract.
+
+`--seed` is optional; without it, the draw set falls back to OS entropy and
+is not reproducible. An unknown distribution tag (e.g. `triangular`) exits
+with code `2`.
+
+## `latin-hypercube`
+
+Draw `n` Latin hypercube points stratified across each `--perturb` axis,
+mapping each axis through the user's distribution. Same `--perturb` syntax as
+`monte-carlo`.
+
+```bash
+gmat-sweep latin-hypercube \
+    --n 100 \
+    --perturb 'Sat.SMA=normal:7100:50' \
+    --seed 42 \
+    --workers 4 \
+    --out ./lhs-out \
+    mission.script
+```
+
+Latin hypercube sampling typically beats plain Monte Carlo when `n` is small
+relative to the problem's dimensionality, because the per-axis coverage is
+enforced by construction.
+
+## `explicit`
+
+Run one mission per row of a pre-built sample design. Column names are
+[dotted-path field names](parameter-spec.md#dotted-path-keys); the row index
+becomes `run_id`.
+
+```bash
+gmat-sweep explicit \
+    --samples ./samples.csv \
+    --workers 4 \
+    --out ./explicit-out \
+    mission.script
+```
+
+`--samples PATH` accepts `.csv` (loaded via `pandas.read_csv`) and `.parquet`
+(loaded via `pandas.read_parquet`). Other suffixes exit with code `2`. The
+DataFrame must use a default `RangeIndex(start=0)` and unique string column
+names — see [`expand_samples_to_run_specs`][gmat_sweep.expand_samples_to_run_specs]
+for the full validation surface.
+
+Use `explicit` when you have already built a sampling design (Halton, Sobol,
+custom optimisation results) and want to hand it in directly.
+
+## `resume`
+
+Re-run only the failed and never-recorded entries from an existing
+`manifest.jsonl`. Successful runs' Parquet files are reused from disk.
+
+```bash
+gmat-sweep resume ./sweep-out/manifest.jsonl \
+    --script mission.script \
+    --workers 4
+```
+
+Required positional: `MANIFEST` — the existing `manifest.jsonl`.
+
+Required flag: `--script PATH` — the same GMAT `.script` the original sweep
+loaded. Its canonical SHA-256 must equal the manifest's `script_sha256`; see
+[Resume § Script drift](resume.md#script-drift) for the full contract. Add
+`--allow-script-drift` to proceed past a hash mismatch (emits a
+`RuntimeWarning`).
+
+A missing `MANIFEST` exits with code `3`; a missing `--script` or a hash
+mismatch exits with code `2`.
+
+## `show`
+
+Print the one-line summary line for a manifest produced by any of the
+sweep-running subcommands.
+
+```bash
+gmat-sweep show ./sweep-out/manifest.jsonl
+```
+
+A missing or unparseable manifest exits with code `3`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,6 +56,8 @@ order-independence contracts.
   and the CLI's mini-grammar work.
 - **[Monte Carlo](monte-carlo.md)** — stochastic dispersion sweeps with
   named distributions and a determinism contract.
+- **[CLI reference](cli.md)** — the `gmat-sweep` console script: every
+  Python entry point exposed as a subcommand.
 - **[Manifest schema](manifest-schema.md)** — the JSON Lines manifest each
   sweep writes alongside its outputs.
 - **[Supported versions](supported-versions.md)** — GMAT × Python × OS matrix.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,7 @@ nav:
   - Monte Carlo: monte-carlo.md
   - Aggregation: aggregation.md
   - Resume: resume.md
+  - CLI reference: cli.md
   - Manifest schema: manifest-schema.md
   - Supported versions: supported-versions.md
   - Examples:

--- a/src/gmat_sweep/cli.py
+++ b/src/gmat_sweep/cli.py
@@ -1,8 +1,9 @@
-"""Console-script entry point: ``gmat-sweep run`` / ``gmat-sweep show``.
+"""Console-script entry point for the ``gmat-sweep`` command.
 
-The CLI is a thin wrapper over :func:`gmat_sweep.api.sweep` and
-:meth:`gmat_sweep.manifest.Manifest.load`. Argument parsing and grid-spec
-parsing live here; everything else delegates to the existing public surface.
+The CLI is a thin wrapper over :mod:`gmat_sweep.api` and
+:meth:`gmat_sweep.manifest.Manifest.load`. Argument parsing, grid-spec parsing,
+and perturb-spec parsing live here; everything else delegates to the existing
+public surface.
 
 Exit codes
 ----------
@@ -19,11 +20,11 @@ import argparse
 import sys
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from gmat_sweep.api import sweep
+from gmat_sweep.api import latin_hypercube, monte_carlo, sweep
 from gmat_sweep.errors import (
     BackendError,
     GmatSweepError,
@@ -32,6 +33,11 @@ from gmat_sweep.errors import (
 )
 from gmat_sweep.manifest import Manifest
 
+if TYPE_CHECKING:
+    import pandas as pd
+
+    from gmat_sweep.distributions import DistSpec
+
 __all__ = ["main"]
 
 EXIT_OK = 0
@@ -39,6 +45,8 @@ EXIT_GENERIC = 1
 EXIT_CONFIG = 2
 EXIT_MANIFEST = 3
 EXIT_BACKEND = 4
+
+_PERTURB_TAGS = ("normal", "uniform", "lognormal")
 
 
 def _parse_grid_value(token: str) -> int | float | str:
@@ -110,6 +118,76 @@ def _parse_grid_spec(spec: str) -> tuple[str, list[Any]]:
     return name, [_parse_grid_value(t) for t in tokens]
 
 
+def _parse_perturb_spec(spec: str) -> tuple[str, DistSpec]:
+    """Parse one ``--perturb`` argument into ``(dotted_path, DistSpec)``.
+
+    Three shorthand forms — ``name=normal:mu:sigma``,
+    ``name=uniform:lo:hi``, and ``name=lognormal:mu:sigma`` — mirroring the
+    tuple specs accepted by :func:`gmat_sweep.monte_carlo` and
+    :func:`gmat_sweep.latin_hypercube`. The unknown-tag check happens here so
+    a typo surfaces at parse time; numeric validation (``sigma > 0``,
+    ``hi > lo``, finiteness) is left to
+    :func:`gmat_sweep.distributions.to_rv_frozen`, which raises the same
+    :class:`SweepConfigError` downstream.
+    """
+    if "=" not in spec:
+        raise SweepConfigError(
+            f"perturb spec must contain '=': {spec!r} "
+            "(expected 'name=normal:mu:sigma', 'name=uniform:lo:hi', "
+            "or 'name=lognormal:mu:sigma')"
+        )
+    name, _, rhs = spec.partition("=")
+    name = name.strip()
+    if not name:
+        raise SweepConfigError(f"perturb spec is missing a name: {spec!r}")
+    if not rhs:
+        raise SweepConfigError(f"perturb spec for {name!r} has no distribution: {spec!r}")
+
+    parts = rhs.split(":")
+    if len(parts) != 3:
+        raise SweepConfigError(
+            f"perturb spec for {name!r} must have three colon-separated parts "
+            f"'tag:p1:p2', got {rhs!r}"
+        )
+    tag, p1_str, p2_str = parts
+    if tag not in _PERTURB_TAGS:
+        raise SweepConfigError(
+            f"unknown perturb distribution tag {tag!r} for {name!r}; "
+            f"expected one of {', '.join(_PERTURB_TAGS)}"
+        )
+    try:
+        p1 = float(p1_str)
+        p2 = float(p2_str)
+    except ValueError as exc:
+        raise SweepConfigError(
+            f"perturb parameters for {name!r} must be numeric, got {p1_str!r}:{p2_str!r}"
+        ) from exc
+    return name, (tag, p1, p2)
+
+
+def _load_samples(path: Path) -> pd.DataFrame:
+    """Load an explicit-row samples DataFrame from CSV or Parquet.
+
+    Suffix-dispatched: ``.csv`` reads via :func:`pandas.read_csv`, ``.parquet``
+    via :func:`pandas.read_parquet`. Any other suffix raises
+    :class:`SweepConfigError`. A missing file also raises
+    :class:`SweepConfigError` so the CLI's "bad config" exit code applies
+    uniformly.
+    """
+    if not path.is_file():
+        raise SweepConfigError(f"samples file not found: {path}")
+    suffix = path.suffix.lower()
+    import pandas as pd
+
+    if suffix == ".csv":
+        return pd.read_csv(path)
+    if suffix == ".parquet":
+        return pd.read_parquet(path)
+    raise SweepConfigError(
+        f"samples file suffix {suffix!r} is not supported; expected '.csv' or '.parquet'"
+    )
+
+
 def _format_summary(manifest: Manifest, output_dir: Path) -> str:
     """One-line summary: ``N runs (A ok[, B failed][, C skipped]) in T.TT s — output: PATH``.
 
@@ -155,6 +233,103 @@ def _cmd_show(args: argparse.Namespace) -> int:
         return EXIT_MANIFEST
     manifest = Manifest.load(manifest_path)
     print(_format_summary(manifest, manifest_path.parent))
+    return EXIT_OK
+
+
+def _collect_perturb(raw_specs: list[str]) -> dict[str, DistSpec]:
+    """Parse repeated ``--perturb`` flags into a single mapping; reject duplicates."""
+    perturb: dict[str, DistSpec] = {}
+    for raw in raw_specs:
+        name, dist = _parse_perturb_spec(raw)
+        if name in perturb:
+            raise SweepConfigError(f"perturb spec for {name!r} given more than once")
+        perturb[name] = dist
+    return perturb
+
+
+def _cmd_monte_carlo(args: argparse.Namespace) -> int:
+    script = Path(args.script)
+    if not script.is_file():
+        print(f"gmat-sweep: script not found: {script}", file=sys.stderr)
+        return EXIT_CONFIG
+
+    perturb = _collect_perturb(args.perturb)
+    out = Path(args.out)
+    monte_carlo(
+        script,
+        n=args.n,
+        perturb=perturb,
+        seed=args.seed,
+        workers=args.workers,
+        out=out,
+    )
+
+    manifest = Manifest.load(out / "manifest.jsonl")
+    print(_format_summary(manifest, out))
+    return EXIT_OK
+
+
+def _cmd_latin_hypercube(args: argparse.Namespace) -> int:
+    script = Path(args.script)
+    if not script.is_file():
+        print(f"gmat-sweep: script not found: {script}", file=sys.stderr)
+        return EXIT_CONFIG
+
+    perturb = _collect_perturb(args.perturb)
+    out = Path(args.out)
+    latin_hypercube(
+        script,
+        n=args.n,
+        perturb=perturb,
+        seed=args.seed,
+        workers=args.workers,
+        out=out,
+    )
+
+    manifest = Manifest.load(out / "manifest.jsonl")
+    print(_format_summary(manifest, out))
+    return EXIT_OK
+
+
+def _cmd_explicit(args: argparse.Namespace) -> int:
+    script = Path(args.script)
+    if not script.is_file():
+        print(f"gmat-sweep: script not found: {script}", file=sys.stderr)
+        return EXIT_CONFIG
+
+    samples = _load_samples(Path(args.samples))
+    out = Path(args.out)
+    sweep(script, samples=samples, workers=args.workers, out=out)
+
+    manifest = Manifest.load(out / "manifest.jsonl")
+    print(_format_summary(manifest, out))
+    return EXIT_OK
+
+
+def _cmd_resume(args: argparse.Namespace) -> int:
+    manifest_path = Path(args.manifest)
+    if not manifest_path.is_file():
+        print(f"gmat-sweep: manifest not found: {manifest_path}", file=sys.stderr)
+        return EXIT_MANIFEST
+    script = Path(args.script)
+    if not script.is_file():
+        print(f"gmat-sweep: script not found: {script}", file=sys.stderr)
+        return EXIT_CONFIG
+
+    # Local imports keep gmat_sweep.cli's import-time surface narrow — these
+    # are only needed by the resume path.
+    from gmat_sweep.backends.joblib import LocalJoblibPool
+    from gmat_sweep.sweep import Sweep
+
+    with LocalJoblibPool(workers=args.workers) as pool:
+        sweep_obj = Sweep.from_manifest(
+            manifest_path,
+            script,
+            backend=pool,
+            allow_script_drift=args.allow_script_drift,
+        ).resume()
+
+    print(_format_summary(sweep_obj.to_manifest(), manifest_path.parent))
     return EXIT_OK
 
 
@@ -217,6 +392,192 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Path to a manifest.jsonl produced by 'gmat-sweep run'.",
     )
     show.set_defaults(func=_cmd_show)
+
+    monte = subparsers.add_parser(
+        "monte-carlo",
+        help="Run a Monte Carlo dispersion sweep over a GMAT script.",
+        description=(
+            "Run n stochastic samples by independently sampling each --perturb "
+            "parameter from its own distribution. With --seed set, the run set "
+            "is reproducible."
+        ),
+    )
+    monte.add_argument(
+        "--n",
+        type=int,
+        required=True,
+        metavar="N",
+        help="Number of stochastic runs (>= 1).",
+    )
+    monte.add_argument(
+        "--perturb",
+        action="append",
+        default=[],
+        required=True,
+        metavar="SPEC",
+        help=(
+            "Perturb axis spec. Three forms: "
+            "'name=normal:mu:sigma', 'name=uniform:lo:hi', 'name=lognormal:mu:sigma' "
+            "(e.g. 'Sat.SMA=normal:7100:50'). Repeat --perturb for additional axes."
+        ),
+    )
+    monte.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        metavar="SEED",
+        help="Optional integer parent seed. Omit for OS entropy (non-reproducible).",
+    )
+    monte.add_argument(
+        "--workers",
+        type=int,
+        default=-1,
+        metavar="N",
+        help="Number of subprocess workers. Default -1 uses every available core.",
+    )
+    monte.add_argument(
+        "--out",
+        required=True,
+        metavar="PATH",
+        help="Output directory for per-run artefacts and manifest.jsonl.",
+    )
+    monte.add_argument(
+        "script",
+        metavar="SCRIPT",
+        help="Path to the GMAT .script file.",
+    )
+    monte.set_defaults(func=_cmd_monte_carlo)
+
+    lhs = subparsers.add_parser(
+        "latin-hypercube",
+        help="Run a Latin hypercube sweep over a GMAT script.",
+        description=(
+            "Draw n Latin hypercube points stratified across each --perturb axis "
+            "and map them through the user's distribution. Same --perturb syntax "
+            "as 'monte-carlo'."
+        ),
+    )
+    lhs.add_argument(
+        "--n",
+        type=int,
+        required=True,
+        metavar="N",
+        help="Number of Latin hypercube points (>= 1).",
+    )
+    lhs.add_argument(
+        "--perturb",
+        action="append",
+        default=[],
+        required=True,
+        metavar="SPEC",
+        help=(
+            "Perturb axis spec. Three forms: "
+            "'name=normal:mu:sigma', 'name=uniform:lo:hi', 'name=lognormal:mu:sigma'. "
+            "Repeat --perturb for additional axes."
+        ),
+    )
+    lhs.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        metavar="SEED",
+        help="Optional integer seed for the Latin hypercube sampler.",
+    )
+    lhs.add_argument(
+        "--workers",
+        type=int,
+        default=-1,
+        metavar="N",
+        help="Number of subprocess workers. Default -1 uses every available core.",
+    )
+    lhs.add_argument(
+        "--out",
+        required=True,
+        metavar="PATH",
+        help="Output directory for per-run artefacts and manifest.jsonl.",
+    )
+    lhs.add_argument(
+        "script",
+        metavar="SCRIPT",
+        help="Path to the GMAT .script file.",
+    )
+    lhs.set_defaults(func=_cmd_latin_hypercube)
+
+    explicit = subparsers.add_parser(
+        "explicit",
+        help="Run an explicit-row sweep from a CSV or Parquet sample design.",
+        description=(
+            "Load --samples (CSV or Parquet) into a DataFrame and run one mission "
+            "per row. Column names are dotted-path field names; the row index "
+            "becomes run_id."
+        ),
+    )
+    explicit.add_argument(
+        "--samples",
+        required=True,
+        metavar="PATH",
+        help="Path to a .csv or .parquet sample design.",
+    )
+    explicit.add_argument(
+        "--workers",
+        type=int,
+        default=-1,
+        metavar="N",
+        help="Number of subprocess workers. Default -1 uses every available core.",
+    )
+    explicit.add_argument(
+        "--out",
+        required=True,
+        metavar="PATH",
+        help="Output directory for per-run artefacts and manifest.jsonl.",
+    )
+    explicit.add_argument(
+        "script",
+        metavar="SCRIPT",
+        help="Path to the GMAT .script file.",
+    )
+    explicit.set_defaults(func=_cmd_explicit)
+
+    resume = subparsers.add_parser(
+        "resume",
+        help="Re-run only the failed and missing entries from an existing manifest.",
+        description=(
+            "Reload a manifest.jsonl, rebuild the original run iterable, and "
+            "re-submit only the runs whose latest entry is 'failed' or that have "
+            "no entry on disk yet. Successful runs' Parquet files are reused."
+        ),
+    )
+    resume.add_argument(
+        "manifest",
+        metavar="MANIFEST",
+        help="Path to a manifest.jsonl produced by a prior sweep.",
+    )
+    resume.add_argument(
+        "--script",
+        required=True,
+        metavar="PATH",
+        help=(
+            "Path to the same GMAT .script the original sweep loaded. Its canonical "
+            "SHA-256 must equal the manifest's script_sha256 unless --allow-script-drift "
+            "is set."
+        ),
+    )
+    resume.add_argument(
+        "--workers",
+        type=int,
+        default=-1,
+        metavar="N",
+        help="Number of subprocess workers. Default -1 uses every available core.",
+    )
+    resume.add_argument(
+        "--allow-script-drift",
+        action="store_true",
+        help=(
+            "Proceed even if the script's canonical hash differs from the manifest's. "
+            "Emits a RuntimeWarning."
+        ),
+    )
+    resume.set_defaults(func=_cmd_resume)
 
     return parser
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -396,3 +396,542 @@ def test_run_help_lists_grid_flag(capsys: pytest.CaptureFixture[str]) -> None:
     captured = capsys.readouterr()
     assert "--grid" in captured.out
     assert "lo:hi:count" in captured.out
+
+
+def test_main_help_lists_all_six_subcommands(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["--help"])
+    assert exc_info.value.code == 0
+    out = capsys.readouterr().out
+    for subcommand in ("run", "show", "monte-carlo", "latin-hypercube", "explicit", "resume"):
+        assert subcommand in out
+
+
+# ---- _parse_perturb_spec ------------------------------------------------
+
+
+def test_parse_perturb_spec_normal_returns_tuple_dist() -> None:
+    name, dist = cli._parse_perturb_spec("Sat.SMA=normal:7100:50")
+    assert name == "Sat.SMA"
+    assert dist == ("normal", 7100.0, 50.0)
+
+
+def test_parse_perturb_spec_uniform_returns_tuple_dist() -> None:
+    name, dist = cli._parse_perturb_spec("Sat.INC=uniform:0:90")
+    assert (name, dist) == ("Sat.INC", ("uniform", 0.0, 90.0))
+
+
+def test_parse_perturb_spec_lognormal_returns_tuple_dist() -> None:
+    _, dist = cli._parse_perturb_spec("Sat.DryMass=lognormal:5:0.1")
+    assert dist == ("lognormal", 5.0, 0.1)
+
+
+def test_parse_perturb_spec_rejects_missing_equals() -> None:
+    with pytest.raises(SweepConfigError, match="must contain '='"):
+        cli._parse_perturb_spec("Sat.SMA")
+
+
+def test_parse_perturb_spec_rejects_empty_name() -> None:
+    with pytest.raises(SweepConfigError, match="missing a name"):
+        cli._parse_perturb_spec("=normal:1:2")
+
+
+def test_parse_perturb_spec_rejects_empty_rhs() -> None:
+    with pytest.raises(SweepConfigError, match="no distribution"):
+        cli._parse_perturb_spec("Sat.SMA=")
+
+
+def test_parse_perturb_spec_rejects_wrong_arity() -> None:
+    with pytest.raises(SweepConfigError, match="three colon-separated"):
+        cli._parse_perturb_spec("Sat.SMA=normal:7100")
+
+
+def test_parse_perturb_spec_rejects_unknown_tag() -> None:
+    with pytest.raises(SweepConfigError, match="unknown perturb distribution tag 'zaphod'"):
+        cli._parse_perturb_spec("Sat.SMA=zaphod:1:2")
+
+
+def test_parse_perturb_spec_rejects_non_numeric_params() -> None:
+    with pytest.raises(SweepConfigError, match="must be numeric"):
+        cli._parse_perturb_spec("Sat.SMA=normal:foo:50")
+
+
+# ---- _load_samples ------------------------------------------------------
+
+
+def test_load_samples_csv(tmp_path: Path) -> None:
+    csv = tmp_path / "samples.csv"
+    csv.write_text("Sat.SMA,Sat.ECC\n7100,0.01\n7200,0.02\n", encoding="utf-8")
+    df = cli._load_samples(csv)
+    assert list(df.columns) == ["Sat.SMA", "Sat.ECC"]
+    assert len(df) == 2
+
+
+def test_load_samples_parquet(tmp_path: Path) -> None:
+    df_in = pd.DataFrame({"Sat.SMA": [7100, 7200], "Sat.ECC": [0.01, 0.02]})
+    parquet = tmp_path / "samples.parquet"
+    df_in.to_parquet(parquet)
+    df_out = cli._load_samples(parquet)
+    assert list(df_out.columns) == ["Sat.SMA", "Sat.ECC"]
+    assert len(df_out) == 2
+
+
+def test_load_samples_rejects_unknown_suffix(tmp_path: Path) -> None:
+    bad = tmp_path / "samples.txt"
+    bad.write_text("Sat.SMA\n7100\n", encoding="utf-8")
+    with pytest.raises(SweepConfigError, match="not supported"):
+        cli._load_samples(bad)
+
+
+def test_load_samples_rejects_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(SweepConfigError, match="not found"):
+        cli._load_samples(tmp_path / "no-such-file.csv")
+
+
+# ---- monte-carlo subcommand ---------------------------------------------
+
+
+def test_monte_carlo_writes_manifest_and_prints_summary(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun, capsys: pytest.CaptureFixture[str]
+) -> None:
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    rc = cli.main(
+        [
+            "monte-carlo",
+            "--n",
+            "3",
+            "--perturb",
+            "Sat.SMA=normal:7100:50",
+            "--seed",
+            "42",
+            "--workers",
+            "1",
+            "--out",
+            str(out),
+            str(script),
+        ]
+    )
+
+    assert rc == 0
+    assert (out / "manifest.jsonl").exists()
+    captured = capsys.readouterr()
+    assert "3 runs" in captured.out
+    assert "3 ok" in captured.out
+
+
+def test_monte_carlo_with_two_perturb_flags(tmp_path: Path, fake_gmat_run: FakeGmatRun) -> None:
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    rc = cli.main(
+        [
+            "monte-carlo",
+            "--n",
+            "2",
+            "--perturb",
+            "Sat.SMA=normal:7100:50",
+            "--perturb",
+            "Sat.INC=uniform:0:90",
+            "--seed",
+            "0",
+            "--workers",
+            "1",
+            "--out",
+            str(out),
+            str(script),
+        ]
+    )
+
+    assert rc == 0
+    manifest = Manifest.load(out / "manifest.jsonl")
+    assert manifest.run_count == 2
+    assert sorted(manifest.parameter_spec["perturb"].keys()) == ["Sat.INC", "Sat.SMA"]
+
+
+def test_monte_carlo_rejects_unknown_perturb_tag(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun, capsys: pytest.CaptureFixture[str]
+) -> None:
+    script = _write_script(tmp_path)
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    rc = cli.main(
+        [
+            "monte-carlo",
+            "--n",
+            "1",
+            "--perturb",
+            "Sat.SMA=zaphod:1:2",
+            "--out",
+            str(tmp_path / "out"),
+            str(script),
+        ]
+    )
+    assert rc == cli.EXIT_CONFIG
+    err = capsys.readouterr().err
+    assert "zaphod" in err
+
+
+def test_monte_carlo_rejects_duplicate_perturb_axis(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun, capsys: pytest.CaptureFixture[str]
+) -> None:
+    script = _write_script(tmp_path)
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    rc = cli.main(
+        [
+            "monte-carlo",
+            "--n",
+            "1",
+            "--perturb",
+            "Sat.SMA=normal:7100:50",
+            "--perturb",
+            "Sat.SMA=uniform:6000:8000",
+            "--out",
+            str(tmp_path / "out"),
+            str(script),
+        ]
+    )
+    assert rc == cli.EXIT_CONFIG
+    assert "more than once" in capsys.readouterr().err
+
+
+def test_monte_carlo_rejects_missing_script(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc = cli.main(
+        [
+            "monte-carlo",
+            "--n",
+            "1",
+            "--perturb",
+            "Sat.SMA=normal:7100:50",
+            "--out",
+            str(tmp_path / "out"),
+            str(tmp_path / "does-not-exist.script"),
+        ]
+    )
+    assert rc == cli.EXIT_CONFIG
+    assert "script not found" in capsys.readouterr().err
+
+
+# ---- latin-hypercube subcommand -----------------------------------------
+
+
+def test_latin_hypercube_writes_manifest_and_prints_summary(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun, capsys: pytest.CaptureFixture[str]
+) -> None:
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    rc = cli.main(
+        [
+            "latin-hypercube",
+            "--n",
+            "4",
+            "--perturb",
+            "Sat.SMA=normal:7100:50",
+            "--seed",
+            "42",
+            "--workers",
+            "1",
+            "--out",
+            str(out),
+            str(script),
+        ]
+    )
+
+    assert rc == 0
+    manifest = Manifest.load(out / "manifest.jsonl")
+    assert manifest.run_count == 4
+    assert manifest.parameter_spec["_kind"] == "latin_hypercube"
+    captured = capsys.readouterr()
+    assert "4 runs" in captured.out
+
+
+def test_latin_hypercube_rejects_missing_script(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc = cli.main(
+        [
+            "latin-hypercube",
+            "--n",
+            "2",
+            "--perturb",
+            "Sat.SMA=normal:7100:50",
+            "--out",
+            str(tmp_path / "out"),
+            str(tmp_path / "does-not-exist.script"),
+        ]
+    )
+    assert rc == cli.EXIT_CONFIG
+    assert "script not found" in capsys.readouterr().err
+
+
+# ---- explicit subcommand ------------------------------------------------
+
+
+def test_explicit_with_csv_samples(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun, capsys: pytest.CaptureFixture[str]
+) -> None:
+    script = _write_script(tmp_path)
+    samples = tmp_path / "samples.csv"
+    samples.write_text("Sat.SMA\n7100\n7200\n7300\n", encoding="utf-8")
+    out = tmp_path / "out"
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    rc = cli.main(
+        [
+            "explicit",
+            "--samples",
+            str(samples),
+            "--workers",
+            "1",
+            "--out",
+            str(out),
+            str(script),
+        ]
+    )
+
+    assert rc == 0
+    manifest = Manifest.load(out / "manifest.jsonl")
+    assert manifest.run_count == 3
+    assert manifest.parameter_spec["_kind"] == "explicit"
+    captured = capsys.readouterr()
+    assert "3 runs" in captured.out
+
+
+def test_explicit_with_parquet_samples(tmp_path: Path, fake_gmat_run: FakeGmatRun) -> None:
+    script = _write_script(tmp_path)
+    samples = tmp_path / "samples.parquet"
+    pd.DataFrame({"Sat.SMA": [7100, 7200]}).to_parquet(samples)
+    out = tmp_path / "out"
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    rc = cli.main(
+        [
+            "explicit",
+            "--samples",
+            str(samples),
+            "--workers",
+            "1",
+            "--out",
+            str(out),
+            str(script),
+        ]
+    )
+
+    assert rc == 0
+    manifest = Manifest.load(out / "manifest.jsonl")
+    assert manifest.run_count == 2
+
+
+def test_explicit_rejects_missing_samples_file(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun, capsys: pytest.CaptureFixture[str]
+) -> None:
+    script = _write_script(tmp_path)
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    rc = cli.main(
+        [
+            "explicit",
+            "--samples",
+            str(tmp_path / "no-such-samples.csv"),
+            "--out",
+            str(tmp_path / "out"),
+            str(script),
+        ]
+    )
+    assert rc == cli.EXIT_CONFIG
+    assert "not found" in capsys.readouterr().err
+
+
+def test_explicit_rejects_unknown_samples_suffix(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun, capsys: pytest.CaptureFixture[str]
+) -> None:
+    script = _write_script(tmp_path)
+    samples = tmp_path / "samples.txt"
+    samples.write_text("Sat.SMA\n7100\n", encoding="utf-8")
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    rc = cli.main(
+        [
+            "explicit",
+            "--samples",
+            str(samples),
+            "--out",
+            str(tmp_path / "out"),
+            str(script),
+        ]
+    )
+    assert rc == cli.EXIT_CONFIG
+    assert "not supported" in capsys.readouterr().err
+
+
+def test_explicit_rejects_missing_script(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    samples = tmp_path / "samples.csv"
+    samples.write_text("Sat.SMA\n7100\n", encoding="utf-8")
+    rc = cli.main(
+        [
+            "explicit",
+            "--samples",
+            str(samples),
+            "--out",
+            str(tmp_path / "out"),
+            str(tmp_path / "does-not-exist.script"),
+        ]
+    )
+    assert rc == cli.EXIT_CONFIG
+    assert "script not found" in capsys.readouterr().err
+
+
+# ---- resume subcommand --------------------------------------------------
+
+
+def test_resume_replays_failed_runs(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun, capsys: pytest.CaptureFixture[str]
+) -> None:
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+
+    # First run: one of the two runs fails.
+    def _setitem(_key: str, value: Any) -> None:
+        if value == 8000.0:
+            raise ValueError("first-pass rejection")
+
+    fake_gmat_run.install_loader(setitem_hook=_setitem, run_hook=_payload_run_hook())
+    rc = cli.main(
+        [
+            "run",
+            "--grid",
+            "Sat.SMA=7000:8000:2",
+            "--workers",
+            "1",
+            "--out",
+            str(out),
+            str(script),
+        ]
+    )
+    assert rc == 0
+    capsys.readouterr()  # discard first summary
+
+    # Resume with no setitem failure: the failed run should now succeed.
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+    rc = cli.main(
+        [
+            "resume",
+            str(out / "manifest.jsonl"),
+            "--script",
+            str(script),
+            "--workers",
+            "1",
+        ]
+    )
+    assert rc == 0
+    captured = capsys.readouterr()
+    summary_line = captured.out.splitlines()[0]
+    breakdown = summary_line.split("(", 1)[1].split(")", 1)[0]
+    assert "2 runs" in summary_line
+    assert breakdown == "2 ok"
+
+
+def test_resume_on_missing_manifest_exits_manifest_code(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    script = _write_script(tmp_path)
+    rc = cli.main(
+        [
+            "resume",
+            str(tmp_path / "no-such-manifest.jsonl"),
+            "--script",
+            str(script),
+        ]
+    )
+    assert rc == cli.EXIT_MANIFEST
+    assert "not found" in capsys.readouterr().err
+
+
+def test_resume_on_missing_script_exits_config_code(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun, capsys: pytest.CaptureFixture[str]
+) -> None:
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    cli.main(
+        [
+            "run",
+            "--grid",
+            "a=1,2",
+            "--workers",
+            "1",
+            "--out",
+            str(out),
+            str(script),
+        ]
+    )
+    capsys.readouterr()
+
+    rc = cli.main(
+        [
+            "resume",
+            str(out / "manifest.jsonl"),
+            "--script",
+            str(tmp_path / "does-not-exist.script"),
+        ]
+    )
+    assert rc == cli.EXIT_CONFIG
+    assert "script not found" in capsys.readouterr().err
+
+
+def test_resume_rejects_script_drift(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun, capsys: pytest.CaptureFixture[str]
+) -> None:
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    cli.main(
+        [
+            "run",
+            "--grid",
+            "a=1,2",
+            "--workers",
+            "1",
+            "--out",
+            str(out),
+            str(script),
+        ]
+    )
+    capsys.readouterr()
+
+    # Mutate the script so its canonical hash drifts.
+    script.write_text(
+        "% GMAT mission\nCreate Spacecraft Sat;\nCreate ForceModel FM;\n", encoding="utf-8"
+    )
+
+    rc = cli.main(
+        [
+            "resume",
+            str(out / "manifest.jsonl"),
+            "--script",
+            str(script),
+        ]
+    )
+    assert rc == cli.EXIT_CONFIG
+    assert "script hash mismatch" in capsys.readouterr().err
+
+
+def test_resume_help_lists_allow_script_drift(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["resume", "--help"])
+    assert exc_info.value.code == 0
+    out = capsys.readouterr().out
+    assert "--allow-script-drift" in out
+    assert "--script" in out


### PR DESCRIPTION
## Summary

- Adds four CLI subcommands on top of the existing `run`/`show`, each a thin wrapper over the matching public entry point: `monte-carlo` and `latin-hypercube` take repeatable `--perturb 'name=tag:p1:p2'` flags; `explicit` loads a CSV/Parquet sample design via a new `_load_samples` helper; `resume` calls `Sweep.from_manifest(...).resume()` against an existing manifest with a required `--script PATH`.
- New helpers `_parse_perturb_spec` and `_load_samples` mirror the shape and error style of `_parse_grid_spec`. Exit codes reuse the existing `EXIT_*` constants.
- Adds `docs/cli.md` covering all six subcommands; wired into `mkdocs.yml` and linked from `docs/index.md`.

## Test plan
- [x] `uv run pytest` — 360 passed (54 new cli tests covering each subcommand's success path, the four `EXIT_CONFIG`/`EXIT_MANIFEST` acceptance criteria, and `_parse_perturb_spec` / `_load_samples` unit coverage)
- [x] `uv run ruff check`
- [x] `uv run ruff format --check`
- [x] `uv run mypy`
- [x] `cli.py` coverage: 100% (issue target was ≥85%)
- [ ] CI passes on Ubuntu and Windows

Closes #37