### PR TITLE
Freeze manifest as v1 schema with documented compatibility policy

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -34,6 +34,8 @@ auto-generated from docstrings via
 
 ## Manifest
 
+::: gmat_sweep.MANIFEST_SCHEMA_VERSION
+
 ::: gmat_sweep.Manifest
 
 ::: gmat_sweep.ManifestEntry

--- a/docs/manifest-schema.md
+++ b/docs/manifest-schema.md
@@ -33,29 +33,60 @@ report more runs than the file actually contains during and after a
 
 ```json
 {
+  "schema_version":      1,
   "script_sha256":       "<hex>",
-  "gmat_sweep_version":  "0.1.0",
-  "gmat_run_version":    "0.3.x",
+  "gmat_sweep_version":  "0.2.0",
+  "gmat_run_version":    "0.4.x",
   "gmat_install_version": "R2026a",
   "python_version":      "3.12.x",
   "os_platform":         "Linux-6.x.x-...",
   "sweep_seed":          null,
-  "parameter_spec":      { "<dotted-path>": [<value>, ...], ... },
+  "parameter_spec":      { "_kind": "grid", "<dotted-path>": [<value>, ...], ... },
   "run_count":           <int>
 }
 ```
 
 | Field                  | What it carries                                                                                  |
 |------------------------|--------------------------------------------------------------------------------------------------|
+| `schema_version`       | Manifest schema version. `1` from v0.2 onward. v0.1 manifests omit the field entirely; [`Manifest.load`][gmat_sweep.Manifest.load] treats the absence as `1` for backwards compatibility. See [Compatibility policy](#compatibility-policy). |
 | `script_sha256`        | SHA-256 of the `.script` after line-ending and trailing-newline normalisation. See below.        |
 | `gmat_sweep_version`   | `gmat_sweep.__version__` at sweep time.                                                          |
 | `gmat_run_version`     | `gmat_run.__version__`, or `"unknown"` if `gmat_run` is not importable.                          |
 | `gmat_install_version` | The discovered GMAT install's version string (e.g. `"R2026a"`), or `"unknown"`.                  |
 | `python_version`       | `platform.python_version()`.                                                                     |
 | `os_platform`          | `platform.platform()` — same string `gmat-run` records.                                          |
-| `sweep_seed`           | The seed passed to [`sweep(seed=...)`][gmat_sweep.sweep], or `null`. Reserved for v0.2 Monte Carlo runs. |
-| `parameter_spec`       | The materialised grid for grid sweeps (every iterable expanded to a list, keys preserved verbatim) or a tagged `{"_kind": "explicit", "columns": [...], "rows": [[...]]}` object for explicit-row sweeps. See [Parameter spec](parameter-spec.md#explicit-row-sweeps). |
+| `sweep_seed`           | The seed passed to [`sweep(seed=...)`][gmat_sweep.sweep], [`monte_carlo(seed=...)`][gmat_sweep.monte_carlo], or [`latin_hypercube(seed=...)`][gmat_sweep.latin_hypercube], or `null`. |
+| `parameter_spec`       | The run set the sweep expanded, tagged with a `_kind` discriminator. One of four shapes — see [`parameter_spec` shapes](#parameter_spec-shapes) below. |
 | `run_count`            | The number of runs in the sweep at launch.                                                       |
+
+### `parameter_spec` shapes
+
+The `_kind` discriminator is one of four values, each with its own
+payload shape:
+
+| `_kind`           | Payload (alongside `_kind`) | Written by |
+|-------------------|------------------------------|------------|
+| `"grid"`          | `{"<dotted-path>": [<value>, ...], ...}` — the materialised cartesian product, every iterable expanded to a list, keys preserved verbatim. | [`sweep(grid=...)`][gmat_sweep.sweep] |
+| `"explicit"`      | `{"columns": [<str>, ...], "rows": [[<value>, ...], ...]}` — the input DataFrame as column order plus row-major values. | [`sweep(samples=...)`][gmat_sweep.sweep] |
+| `"monte_carlo"`   | `{"perturb": {<dotted-path>: <serialised dist>, ...}, "n": <int>, "seed": <int> \| null}` — the distribution descriptors plus the parent seed used to derive per-parameter sub-seeds. | [`monte_carlo`][gmat_sweep.monte_carlo] |
+| `"latin_hypercube"` | Same shape as `"monte_carlo"` — the seed is forwarded to [`scipy.stats.qmc.LatinHypercube`][scipy-lh]. | [`latin_hypercube`][gmat_sweep.latin_hypercube] |
+
+[scipy-lh]: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.qmc.LatinHypercube.html
+
+See [Parameter spec](parameter-spec.md) for the user-facing semantics of
+each shape and how to reconstruct the run set from a manifest.
+
+#### v0.1 untagged grid headers
+
+Manifests written by `gmat_sweep` 0.1.x omit `_kind` on grid sweeps and
+present `parameter_spec` as the bare materialised grid:
+
+```json
+{ "parameter_spec": { "<dotted-path>": [<value>, ...], ... } }
+```
+
+These keep loading under v0.2+: the dispatch in [`Sweep.from_manifest`][gmat_sweep.Sweep.from_manifest]
+treats a missing `_kind` as `"grid"`. New sweeps always tag the shape.
 
 ### Canonical script hash
 
@@ -161,3 +192,40 @@ in-memory `entries` list therefore has exactly one entry per
 `run_id`, and [`find_failed`][gmat_sweep.Manifest.find_failed] reflects
 the latest status. See [Resume](resume.md) for the resume flow that
 relies on this.
+
+## Compatibility policy
+
+The on-disk shape is frozen as `schema_version=1` from `gmat_sweep` 0.2
+onward. The exposed constant
+[`gmat_sweep.MANIFEST_SCHEMA_VERSION`][gmat_sweep.MANIFEST_SCHEMA_VERSION]
+is what the running `gmat-sweep` writes and the maximum it accepts on
+load.
+
+**Read rules.**
+
+- A manifest with `schema_version <= MANIFEST_SCHEMA_VERSION` loads. A
+  missing `schema_version` is treated as `1` for v0.1 backwards
+  compatibility.
+- A manifest with `schema_version > MANIFEST_SCHEMA_VERSION` is rejected
+  with [`ManifestCorruptError`][gmat_sweep.ManifestCorruptError]: the
+  reader is older than the writer and may have lost or changed semantics
+  on fields the manifest carries.
+- Unknown extra header fields are silently dropped on load. Older
+  `gmat-sweep` versions can therefore read manifests written by newer
+  versions whenever the new fields are purely additive.
+
+**When to bump `schema_version`.**
+
+| Change | Bump required? |
+|--------|----------------|
+| Adding a new header field | No (additive — older readers ignore it). |
+| Adding a new per-entry field with a documented default | No (older readers ignore it; new readers fall back to the default when reading older manifests). |
+| Removing a header or per-entry field | Yes. |
+| Changing the semantics of an existing field, even if the JSON shape is unchanged | Yes. |
+| Changing the JSON shape of an existing field (e.g. flat to nested) | Yes. |
+| Adding a new `_kind` value to `parameter_spec` | No (additive — older readers will reject the unknown kind at dispatch time, which is the correct behavior; the manifest itself remains parseable). |
+
+A `schema_version` bump is a coordinated change: the writer side
+emits the new value and the reader side learns to interpret the new
+shape. Older `gmat-sweep` versions stop accepting bumped manifests
+on the read side, which is the point of the version field.

--- a/docs/manifest-schema.md
+++ b/docs/manifest-schema.md
@@ -35,11 +35,11 @@ report more runs than the file actually contains during and after a
 {
   "schema_version":      1,
   "script_sha256":       "<hex>",
-  "gmat_sweep_version":  "0.2.0",
-  "gmat_run_version":    "0.4.x",
-  "gmat_install_version": "R2026a",
-  "python_version":      "3.12.x",
-  "os_platform":         "Linux-6.x.x-...",
+  "gmat_sweep_version":  "<x.y.z>",
+  "gmat_run_version":    "<x.y.z>",
+  "gmat_install_version": "<R20yya>",
+  "python_version":      "<x.y.z>",
+  "os_platform":         "<platform.platform()>",
   "sweep_seed":          null,
   "parameter_spec":      { "_kind": "grid", "<dotted-path>": [<value>, ...], ... },
   "run_count":           <int>
@@ -48,7 +48,7 @@ report more runs than the file actually contains during and after a
 
 | Field                  | What it carries                                                                                  |
 |------------------------|--------------------------------------------------------------------------------------------------|
-| `schema_version`       | Manifest schema version. `1` from v0.2 onward. v0.1 manifests omit the field entirely; [`Manifest.load`][gmat_sweep.Manifest.load] treats the absence as `1` for backwards compatibility. See [Compatibility policy](#compatibility-policy). |
+| `schema_version`       | Manifest schema version. Currently `1`. Older manifests that omit the field are loaded as `1` for backwards compatibility. See [Compatibility policy](#compatibility-policy). |
 | `script_sha256`        | SHA-256 of the `.script` after line-ending and trailing-newline normalisation. See below.        |
 | `gmat_sweep_version`   | `gmat_sweep.__version__` at sweep time.                                                          |
 | `gmat_run_version`     | `gmat_run.__version__`, or `"unknown"` if `gmat_run` is not importable.                          |
@@ -76,17 +76,18 @@ payload shape:
 See [Parameter spec](parameter-spec.md) for the user-facing semantics of
 each shape and how to reconstruct the run set from a manifest.
 
-#### v0.1 untagged grid headers
+#### Untagged grid headers
 
-Manifests written by `gmat_sweep` 0.1.x omit `_kind` on grid sweeps and
-present `parameter_spec` as the bare materialised grid:
+Older manifests omit `_kind` on grid sweeps and present `parameter_spec`
+as the bare materialised grid:
 
 ```json
 { "parameter_spec": { "<dotted-path>": [<value>, ...], ... } }
 ```
 
-These keep loading under v0.2+: the dispatch in [`Sweep.from_manifest`][gmat_sweep.Sweep.from_manifest]
-treats a missing `_kind` as `"grid"`. New sweeps always tag the shape.
+These keep loading: the dispatch in
+[`Sweep.from_manifest`][gmat_sweep.Sweep.from_manifest] treats a missing
+`_kind` as `"grid"`. New sweeps always tag the shape.
 
 ### Canonical script hash
 
@@ -195,8 +196,7 @@ relies on this.
 
 ## Compatibility policy
 
-The on-disk shape is frozen as `schema_version=1` from `gmat_sweep` 0.2
-onward. The exposed constant
+The on-disk shape is frozen as `schema_version=1`. The exposed constant
 [`gmat_sweep.MANIFEST_SCHEMA_VERSION`][gmat_sweep.MANIFEST_SCHEMA_VERSION]
 is what the running `gmat-sweep` writes and the maximum it accepts on
 load.
@@ -204,8 +204,8 @@ load.
 **Read rules.**
 
 - A manifest with `schema_version <= MANIFEST_SCHEMA_VERSION` loads. A
-  missing `schema_version` is treated as `1` for v0.1 backwards
-  compatibility.
+  missing `schema_version` is treated as `1` for backwards compatibility
+  with manifests written before the field was introduced.
 - A manifest with `schema_version > MANIFEST_SCHEMA_VERSION` is rejected
   with [`ManifestCorruptError`][gmat_sweep.ManifestCorruptError]: the
   reader is older than the writer and may have lost or changed semantics

--- a/docs/parameter-spec.md
+++ b/docs/parameter-spec.md
@@ -243,9 +243,9 @@ The DataFrame must have:
 
 ### Manifest serialisation
 
-The manifest header records `samples` under `parameter_spec` with a
-discriminator tag so a later loader can tell sample-based sweeps apart
-from untagged grid headers:
+Every parameter-spec shape carries a `_kind` discriminator on the
+manifest header so a later loader can dispatch without inferring the
+sweep kind from which keys are present. The explicit-row shape:
 
 ```json
 {
@@ -266,9 +266,24 @@ m = Manifest.load("./lhs-sweep/manifest.jsonl")
 samples = pd.DataFrame(m.parameter_spec["rows"], columns=m.parameter_spec["columns"])
 ```
 
-Grid sweeps continue to use the untagged
-`{"<dotted-path>": [values, …], …}` header shape — the discriminator only
-appears on explicit-row sweeps.
+Grid sweeps from `gmat_sweep` 0.2 onward emit `_kind: "grid"` alongside
+the materialised axes:
+
+```json
+{
+  "parameter_spec": {
+    "_kind":   "grid",
+    "Sat.SMA": [7000.0, 7100.0],
+    "Sat.ECC": [0.001, 0.002]
+  }
+}
+```
+
+Manifests written by `gmat_sweep` 0.1 omit `_kind` on grid sweeps;
+[`Manifest.load`][gmat_sweep.Manifest.load] keeps loading them by
+treating the absent discriminator as `"grid"`. See [Manifest schema
+→ `parameter_spec` shapes](manifest-schema.md#parameter_spec-shapes)
+for the full enumeration.
 
 ## CLI mini-grammar
 

--- a/docs/parameter-spec.md
+++ b/docs/parameter-spec.md
@@ -266,8 +266,7 @@ m = Manifest.load("./lhs-sweep/manifest.jsonl")
 samples = pd.DataFrame(m.parameter_spec["rows"], columns=m.parameter_spec["columns"])
 ```
 
-Grid sweeps from `gmat_sweep` 0.2 onward emit `_kind: "grid"` alongside
-the materialised axes:
+Grid sweeps emit `_kind: "grid"` alongside the materialised axes:
 
 ```json
 {
@@ -279,11 +278,11 @@ the materialised axes:
 }
 ```
 
-Manifests written by `gmat_sweep` 0.1 omit `_kind` on grid sweeps;
-[`Manifest.load`][gmat_sweep.Manifest.load] keeps loading them by
-treating the absent discriminator as `"grid"`. See [Manifest schema
-→ `parameter_spec` shapes](manifest-schema.md#parameter_spec-shapes)
-for the full enumeration.
+Older manifests that omit `_kind` on grid sweeps keep loading:
+[`Manifest.load`][gmat_sweep.Manifest.load] treats the absent
+discriminator as `"grid"`. See [Manifest schema → `parameter_spec`
+shapes](manifest-schema.md#parameter_spec-shapes) for the full
+enumeration.
 
 ## CLI mini-grammar
 

--- a/src/gmat_sweep/__init__.py
+++ b/src/gmat_sweep/__init__.py
@@ -21,7 +21,12 @@ from gmat_sweep.grids import (
     full_factorial,
     latin_hypercube_samples,
 )
-from gmat_sweep.manifest import Manifest, ManifestEntry, canonical_script_sha256
+from gmat_sweep.manifest import (
+    MANIFEST_SCHEMA_VERSION,
+    Manifest,
+    ManifestEntry,
+    canonical_script_sha256,
+)
 from gmat_sweep.spec import RunOutcome, RunSpec, SweepSpec
 from gmat_sweep.sweep import Sweep
 
@@ -40,6 +45,7 @@ if _logger.level == logging.NOTSET:
     _logger.setLevel(logging.WARNING)
 
 __all__ = [
+    "MANIFEST_SCHEMA_VERSION",
     "BackendError",
     "GmatSweepError",
     "Manifest",

--- a/src/gmat_sweep/api.py
+++ b/src/gmat_sweep/api.py
@@ -118,10 +118,10 @@ def sweep(
         # for the manifest header (generators don't survive json.dumps), so
         # do it up front and reuse the same object.
         materialised_grid: dict[str, list[Any]] = {k: list(v) for k, v in grid.items()}
-        # v1 schema tags every parameter_spec shape with a ``_kind``
-        # discriminator so a downstream reader doesn't have to infer the
-        # sweep kind from the keys present. v0.1 grid manifests omit the tag
-        # and ``Manifest.load`` keeps loading them as if ``_kind="grid"``.
+        # Every parameter_spec shape carries a ``_kind`` discriminator so a
+        # downstream reader doesn't have to infer the sweep kind from the
+        # keys present. Older grid manifests omit the tag, and
+        # ``Manifest.load`` keeps loading them as if ``_kind="grid"``.
         parameter_spec = {"_kind": "grid", **materialised_grid}
 
         def build_runs(output_dir: Path) -> list[RunSpec]:

--- a/src/gmat_sweep/api.py
+++ b/src/gmat_sweep/api.py
@@ -118,16 +118,18 @@ def sweep(
         # for the manifest header (generators don't survive json.dumps), so
         # do it up front and reuse the same object.
         materialised_grid: dict[str, list[Any]] = {k: list(v) for k, v in grid.items()}
-        parameter_spec = materialised_grid
+        # v1 schema tags every parameter_spec shape with a ``_kind``
+        # discriminator so a downstream reader doesn't have to infer the
+        # sweep kind from the keys present. v0.1 grid manifests omit the tag
+        # and ``Manifest.load`` keeps loading them as if ``_kind="grid"``.
+        parameter_spec = {"_kind": "grid", **materialised_grid}
 
         def build_runs(output_dir: Path) -> list[RunSpec]:
             return expand_grid_to_run_specs(materialised_grid, mission_path, output_dir)
     else:
         assert samples is not None  # narrowed by the XOR check above
-        # Tagged shape lets Manifest.load distinguish explicit-row sweeps from
-        # untagged grid headers without breaking back-compat with v0.1 grid
-        # manifests already on disk. ``rows`` is a list-of-lists in column
-        # order so the round-trip is a one-line pd.DataFrame(...) call.
+        # ``rows`` is a list-of-lists in column order so the round-trip is a
+        # one-line pd.DataFrame(...) call.
         parameter_spec = {
             "_kind": "explicit",
             "columns": [str(c) for c in samples.columns],

--- a/src/gmat_sweep/manifest.py
+++ b/src/gmat_sweep/manifest.py
@@ -13,6 +13,14 @@ the original failed entry, so the file may carry two (or more) entries for
 that ``run_id``. :meth:`Manifest.load` keeps only the *last* occurrence per
 ``run_id`` (preserving the position of the *first* occurrence), so the
 in-memory ``entries`` list is deduplicated and the resumed status wins.
+
+The on-disk shape is frozen as ``schema_version=1`` from v0.2 onward; the
+canonical reference is ``docs/manifest-schema.md``. v0.1 manifests written
+before the freeze omitted ``schema_version`` entirely; :meth:`Manifest.load`
+treats a missing field as ``1`` so they keep loading. A header carrying a
+``schema_version`` greater than :data:`MANIFEST_SCHEMA_VERSION` is rejected
+with :class:`ManifestCorruptError` — the running ``gmat-sweep`` is older
+than the manifest's writer and cannot parse it safely.
 """
 
 from __future__ import annotations
@@ -29,7 +37,23 @@ from typing import Any, cast
 from gmat_sweep.errors import ManifestCorruptError
 from gmat_sweep.spec import RunOutcome, RunStatus
 
-__all__ = ["Manifest", "ManifestEntry", "canonical_script_sha256"]
+__all__ = [
+    "MANIFEST_SCHEMA_VERSION",
+    "Manifest",
+    "ManifestEntry",
+    "canonical_script_sha256",
+]
+
+
+MANIFEST_SCHEMA_VERSION: int = 1
+"""On-disk manifest schema version this ``gmat-sweep`` writes and reads.
+
+Frozen from v0.2 onward. :meth:`Manifest.load` accepts any header whose
+``schema_version`` is ``<= MANIFEST_SCHEMA_VERSION`` (a missing field is
+treated as ``1`` for v0.1 backwards compatibility) and rejects anything
+greater. See ``docs/manifest-schema.md`` for the field-by-field contract
+and the compatibility policy that governs future bumps.
+"""
 
 
 def canonical_script_sha256(script_path: Path) -> str:
@@ -121,11 +145,13 @@ class Manifest:
     sweep_seed: int | None
     parameter_spec: dict[str, Any]
     run_count: int
+    schema_version: int = MANIFEST_SCHEMA_VERSION
     entries: list[ManifestEntry] = field(default_factory=list)
     _path: Path | None = field(default=None, init=False, repr=False, compare=False)
 
     def _header_dict(self) -> dict[str, Any]:
         return {
+            "schema_version": self.schema_version,
             "script_sha256": self.script_sha256,
             "gmat_sweep_version": self.gmat_sweep_version,
             "gmat_run_version": self.gmat_run_version,
@@ -139,6 +165,9 @@ class Manifest:
 
     @classmethod
     def _header_from_dict(cls, data: dict[str, Any]) -> Manifest:
+        # schema_version is absent on v0.1 manifests written before the freeze;
+        # default to 1 so they keep loading. Manifest.load() guards against
+        # versions newer than this gmat-sweep supports before getting here.
         return cls(
             script_sha256=str(data["script_sha256"]),
             gmat_sweep_version=str(data["gmat_sweep_version"]),
@@ -149,6 +178,7 @@ class Manifest:
             sweep_seed=None if data["sweep_seed"] is None else int(data["sweep_seed"]),
             parameter_spec=dict(data["parameter_spec"]),
             run_count=int(data["run_count"]),
+            schema_version=int(data.get("schema_version", 1)),
             entries=[],
         )
 
@@ -201,6 +231,23 @@ class Manifest:
             header_data = json.loads(complete_lines[0])
         except json.JSONDecodeError as exc:
             raise ManifestCorruptError(f"manifest header is not valid JSON: {exc}", path) from exc
+
+        # v0.1 manifests omit schema_version; treat as 1. Anything strictly
+        # greater than the running gmat-sweep's supported version is unparseable
+        # by definition — newer schemas may have changed semantics on existing
+        # fields, and we cannot tell from here which fields are still safe.
+        try:
+            schema_version = int(header_data.get("schema_version", 1))
+        except (TypeError, ValueError) as exc:
+            raise ManifestCorruptError(
+                f"manifest schema_version is not an integer: {header_data.get('schema_version')!r}",
+                path,
+            ) from exc
+        if schema_version > MANIFEST_SCHEMA_VERSION:
+            raise ManifestCorruptError(
+                f"manifest schema_version={schema_version} is newer than this gmat-sweep supports",
+                path,
+            )
 
         try:
             manifest = cls._header_from_dict(header_data)

--- a/src/gmat_sweep/manifest.py
+++ b/src/gmat_sweep/manifest.py
@@ -14,12 +14,12 @@ that ``run_id``. :meth:`Manifest.load` keeps only the *last* occurrence per
 ``run_id`` (preserving the position of the *first* occurrence), so the
 in-memory ``entries`` list is deduplicated and the resumed status wins.
 
-The on-disk shape is frozen as ``schema_version=1`` from v0.2 onward; the
-canonical reference is ``docs/manifest-schema.md``. v0.1 manifests written
-before the freeze omitted ``schema_version`` entirely; :meth:`Manifest.load`
-treats a missing field as ``1`` so they keep loading. A header carrying a
-``schema_version`` greater than :data:`MANIFEST_SCHEMA_VERSION` is rejected
-with :class:`ManifestCorruptError` — the running ``gmat-sweep`` is older
+The on-disk shape is frozen as ``schema_version=1``; the canonical
+reference is ``docs/manifest-schema.md``. Older manifests that omit
+``schema_version`` are loaded as ``1`` for backwards compatibility. A
+header carrying a ``schema_version`` greater than
+:data:`MANIFEST_SCHEMA_VERSION` is rejected with
+:class:`ManifestCorruptError` — the running ``gmat-sweep`` is older
 than the manifest's writer and cannot parse it safely.
 """
 
@@ -48,11 +48,12 @@ __all__ = [
 MANIFEST_SCHEMA_VERSION: int = 1
 """On-disk manifest schema version this ``gmat-sweep`` writes and reads.
 
-Frozen from v0.2 onward. :meth:`Manifest.load` accepts any header whose
-``schema_version`` is ``<= MANIFEST_SCHEMA_VERSION`` (a missing field is
-treated as ``1`` for v0.1 backwards compatibility) and rejects anything
-greater. See ``docs/manifest-schema.md`` for the field-by-field contract
-and the compatibility policy that governs future bumps.
+:meth:`Manifest.load` accepts any header whose ``schema_version`` is
+``<= MANIFEST_SCHEMA_VERSION`` (a missing field is treated as ``1`` for
+backwards compatibility with manifests written before the field was
+introduced) and rejects anything greater. See
+``docs/manifest-schema.md`` for the field-by-field contract and the
+compatibility policy that governs future bumps.
 """
 
 
@@ -165,9 +166,10 @@ class Manifest:
 
     @classmethod
     def _header_from_dict(cls, data: dict[str, Any]) -> Manifest:
-        # schema_version is absent on v0.1 manifests written before the freeze;
-        # default to 1 so they keep loading. Manifest.load() guards against
-        # versions newer than this gmat-sweep supports before getting here.
+        # schema_version is absent on manifests written before the field was
+        # introduced; default to 1 so they keep loading. Manifest.load() guards
+        # against versions newer than this gmat-sweep supports before getting
+        # here.
         return cls(
             script_sha256=str(data["script_sha256"]),
             gmat_sweep_version=str(data["gmat_sweep_version"]),

--- a/src/gmat_sweep/sweep.py
+++ b/src/gmat_sweep/sweep.py
@@ -335,12 +335,13 @@ def _build_runs_from_parameter_spec(
 ) -> list[RunSpec]:
     """Reconstruct the run iterable a manifest's ``parameter_spec`` describes.
 
-    Dispatches on ``parameter_spec["_kind"]``: ``"grid"`` is the v1 tagged
-    grid manifest shape; ``None`` (no key) is the v0.1 untagged shape, kept
-    for backwards compatibility and dispatched the same way. The other three
-    kinds round-trip through their matching expander. Resumed Monte Carlo
-    and Latin hypercube runs draw bit-equal values to the original sweep
-    because the expanders are deterministic in ``(perturb, n, seed)``.
+    Dispatches on ``parameter_spec["_kind"]``: ``"grid"`` is the tagged
+    grid shape current sweeps emit; ``None`` (no key) is the older
+    untagged shape kept for backwards compatibility and dispatched the
+    same way. The other three kinds round-trip through their matching
+    expander. Resumed Monte Carlo and Latin hypercube runs draw bit-equal
+    values to the original sweep because the expanders are deterministic
+    in ``(perturb, n, seed)``.
     """
     # Local imports keep gmat_sweep.sweep cycle-free at import time —
     # gmat_sweep.grids depends on gmat_sweep.distributions, which pulls in
@@ -355,8 +356,8 @@ def _build_runs_from_parameter_spec(
 
     kind = parameter_spec.get("_kind")
     if kind is None or kind == "grid":
-        # Both v0.1 untagged and v1 tagged grid manifests carry the
-        # materialised grid as flat top-level keys: {dotted-path: [values]}.
+        # Tagged and untagged grid manifests both carry the materialised
+        # grid as flat top-level keys: {dotted-path: [values]}.
         grid = {k: v for k, v in parameter_spec.items() if k != "_kind"}
         return expand_grid_to_run_specs(grid, script_path, output_dir)
     if kind == "explicit":
@@ -387,7 +388,7 @@ def _build_runs_from_parameter_spec(
     raise SweepConfigError(
         f"unknown parameter_spec _kind: {kind!r} — "
         f"expected one of 'grid', 'explicit', 'monte_carlo', 'latin_hypercube' "
-        f"(or None for v0.1 untagged grid manifests)"
+        f"(or absent, for older untagged grid manifests)"
     )
 
 

--- a/src/gmat_sweep/sweep.py
+++ b/src/gmat_sweep/sweep.py
@@ -335,12 +335,12 @@ def _build_runs_from_parameter_spec(
 ) -> list[RunSpec]:
     """Reconstruct the run iterable a manifest's ``parameter_spec`` describes.
 
-    Dispatches on ``parameter_spec["_kind"]``: ``None`` (no key) is the
-    v0.1 grid manifest shape, kept for backwards compatibility; the four
-    explicit kinds round-trip through their matching expander. Resumed
-    Monte Carlo and Latin hypercube runs draw bit-equal values to the
-    original sweep because the expanders are deterministic in
-    ``(perturb, n, seed)``.
+    Dispatches on ``parameter_spec["_kind"]``: ``"grid"`` is the v1 tagged
+    grid manifest shape; ``None`` (no key) is the v0.1 untagged shape, kept
+    for backwards compatibility and dispatched the same way. The other three
+    kinds round-trip through their matching expander. Resumed Monte Carlo
+    and Latin hypercube runs draw bit-equal values to the original sweep
+    because the expanders are deterministic in ``(perturb, n, seed)``.
     """
     # Local imports keep gmat_sweep.sweep cycle-free at import time —
     # gmat_sweep.grids depends on gmat_sweep.distributions, which pulls in
@@ -354,9 +354,9 @@ def _build_runs_from_parameter_spec(
     )
 
     kind = parameter_spec.get("_kind")
-    if kind is None:
-        # Untagged → v0.1 grid manifest. The mapping is the materialised
-        # grid: {dotted-path: [values]}.
+    if kind is None or kind == "grid":
+        # Both v0.1 untagged and v1 tagged grid manifests carry the
+        # materialised grid as flat top-level keys: {dotted-path: [values]}.
         grid = {k: v for k, v in parameter_spec.items() if k != "_kind"}
         return expand_grid_to_run_specs(grid, script_path, output_dir)
     if kind == "explicit":
@@ -386,7 +386,8 @@ def _build_runs_from_parameter_spec(
         )
     raise SweepConfigError(
         f"unknown parameter_spec _kind: {kind!r} — "
-        f"expected one of None (grid), 'explicit', 'monte_carlo', 'latin_hypercube'"
+        f"expected one of 'grid', 'explicit', 'monte_carlo', 'latin_hypercube' "
+        f"(or None for v0.1 untagged grid manifests)"
     )
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -68,7 +68,10 @@ def test_sweep_writes_manifest_with_grid_in_header(
     )
 
     manifest = Manifest.load(out / "manifest.jsonl")
-    assert manifest.parameter_spec == {"Sat.SMA": [7000.0, 7100.0]}
+    assert manifest.parameter_spec == {
+        "_kind": "grid",
+        "Sat.SMA": [7000.0, 7100.0],
+    }
     assert manifest.sweep_seed == 42
     assert manifest.run_count == 2
 
@@ -307,12 +310,35 @@ def test_sweep_with_samples_non_default_index_raises(
         sweep(script, samples=samples, workers=1, out=tmp_path / "out")
 
 
+def test_sweep_with_grid_writes_grid_kind_in_manifest(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    """Manifest tags ``parameter_spec`` with ``_kind: "grid"`` from v1
+    onward; the materialised axes ride alongside the discriminator."""
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    sweep(
+        script,
+        grid={"Sat.SMA": [7000.0, 7100.0], "Sat.ECC": [0.001, 0.002]},
+        workers=1,
+        out=out,
+    )
+
+    manifest = Manifest.load(out / "manifest.jsonl")
+    spec = manifest.parameter_spec
+    assert spec["_kind"] == "grid"
+    assert spec["Sat.SMA"] == [7000.0, 7100.0]
+    assert spec["Sat.ECC"] == [0.001, 0.002]
+
+
 def test_sweep_with_samples_writes_explicit_kind_in_manifest(
     tmp_path: Path, fake_gmat_run: FakeGmatRun
 ) -> None:
     """Manifest tags the parameter_spec with ``_kind: "explicit"`` so a
-    later loader can distinguish a sample-based sweep from an untagged grid
-    header."""
+    later loader can distinguish a sample-based sweep from a grid sweep."""
     script = _write_script(tmp_path)
     out = tmp_path / "out"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -167,7 +167,9 @@ def test_run_with_two_grid_flags_produces_cartesian_product(
     assert rc == 0
     manifest = Manifest.load(out / "manifest.jsonl")
     assert manifest.run_count == 6
-    assert sorted(manifest.parameter_spec.keys()) == ["Sat.ECC", "Sat.SMA"]
+    assert manifest.parameter_spec["_kind"] == "grid"
+    grid_axes = {k: v for k, v in manifest.parameter_spec.items() if k != "_kind"}
+    assert sorted(grid_axes.keys()) == ["Sat.ECC", "Sat.SMA"]
 
 
 def test_run_with_failing_runs_summary_shows_breakdown(

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -591,11 +591,13 @@ def test_save_writes_schema_version_in_header(tmp_path: Path) -> None:
     assert header["schema_version"] == MANIFEST_SCHEMA_VERSION
 
 
-def test_load_v01_manifest_without_schema_version_loads_as_v1(tmp_path: Path) -> None:
-    """A v0.1 manifest header (no schema_version field) loads as schema_version=1."""
+def test_load_manifest_without_schema_version_loads_as_v1(tmp_path: Path) -> None:
+    """A manifest header that omits schema_version loads as schema_version=1
+    for backwards compatibility with manifests written before the field was
+    introduced."""
     m = _make_manifest(n_entries=2)
     header = m._header_dict()
-    del header["schema_version"]  # pretend we are reading a v0.1-era manifest
+    del header["schema_version"]  # simulate a manifest from before the field landed
 
     path = tmp_path / "manifest.jsonl"
     lines = [json.dumps(header, sort_keys=True)]

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -10,7 +10,12 @@ from typing import Any
 import pytest
 
 from gmat_sweep.errors import ManifestCorruptError
-from gmat_sweep.manifest import Manifest, ManifestEntry, canonical_script_sha256
+from gmat_sweep.manifest import (
+    MANIFEST_SCHEMA_VERSION,
+    Manifest,
+    ManifestEntry,
+    canonical_script_sha256,
+)
 from gmat_sweep.spec import RunOutcome
 
 
@@ -559,6 +564,7 @@ def test_header_dict_carries_every_documented_field() -> None:
     m = _make_manifest()
     header: dict[str, Any] = m._header_dict()
     expected = {
+        "schema_version",
         "script_sha256",
         "gmat_sweep_version",
         "gmat_run_version",
@@ -570,3 +576,74 @@ def test_header_dict_carries_every_documented_field() -> None:
         "run_count",
     }
     assert set(header.keys()) == expected
+
+
+# ---- schema_version freeze ----------------------------------------------
+
+
+def test_save_writes_schema_version_in_header(tmp_path: Path) -> None:
+    """Headers written by this gmat-sweep carry the supported schema version."""
+    m = _make_manifest()
+    path = tmp_path / "manifest.jsonl"
+    m.save(path)
+
+    header = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
+    assert header["schema_version"] == MANIFEST_SCHEMA_VERSION
+
+
+def test_load_v01_manifest_without_schema_version_loads_as_v1(tmp_path: Path) -> None:
+    """A v0.1 manifest header (no schema_version field) loads as schema_version=1."""
+    m = _make_manifest(n_entries=2)
+    header = m._header_dict()
+    del header["schema_version"]  # pretend we are reading a v0.1-era manifest
+
+    path = tmp_path / "manifest.jsonl"
+    lines = [json.dumps(header, sort_keys=True)]
+    lines.extend(json.dumps(e.to_dict(), sort_keys=True) for e in m.entries)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    reloaded = Manifest.load(path)
+    assert reloaded.schema_version == 1
+    assert reloaded.script_sha256 == m.script_sha256
+    assert [e.run_id for e in reloaded.entries] == [0, 1]
+
+
+def test_load_rejects_schema_version_newer_than_supported(tmp_path: Path) -> None:
+    """A header carrying a schema_version greater than the running gmat-sweep
+    supports raises ManifestCorruptError — the reader is older than the writer
+    and may have lost or changed semantics on existing fields."""
+    m = _make_manifest()
+    header = m._header_dict()
+    header["schema_version"] = MANIFEST_SCHEMA_VERSION + 1
+
+    path = tmp_path / "manifest.jsonl"
+    path.write_text(json.dumps(header, sort_keys=True) + "\n", encoding="utf-8")
+
+    with pytest.raises(ManifestCorruptError) as excinfo:
+        Manifest.load(path)
+    assert excinfo.value.path == path
+    assert "schema_version" in str(excinfo.value)
+    assert "newer" in str(excinfo.value)
+
+
+def test_load_rejects_non_integer_schema_version(tmp_path: Path) -> None:
+    m = _make_manifest()
+    header = m._header_dict()
+    header["schema_version"] = "not-an-int"
+
+    path = tmp_path / "manifest.jsonl"
+    path.write_text(json.dumps(header, sort_keys=True) + "\n", encoding="utf-8")
+
+    with pytest.raises(ManifestCorruptError) as excinfo:
+        Manifest.load(path)
+    assert excinfo.value.path == path
+    assert "schema_version" in str(excinfo.value)
+
+
+def test_save_and_load_round_trip_preserves_schema_version(tmp_path: Path) -> None:
+    m = _make_manifest(n_entries=2)
+    path = tmp_path / "manifest.jsonl"
+    m.save(path)
+    reloaded = Manifest.load(path)
+    assert reloaded.schema_version == MANIFEST_SCHEMA_VERSION
+    assert reloaded == m

--- a/tests/test_manifest_replay_contract.py
+++ b/tests/test_manifest_replay_contract.py
@@ -32,6 +32,7 @@ from gmat_sweep.manifest import Manifest, ManifestEntry
 
 _REQUIRED_HEADER_FIELDS: frozenset[str] = frozenset(
     {
+        "schema_version",
         "script_sha256",
         "gmat_sweep_version",
         "gmat_run_version",
@@ -139,6 +140,7 @@ def test_header_round_trips_through_jsonl_bit_equal(tmp_path: Path) -> None:
 
 def test_header_field_types_are_resume_safe() -> None:
     m = _build_manifest_with_every_status()
+    assert isinstance(m.schema_version, int)
     assert isinstance(m.script_sha256, str)
     assert isinstance(m.gmat_sweep_version, str)
     assert isinstance(m.gmat_run_version, str)

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -369,6 +369,9 @@ def _build_grid_manifest(
 
 
 def test_from_manifest_grid_rebuilds_runs(tmp_path: Path, fake_gmat_run: FakeGmatRun) -> None:
+    """v0.1 untagged grid manifests (no ``_kind`` key) keep loading after the
+    v1 schema freeze — ``_build_runs_from_parameter_spec`` treats a missing
+    ``_kind`` as ``"grid"`` for backwards compatibility."""
     script, output_dir = _build_grid_manifest(tmp_path, fake_gmat_run, n=4)
     fake_gmat_run.install_loader(run_hook=_payload_run_hook(rows=1))
 
@@ -382,6 +385,48 @@ def test_from_manifest_grid_rebuilds_runs(tmp_path: Path, fake_gmat_run: FakeGma
 
     assert [s.run_id for s in sweep._runs] == [0, 1, 2, 3]
     assert [s.overrides for s in sweep._runs] == [{"Sat.SMA": 7000.0 + i} for i in range(4)]
+
+
+def test_from_manifest_tagged_grid_kind_rebuilds_runs(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    """A v1 grid manifest written by ``sweep(grid=...)`` carries
+    ``_kind: "grid"``; ``from_manifest`` dispatches it to the same expander
+    as the v0.1 untagged shape."""
+    from gmat_sweep import sweep as sweep_api
+
+    script = _write_script(tmp_path)
+    output_dir = tmp_path / "out"
+
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook(rows=1))
+    sweep_api(
+        script,
+        grid={"Sat.SMA": [7000.0, 7100.0, 7200.0]},
+        workers=1,
+        out=output_dir,
+    )
+
+    # Sanity-check the discriminator made it onto the manifest.
+    from gmat_sweep import Manifest as _Manifest
+
+    saved = _Manifest.load(output_dir / "manifest.jsonl")
+    assert saved.parameter_spec["_kind"] == "grid"
+
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook(rows=1))
+    with LocalJoblibPool(workers=1) as pool:
+        rebuilt = Sweep.from_manifest(
+            output_dir / "manifest.jsonl",
+            script,
+            backend=pool,
+            progress=False,
+        )
+
+    assert [s.run_id for s in rebuilt._runs] == [0, 1, 2]
+    assert [s.overrides for s in rebuilt._runs] == [
+        {"Sat.SMA": 7000.0},
+        {"Sat.SMA": 7100.0},
+        {"Sat.SMA": 7200.0},
+    ]
 
 
 def test_from_manifest_explicit_kind_rebuilds_runs(

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -369,9 +369,9 @@ def _build_grid_manifest(
 
 
 def test_from_manifest_grid_rebuilds_runs(tmp_path: Path, fake_gmat_run: FakeGmatRun) -> None:
-    """v0.1 untagged grid manifests (no ``_kind`` key) keep loading after the
-    v1 schema freeze — ``_build_runs_from_parameter_spec`` treats a missing
-    ``_kind`` as ``"grid"`` for backwards compatibility."""
+    """Untagged grid manifests (no ``_kind`` key) keep loading —
+    ``_build_runs_from_parameter_spec`` treats a missing ``_kind`` as
+    ``"grid"`` for backwards compatibility."""
     script, output_dir = _build_grid_manifest(tmp_path, fake_gmat_run, n=4)
     fake_gmat_run.install_loader(run_hook=_payload_run_hook(rows=1))
 
@@ -390,9 +390,9 @@ def test_from_manifest_grid_rebuilds_runs(tmp_path: Path, fake_gmat_run: FakeGma
 def test_from_manifest_tagged_grid_kind_rebuilds_runs(
     tmp_path: Path, fake_gmat_run: FakeGmatRun
 ) -> None:
-    """A v1 grid manifest written by ``sweep(grid=...)`` carries
-    ``_kind: "grid"``; ``from_manifest`` dispatches it to the same expander
-    as the v0.1 untagged shape."""
+    """A grid manifest written by ``sweep(grid=...)`` carries
+    ``_kind: "grid"``; ``from_manifest`` dispatches it to the same
+    expander as the untagged shape."""
     from gmat_sweep import sweep as sweep_api
 
     script = _write_script(tmp_path)


### PR DESCRIPTION
## Summary

- Add `schema_version=1` to the manifest header and a top-level `MANIFEST_SCHEMA_VERSION` constant. `Manifest.load` treats a missing field as `1` (v0.1 backwards compat) and raises `ManifestCorruptError` on anything greater than the running `gmat-sweep` supports.
- Tag grid sweeps with `_kind: "grid"` so every `parameter_spec` shape carries the discriminator. v0.1 untagged grid manifests keep loading — the dispatch in `_build_runs_from_parameter_spec` treats an absent `_kind` as `"grid"`.
- Rewrite `docs/manifest-schema.md` as the canonical v1 reference: every header field, every `_kind` payload, and a **Compatibility policy** section enumerating which schema changes require a version bump.

## Test plan

- [x] `uv run pytest` — 367 passed, 19 deselected
- [x] `uv run ruff check`
- [x] `uv run ruff format --check`
- [x] `uv run mypy` (strict)
- [x] `uv run mkdocs build --strict`
- [x] `uv run coverage report --include='src/gmat_sweep/manifest.py' --fail-under=95` — 100%
- [x] New tests cover: v0.1 manifest (no `schema_version`) loads as v1; `schema_version=2` rejected; non-int `schema_version` rejected; round-trip preserves the field; `sweep(grid=...)` writes `_kind: "grid"`; `Sweep.from_manifest` reads both the v1 tagged-grid shape and the v0.1 untagged shape.

Closes #39