### PR TITLE
Add macOS to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,10 @@ jobs:
     timeout-minutes: 30
     strategy:
       fail-fast: false
-      # 2 OSes × 3 Python minors × 2 GMAT releases = 12 cells. macOS is
-      # deferred to v0.2 per the charter; R2026a is the primary target,
-      # R2025a is the previous release we still support.
+      # 3 OSes × 3 Python minors × 2 GMAT releases = 18 cells. R2026a is the
+      # primary target, R2025a is the previous release we still support.
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.10', '3.11', '3.12']
         gmat-version: [R2025a, R2026a]
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,9 +37,9 @@ uv run ruff format --check  # formatting
 uv run mypy                 # types
 ```
 
-CI re-runs all four on Ubuntu and Windows (macOS is added in v0.2). Integration
-tests run in CI against a cached GMAT install; you do not need to run them
-locally unless you are touching the worker, pool, or aggregation paths.
+CI re-runs all four on Ubuntu, Windows, and macOS. Integration tests run in
+CI against a cached GMAT install; you do not need to run them locally unless
+you are touching the worker, pool, or aggregation paths.
 
 ### Coverage thresholds
 

--- a/README.md
+++ b/README.md
@@ -47,12 +47,11 @@ JSON Lines manifest alongside the results so any sweep is reproducible bit-for-b
 
 | GMAT release | Status | CI |
 |---|---|---|
-| R2026a | Primary development target | Exercised on every PR (Ubuntu + Windows, Python 3.10/3.11/3.12) |
-| R2025a | Supported | Exercised on every PR (Ubuntu + Windows, Python 3.10/3.11/3.12) |
+| R2026a | Primary development target | Exercised on every PR (Ubuntu + Windows + macOS, Python 3.10/3.11/3.12) |
+| R2025a | Supported | Exercised on every PR (Ubuntu + Windows + macOS, Python 3.10/3.11/3.12) |
 
 R2023a and R2024a were never released by the upstream GMAT project; R2025a and R2026a are
-the only releases supported in v0.1. macOS is exercised by `gmat-run` and lands in
-`gmat-sweep`'s CI matrix in v0.2.
+the only releases supported.
 
 ## Installation
 
@@ -140,7 +139,7 @@ Runnable example notebooks:
 | Release | Scope |
 |---|---|
 | **v0.1** *(current)* | Full-factorial `sweep(grid=...)`. `LocalJoblibPool` default backend with subprocess isolation per run. Lazy `(run_id, time)` aggregation from per-run Parquet. JSON Lines manifest with append/fsync durability. `gmat-sweep run`/`show` CLI. Ubuntu + Windows CI on R2025a + R2026a × Python 3.10/3.11/3.12. |
-| **v0.2** *(next)* | `monte_carlo()` and `latin_hypercube()` plus explicit-row `samples=DataFrame` sweeps. Programmatic resume via `Sweep.from_manifest(...).resume()`. Ephemeris and contact aggregation across runs. macOS added to CI. Manifest format frozen as a stable v1 schema. Coverage gate raised to 85%. |
+| **v0.2** *(next)* | `monte_carlo()` and `latin_hypercube()` plus explicit-row `samples=DataFrame` sweeps. Programmatic resume via `Sweep.from_manifest(...).resume()`. Ephemeris and contact aggregation across runs. Manifest format frozen as a stable v1 schema. Coverage gate raised to 85%. |
 
 Past releases live in [`CHANGELOG.md`](CHANGELOG.md).
 

--- a/docs/supported-versions.md
+++ b/docs/supported-versions.md
@@ -1,17 +1,17 @@
 # Supported versions
 
-The CI matrix below is the authoritative supported set for v0.1. `gmat-sweep`
+The CI matrix below is the authoritative supported set. `gmat-sweep`
 runs on every cell on every PR, with both unit and integration suites enabled.
 
-## v0.1 matrix
+## CI matrix
 
 | Axis      | Versions                                                       |
 |-----------|----------------------------------------------------------------|
 | GMAT      | R2025a, R2026a (R2026a is the primary development target)      |
 | Python    | 3.10, 3.11, 3.12                                               |
-| Operating system | Ubuntu (`ubuntu-latest`), Windows (`windows-latest`)    |
+| Operating system | Ubuntu (`ubuntu-latest`), Windows (`windows-latest`), macOS (`macos-latest`) |
 
-That gives 2 × 3 × 2 = 12 cells covered on every PR.
+That gives 2 × 3 × 3 = 18 cells covered on every PR.
 
 ### Notes per axis
 
@@ -26,7 +26,7 @@ walks through unpacking and pointing Python at it.
 
 Older GMAT releases (R2022a and earlier) are not in the matrix. The GMAT
 project skipped public R2023a and R2024a releases, so R2025a and R2026a are
-the only releases supported in v0.1.
+the only releases supported.
 
 #### Python
 
@@ -36,10 +36,10 @@ loky backend ship stable wheels for it.
 
 #### Operating system
 
-macOS is **deferred to v0.2**. The blocker is `setup-gmat`'s macOS support,
-not `gmat-sweep` itself. If you need macOS today, building a stub `Pool`
-implementation that runs jobs in-process is straightforward — see the
-[`Pool`][gmat_sweep.Pool] ABC for the contract.
+`macos-latest` is Apple Silicon (arm64); R2025a and R2026a both ship
+arm64-compatible `gmatpy` bindings, so both versions run natively on the
+runner. GMAT installs are provisioned by `setup-gmat` on macOS the same way
+they are on Linux and Windows.
 
 ## Runtime dependencies
 


### PR DESCRIPTION
## Summary

- Add `macos-latest` to the `test` job matrix in `.github/workflows/ci.yml`. Test coverage is now `{ubuntu-latest, windows-latest, macos-latest} × {3.10, 3.11, 3.12} × {R2025a, R2026a}` = 18 cells.
- Update README's supported-version table and `docs/supported-versions.md` to reflect macOS in CI; rewrite the macOS-deferred note to describe the actual Apple-Silicon coverage.
- Drop "macOS added to CI" from the v0.2 roadmap row in README — it's landing now, not later.
- One-line CONTRIBUTING.md fix so the local-checks paragraph no longer claims macOS arrives later.

The setup-gmat blocker referenced by the issue is satisfied: R2025a and R2026a both have full `macos-latest` coverage in setup-gmat's CI; only the `macos-latest × R2022a` cell is unsupported (irrelevant here — R2022a isn't in this repo's matrix).

The `Operating System :: MacOS` classifier mentioned in the issue body was already present in `pyproject.toml`, so no change there.

Branch protection's required-status-checks list is intentionally not touched — that's deferred to the v0.2 release-cut PR (#42), same way Ubuntu+Windows contexts were added in v0.1's release-cut.

## Test plan

- [ ] All 18 matrix cells go green.
- [ ] Lint, typecheck, minimal-install jobs unaffected.
- [ ] If a macOS-specific failure surfaces (likely culprits: subprocess startup / loky semantics, `signal.SIGINT` in the kill-recovery test, or filesystem path quirks), file a separate v0.2 issue and decide fix-and-block vs skip-and-track per the issue's guidance.

Closes #38