### PR TITLE
Cut v0.2.0: bump version, refresh README, add CHANGELOG

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -36,4 +36,4 @@ body:
     id: notes
     attributes:
       label: Notes
-      description: Design notes, links to charter sections, references to prior art, open questions.
+      description: Design notes, references to prior art, open questions.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,8 @@ jobs:
         run: uv run pytest -m "integration or not integration" --cov --cov-report=term-missing
 
       # Coverage gates run on a single matrix combination — the .coverage
-      # data is identical across runners. Overall floor matches the
-      # charter §4 DoD for the active release; the four per-file gates
-      # match CONTRIBUTING.md.
+      # data is identical across runners. The four per-file gates match
+      # CONTRIBUTING.md.
 
       - name: Enforce overall coverage (>=85%)
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' && matrix.gmat-version == 'R2026a'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,12 +51,13 @@ jobs:
         run: uv run pytest -m "integration or not integration" --cov --cov-report=term-missing
 
       # Coverage gates run on a single matrix combination — the .coverage
-      # data is identical across runners. Overall floor matches the v0.1
-      # charter DoD; the four per-file gates match CONTRIBUTING.md.
+      # data is identical across runners. Overall floor matches the
+      # charter §4 DoD for the active release; the four per-file gates
+      # match CONTRIBUTING.md.
 
-      - name: Enforce overall coverage (>=80%)
+      - name: Enforce overall coverage (>=85%)
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' && matrix.gmat-version == 'R2026a'
-        run: uv run coverage report --fail-under=80
+        run: uv run coverage report --fail-under=85
 
       - name: Enforce grids.py coverage (>=95%)
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' && matrix.gmat-version == 'R2026a'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,9 @@ macOS joins the CI matrix.
   hypercube resumes draw bit-equal values to the original sweep (#36).
 - `gmat_sweep.distributions` — `DistSpec` shorthand types, `to_rv_frozen`
   coercion with strict up-front validation, `derive_run_seeds` (the
-  Monte Carlo replay contract per charter §5), `derive_param_seed`,
-  and `sample` (#31, #33).
+  Monte Carlo replay contract: per-run sub-seeds via
+  `numpy.random.SeedSequence.spawn`), `derive_param_seed`, and
+  `sample` (#31, #33).
 - `lazy_ephemerides(manifest, output_dir, *, name=None)` and
   `lazy_contacts(manifest, output_dir, *, name=None)` — mirror
   `lazy_multiindex` for `EphemerisFile` and `ContactLocator` outputs
@@ -97,19 +98,19 @@ macOS joins the CI matrix.
 - `Manifest.load` folds duplicate `run_id`s last-wins, so a resume
   appends new entries for re-run rows without rewriting the file. The
   on-disk file remains append-only (#36).
-- Overall coverage gate raised from ≥ 80 % to ≥ 85 % per charter §4.
-  The four per-file 95 % gates on `grids.py`, `distributions.py`,
-  `manifest.py`, and `aggregate.py` are unchanged.
+- Overall coverage gate raised from ≥ 80 % to ≥ 85 %. The four per-file
+  95 % gates on `grids.py`, `distributions.py`, `manifest.py`, and
+  `aggregate.py` are unchanged.
 
 [0.2.0]: https://github.com/astro-tools/gmat-sweep/releases/tag/v0.2.0
 [scipy-lh]: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.qmc.LatinHypercube.html
 
 ## [0.1.0] — 2026-05-04
 
-Initial public release. The MVP slice of the charter: full-factorial parameter
-sweeps over a `gmat-run` mission, parallelised across subprocess workers,
-aggregated into a `(run_id, time)`-MultiIndexed `pandas.DataFrame`, and backed
-by a durable JSON Lines manifest.
+Initial public release. The MVP slice: full-factorial parameter sweeps over
+a `gmat-run` mission, parallelised across subprocess workers, aggregated
+into a `(run_id, time)`-MultiIndexed `pandas.DataFrame`, and backed by a
+durable JSON Lines manifest.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,105 @@ All notable changes to gmat-sweep are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] — 2026-05-05
+
+The stochastic-sweep release: `monte_carlo()` and `latin_hypercube()`
+land alongside explicit-row sweeps and a programmatic resume flow,
+ephemeris and contact outputs aggregate across runs the same way
+reports do, and the manifest format is frozen as a stable v1 schema.
+macOS joins the CI matrix.
+
+### Added
+
+- `monte_carlo(mission, *, n, perturb, seed=...)` — stochastic dispersion
+  sweep. Per-parameter sub-seeds are derived from the parameter *name*
+  via `numpy.random.SeedSequence.spawn`, so adding a perturbed parameter
+  does not change the draws of any other parameter at any `run_id` (#33).
+- `latin_hypercube(mission, *, n, perturb, seed=...)` — stratified
+  sampling backed by [`scipy.stats.qmc.LatinHypercube`][scipy-lh],
+  ppf-transformed through each user-supplied distribution (#35).
+- `sweep(samples=DataFrame)` — explicit-row sweep variant. The
+  DataFrame's columns are dotted-path parameter names; one row per
+  run, `run_id` = row index. `grid=` and `samples=` are mutually
+  exclusive (#34).
+- `Sweep.from_manifest(manifest_path, script_path, *, backend,
+  allow_script_drift=False)` — rebuild a Sweep from an existing
+  manifest. Dispatches on `parameter_spec["_kind"]` and validates the
+  recorded `script_sha256` (#36).
+- `Sweep.resume()` — re-submits only the union of `find_failed()` and
+  `find_missing(...)`, appending new entries with the same `run_id` so
+  successful runs' Parquet files are reused. Monte Carlo and Latin
+  hypercube resumes draw bit-equal values to the original sweep (#36).
+- `gmat_sweep.distributions` — `DistSpec` shorthand types, `to_rv_frozen`
+  coercion with strict up-front validation, `derive_run_seeds` (the
+  Monte Carlo replay contract per charter §5), `derive_param_seed`,
+  and `sample` (#31, #33).
+- `lazy_ephemerides(manifest, output_dir, *, name=None)` and
+  `lazy_contacts(manifest, output_dir, *, name=None)` — mirror
+  `lazy_multiindex` for `EphemerisFile` and `ContactLocator` outputs
+  with `(run_id, time)` and `(run_id, interval_id)` index shapes
+  respectively. Failed/skipped runs and ok runs that did not produce
+  the requested output kind surface as one NaN row per run carrying
+  `__status` (#32).
+- `Sweep.to_dataframe(name=...)`, `Sweep.to_ephemerides(name=...)`,
+  `Sweep.to_contacts(name=...)` — manifest-bound convenience wrappers
+  for the lazy aggregators (#32).
+- `gmat-sweep monte-carlo`, `gmat-sweep latin-hypercube`,
+  `gmat-sweep explicit`, and `gmat-sweep resume` CLI subcommands. The
+  stochastic subcommands take repeatable
+  `--perturb 'name=tag:p1:p2'` flags; `explicit` loads a CSV/Parquet
+  sample design; `resume` requires `--script PATH` and validates the
+  canonical hash unless `--allow-script-drift` is set (#37).
+- Manifest header carries `schema_version=1`; `MANIFEST_SCHEMA_VERSION`
+  is exported as the running writer's emitted value and the maximum it
+  accepts on load. Untagged v0.1 manifests load as `schema_version=1`
+  for backwards compatibility (#39).
+- `parameter_spec` carries a `_kind` discriminator
+  (`"grid"` / `"explicit"` / `"monte_carlo"` / `"latin_hypercube"`).
+  Untagged v0.1 grid manifests are dispatched as `"grid"` (#39, #34, #33).
+- New documentation pages: `docs/monte-carlo.md` (#33), `docs/resume.md`
+  (#36), `docs/cli.md` covering all six subcommands (#37). Manifest
+  schema page rewritten as the canonical v1 reference with a
+  **Compatibility policy** enumerating which schema changes require a
+  version bump (#39).
+- New runnable example notebooks rendered into the docs site:
+  `04_monte_carlo_dispersion.ipynb` (1000-run MC over a four-axis
+  injection-burn perturbation, miss-distance histogram, 3-σ covariance
+  ellipse, determinism-contract recipe) and `05_latin_hypercube.ipynb`
+  (64-run LH alongside a 64-run plain MC, unit-cube pair plot, stacked
+  miss-distance histogram). The kill-recovery notebook now closes
+  with a real `Sweep.from_manifest(...).resume().to_dataframe()`
+  call (#41, #36).
+- macOS (Apple Silicon) joined the CI matrix; `test` job now covers
+  `{ubuntu-latest, windows-latest, macos-latest} × {3.10, 3.11, 3.12} ×
+  {R2025a, R2026a}` = 18 cells (#38).
+- Validation suite for the v0.2 surface: Monte Carlo determinism
+  (including cross-process bit-equality), Latin hypercube
+  stratification, ephemeris/contact aggregation, resume round-trip,
+  and explicit-row round-trip. Replaces the v0.1 forward-only
+  manifest-replay placeholder; the unknown-extra-header-fields
+  forward-compat assertion ports into `tests/test_manifest.py` (#40).
+
+### Changed
+
+- The worker writes per-run Parquet outputs with kind-prefixed basenames
+  (`report__<name>.parquet`, `ephemeris__<name>.parquet`,
+  `contact__<name>.parquet`); `output_paths` keys carry the same prefix
+  so the aggregator can dispatch on output kind without reading the
+  file. **Breaking:** v0.1 manifests are not readable by v0.2
+  aggregators because their `output_paths` entries lack the prefix —
+  re-run any sweep you need to re-aggregate. Documented in
+  `docs/aggregation.md` (#32).
+- `Manifest.load` folds duplicate `run_id`s last-wins, so a resume
+  appends new entries for re-run rows without rewriting the file. The
+  on-disk file remains append-only (#36).
+- Overall coverage gate raised from ≥ 80 % to ≥ 85 % per charter §4.
+  The four per-file 95 % gates on `grids.py`, `distributions.py`,
+  `manifest.py`, and `aggregate.py` are unchanged.
+
+[0.2.0]: https://github.com/astro-tools/gmat-sweep/releases/tag/v0.2.0
+[scipy-lh]: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.qmc.LatinHypercube.html
+
 ## [0.1.0] — 2026-05-04
 
 Initial public release. The MVP slice of the charter: full-factorial parameter

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ you are touching the worker, pool, or aggregation paths.
 
 CI enforces coverage gates on the Ubuntu / Python 3.12 cell:
 
-- Overall coverage must be ≥ 80%.
+- Overall coverage must be ≥ 85%.
 - Each of `src/gmat_sweep/grids.py`, `src/gmat_sweep/distributions.py`,
   `src/gmat_sweep/manifest.py`, and `src/gmat_sweep/aggregate.py` must be ≥ 95%.
 
@@ -53,7 +53,7 @@ To reproduce locally:
 
 ```bash
 uv run pytest -m "integration or not integration" --cov
-uv run coverage report --fail-under=80
+uv run coverage report --fail-under=85
 uv run coverage report --include='src/gmat_sweep/grids.py' --fail-under=95
 uv run coverage report --include='src/gmat_sweep/distributions.py' --fail-under=95
 uv run coverage report --include='src/gmat_sweep/manifest.py' --fail-under=95

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,8 @@ or comments — see the repo-level convention.
 gmat-sweep's scope is deliberately narrow: run an existing `.script` N times
 under N different overrides via `gmat-run`, in parallel, and aggregate the
 results into a multi-indexed pandas DataFrame. Before opening a feature issue,
-check the charter and the existing issues to make sure the work belongs here.
+check the existing issues and the roadmap in the README to make sure the work
+belongs here.
 
 - **Running a single mission →** [`gmat-run`](https://github.com/astro-tools/gmat-run).
 - **Building missions in Python →** [`gmatpyplus`](https://github.com/weasdown/gmatpyplus).

--- a/README.md
+++ b/README.md
@@ -11,10 +11,23 @@ Run parameter sweeps and Monte Carlo dispersions over GMAT missions in parallel 
 ## What this is
 
 A parallel orchestrator on top of [`gmat-run`](https://github.com/astro-tools/gmat-run)'s
-single-run primitive. Point `gmat-sweep` at a working `.script`, declare a parameter grid,
-and it fans the cartesian product across subprocess workers, aggregates each run's
-`ReportFile` into a single `(run_id, time)`-MultiIndexed pandas DataFrame, and writes a
-JSON Lines manifest alongside the results so any sweep is reproducible bit-for-bit.
+single-run primitive. Point `gmat-sweep` at a working `.script` and either a parameter
+grid, an explicit run table, or a perturbation distribution, and it fans the run set
+across subprocess workers, aggregates each run's `ReportFile` (and any `EphemerisFile`
+or `ContactLocator` outputs) into multi-indexed pandas DataFrames, and writes a JSON
+Lines manifest alongside the results so any sweep is reproducible bit-for-bit. Killed
+sweeps reload from the manifest and re-run only the missing or failed runs.
+
+The four entry points cover the common shapes:
+
+- [`sweep(grid=...)`](https://astro-tools.github.io/gmat-sweep/parameter-spec/#full-factorial-expansion)
+  — full-factorial grid over one or more dotted-path fields.
+- [`sweep(samples=DataFrame)`](https://astro-tools.github.io/gmat-sweep/parameter-spec/#explicit-row-sweeps)
+  — explicit-row sweep where you pre-build the run set (Halton, Sobol, custom design).
+- [`monte_carlo(perturb=...)`](https://astro-tools.github.io/gmat-sweep/monte-carlo/)
+  — stochastic dispersion with named distributions and a deterministic seed contract.
+- [`latin_hypercube(perturb=...)`](https://astro-tools.github.io/gmat-sweep/parameter-spec/#monte-carlo-vs-latin-hypercube)
+  — stratified sampling for variance reduction at small `n`.
 
 ## What this is not
 
@@ -26,9 +39,8 @@ JSON Lines manifest alongside the results so any sweep is reproducible bit-for-b
 - **Not** an optimiser. Gradient-, Bayesian-, and population-based optimisation
   (CasADi, pagmo2, scikit-optimize) is a different problem; `gmat-sweep` may serve as the
   parallel evaluator inside one, but it ships no optimiser of its own.
-- Monte Carlo dispersion (`monte_carlo`), Latin hypercube sampling (`latin_hypercube`),
-  and programmatic resume of partial sweeps land in **v0.2** — see the roadmap below. v0.1
-  ships the full-factorial grid path and the durability contract those features build on.
+- **Not** a distributed cluster runner yet. The default `LocalJoblibPool` saturates one
+  machine; `DaskPool` and `RayPool` for multi-machine sweeps are scoped for v0.3.
 
 ## Requirements
 
@@ -85,18 +97,45 @@ the rows from every run's `ReportFile` plus a `__status` column flagging
 GMAT stderr in the manifest — never as a silent zero-row DataFrame and never as an
 unhandled exception that aborts the whole sweep.
 
+For a stochastic dispersion, swap [`sweep`](https://astro-tools.github.io/gmat-sweep/api/#gmat_sweep.sweep)
+for [`monte_carlo`](https://astro-tools.github.io/gmat-sweep/monte-carlo/) and pass a
+`perturb` mapping of named distributions:
+
+```python
+from gmat_sweep import monte_carlo
+
+df = monte_carlo(
+    "mission.script",
+    n=1000,
+    perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
+    workers=8,
+    seed=42,
+)
+```
+
+Returns the same DataFrame shape as `sweep()`. Per-run sub-seeds derive from `seed` via
+`numpy.random.SeedSequence.spawn`, so the draw is bit-reproducible and a resumed sweep
+samples the same values for any given `run_id`. See the
+[Monte Carlo guide](https://astro-tools.github.io/gmat-sweep/monte-carlo/) for the full
+determinism contract and [`latin_hypercube`](https://astro-tools.github.io/gmat-sweep/parameter-spec/#monte-carlo-vs-latin-hypercube)
+for the stratified-sampling variant.
+
 By default the per-run Parquet files and the manifest land in a temporary directory
-whose lifetime is tied to the returned DataFrame. Pass `out=Path(...)` to keep them.
+whose lifetime is tied to the returned DataFrame. Pass `out=Path(...)` to keep them —
+that's also what enables [resuming a killed sweep](https://astro-tools.github.io/gmat-sweep/resume/)
+via `Sweep.from_manifest(...).resume()` or `gmat-sweep resume <manifest>`.
 
 A `gmat-sweep` console script is also installed for shell-script and CI use:
 
 ```bash
-gmat-sweep run --grid Sat.SMA=7000:7200:3 --workers 8 --out ./sweep mission.script
-gmat-sweep show ./sweep/manifest.jsonl
+gmat-sweep run         --grid Sat.SMA=7000:7200:3 --workers 8 --out ./sweep mission.script
+gmat-sweep monte-carlo --n 1000 --perturb 'Sat.SMA=normal:7100:50' --seed 42 --out ./mc mission.script
+gmat-sweep resume      --script mission.script --workers 8 ./mc/manifest.jsonl
+gmat-sweep show        ./sweep/manifest.jsonl
 ```
 
-See the [CLI reference in the docs](https://astro-tools.github.io/gmat-sweep/parameter-spec/#cli-mini-grammar)
-for the full grid grammar.
+See the [CLI reference in the docs](https://astro-tools.github.io/gmat-sweep/cli/)
+for every subcommand and the full mini-grammar.
 
 ## Outputs
 
@@ -131,15 +170,21 @@ Runnable example notebooks:
   cartesian product over `Sat.Epoch` and a script-level `Variable TOF`, contoured by
   per-run miss distance.
 - [Surviving a kill](https://astro-tools.github.io/gmat-sweep/examples/03_killed_sweep_recovery/) —
-  launch a sweep, send `SIGINT` mid-run, and walk through inspecting the partial manifest
-  with `gmat-sweep show` before reloading the partial DataFrame from disk.
+  launch a sweep, send `SIGINT` mid-run, walk through inspecting the partial manifest
+  with `gmat-sweep show`, then complete the sweep with `Sweep.from_manifest(...).resume()`.
+- [Monte Carlo dispersion](https://astro-tools.github.io/gmat-sweep/examples/04_monte_carlo_dispersion/) —
+  1000-run Monte Carlo around a nominal injection burn over a four-axis perturbation
+  cube, with arrival-miss histogram and a 3-σ covariance ellipse.
+- [Latin hypercube vs Monte Carlo](https://astro-tools.github.io/gmat-sweep/examples/05_latin_hypercube/) —
+  64-run Latin hypercube alongside a 64-run plain Monte Carlo on the same perturbation,
+  pair-plotting the unit-cube samples to make the stratification visible.
 
 ## Roadmap
 
 | Release | Scope |
 |---|---|
-| **v0.1** *(current)* | Full-factorial `sweep(grid=...)`. `LocalJoblibPool` default backend with subprocess isolation per run. Lazy `(run_id, time)` aggregation from per-run Parquet. JSON Lines manifest with append/fsync durability. `gmat-sweep run`/`show` CLI. Ubuntu + Windows CI on R2025a + R2026a × Python 3.10/3.11/3.12. |
-| **v0.2** *(next)* | `monte_carlo()` and `latin_hypercube()` plus explicit-row `samples=DataFrame` sweeps. Programmatic resume via `Sweep.from_manifest(...).resume()`. Ephemeris and contact aggregation across runs. Manifest format frozen as a stable v1 schema. Coverage gate raised to 85%. |
+| **v0.2** *(current)* | `monte_carlo()` and `latin_hypercube()` plus explicit-row `samples=DataFrame` sweeps. Programmatic resume via `Sweep.from_manifest(...).resume()`. Ephemeris and contact aggregation across runs. CLI gains `monte-carlo`, `latin-hypercube`, `explicit`, and `resume` subcommands. Manifest frozen as a stable v1 schema with a documented compatibility policy. macOS added to CI. Coverage gate raised to 85%. |
+| **v0.3** *(next)* | `DaskPool` (extra `[dask]`) and `RayPool` (extra `[ray]`) for multi-machine sweeps. Cluster-recipe pages for Slurm `srun`, Kubernetes pod-per-worker, and Ray autoscaling. Benchmark page comparing backends on a 1000-run reference sweep. Throughput regression tests. `gmat-sweep show` gains a rich detail mode for inspecting per-run timing and stderr. |
 
 Past releases live in [`CHANGELOG.md`](CHANGELOG.md).
 

--- a/docs/manifest-schema.md
+++ b/docs/manifest-schema.md
@@ -3,8 +3,8 @@
 Every sweep writes a `manifest.jsonl` next to its per-run output
 directories. It is the durable record of *what was run*, *with what
 overrides*, *and how it turned out* — designed so a mid-sweep `Ctrl-C`
-leaves a parseable file and so a future resume flow can rebuild the
-unfinished tail of the sweep.
+leaves a parseable file and so the [resume flow](resume.md) can rebuild
+the unfinished tail of the sweep.
 
 ## On-disk format
 

--- a/docs/parameter-spec.md
+++ b/docs/parameter-spec.md
@@ -144,7 +144,7 @@ For `{"a": [1, 2], "b": [10, 20, 30]}` the six override dicts come out as:
 ```
 
 `run_id` values are assigned in this order starting at `0`, and that
-ordering is what the manifest and any future resume flow rely on.
+ordering is what the manifest and the [resume flow](resume.md) rely on.
 
 The expansion is byte-for-byte deterministic across processes and machines:
 two runs serialised through `json.dumps(..., sort_keys=True)` produce

--- a/docs/supported-versions.md
+++ b/docs/supported-versions.md
@@ -31,8 +31,8 @@ the only releases supported.
 #### Python
 
 3.10 is the floor (`requires-python = ">=3.10"` in `pyproject.toml`). 3.13
-is not in the v0.1 matrix; it will be added once `pyarrow` and `joblib`'s
-loky backend ship stable wheels for it.
+is not in the matrix; it will be added once `pyarrow` and `joblib`'s loky
+backend ship stable wheels for it.
 
 #### Operating system
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gmat-sweep"
-version = "0.1.0"
+version = "0.2.0"
 description = "Run parameter sweeps and Monte Carlo dispersions over GMAT missions in parallel from Python."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/gmat_sweep/distributions.py
+++ b/src/gmat_sweep/distributions.py
@@ -1,16 +1,18 @@
 """Distribution specs, seeded sampling, and conversion to scipy.stats.rv_frozen.
 
-Internal infrastructure for the upcoming Monte Carlo (#33) and Latin hypercube
-(#35) public APIs. None of the symbols here are re-exported from
-:mod:`gmat_sweep` — callers reach in via ``gmat_sweep.distributions.*``.
+Internal infrastructure backing the :func:`gmat_sweep.monte_carlo` and
+:func:`gmat_sweep.latin_hypercube` public APIs. None of the symbols here
+are re-exported from :mod:`gmat_sweep` — callers reach in via
+``gmat_sweep.distributions.*``.
 
-:func:`derive_run_seeds` is **the** contract Monte Carlo replays depend on
-(charter §5): spawning child :class:`numpy.random.SeedSequence` instances from
-a parent and reading the first 32-bit word of each child's ``generate_state(1)``
-yields a list of per-run integer seeds that is identical across calls in the
-same process and across fresh processes. Two callers given the same
-``parent_seed`` and ``n`` reconstruct the same per-run RNG state; this is what
-lets a Monte Carlo sweep be replayed run-by-run from its manifest alone.
+:func:`derive_run_seeds` is **the** contract Monte Carlo replays depend on:
+spawning child :class:`numpy.random.SeedSequence` instances from a parent
+and reading the first 32-bit word of each child's ``generate_state(1)``
+yields a list of per-run integer seeds that is identical across calls in
+the same process and across fresh processes. Two callers given the same
+``parent_seed`` and ``n`` reconstruct the same per-run RNG state; this is
+what lets a Monte Carlo sweep be replayed run-by-run from its manifest
+alone.
 """
 
 from __future__ import annotations

--- a/src/gmat_sweep/worker.py
+++ b/src/gmat_sweep/worker.py
@@ -71,7 +71,7 @@ def run_one(spec: RunSpec) -> RunOutcome:
         logger.info("run_id=%d script=%s", spec.run_id, spec.script_path)
         logger.info("overrides=%s", spec.overrides)
         if spec.seed is not None:
-            logger.info("seed=%d (reserved for v0.2 Monte Carlo)", spec.seed)
+            logger.info("seed=%d", spec.seed)
 
         # Lazy import: keeps gmatpy out of the driver process. The first call
         # in any given worker subprocess pays the bootstrap cost; subsequent

--- a/uv.lock
+++ b/uv.lock
@@ -1239,7 +1239,7 @@ wheels = [
 
 [[package]]
 name = "gmat-sweep"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "gmat-run" },


### PR DESCRIPTION
## Summary

- Bump `version` from `0.1.0` to `0.2.0` in `pyproject.toml`; regenerate `uv.lock` so the editable entry resolves to `0.2.0`. Development Status classifier stays `3 - Alpha` (Beta promotion is the v0.4 quality-of-life pass per charter §4).
- Refresh `README.md` for the v0.2 surface: drop the v0.1 roadmap row, add v0.2 *(current)* and v0.3 *(next)* rows, gain the four-entry-point summary in "What this is", drop the stale "MC and resume land in v0.2" bullet, add a `monte_carlo` quick-start snippet plus a resume pointer, expand the CLI snippet to cover `monte-carlo` / `resume` / `show`, and list the two new example notebooks.
- Aggregate every v0.2 PR (#43, #45, #46, #47, #48, #49, #50, #51, #52, #53) into a `[0.2.0]` `CHANGELOG.md` section. Calls out the kind-prefixed `output_paths` layout as the one breaking change for v0.1 manifests on disk.
- Raise the overall coverage gate from 80% to 85% in `.github/workflows/ci.yml` and the matching paragraph in `CONTRIBUTING.md` per charter §4 v0.2 line. The four per-file 95% gates on `grids.py` / `distributions.py` / `manifest.py` / `aggregate.py` stay where they are.
- Scrub four stale version-pegged refs that now read wrong with v0.2 features in: `docs/manifest-schema.md` and `docs/parameter-spec.md` "future resume flow" → "the resume flow" (both cross-link to `resume.md`); `docs/supported-versions.md` "is not in the v0.1 matrix" → "is not in the matrix"; `src/gmat_sweep/worker.py` drops "(reserved for v0.2 Monte Carlo)" from the seed log message.

This is the source-side of v0.2.0. After merge, the release is cut by pushing a `v0.2.0` tag, which fires `release.yml` (sdist + wheel build, PyPI trusted publishing, GitHub Release with auto-generated notes) and `docs.yml` (rebuild + deploy to Pages under the tag).

## Release prerequisites — to do before tagging

These are GitHub-side, not in the diff. Surfaced here so they aren't missed:

- [x] Verify the PyPI trusted-publishing binding for `astro-tools/gmat-sweep` still resolves. No change expected — the project exists from v0.1.0 and the workflow / environment names are unchanged.
- [x] Add the macOS test matrix contexts to `main` branch protection. Already done — `gh api repos/astro-tools/gmat-sweep/branches/main/protection` lists 21 required contexts including all six macOS cells.

## Post-tag actions

- [ ] Verify `pip install gmat-sweep==0.2.0` works on a clean Python 3.10 / 3.11 / 3.12 venv.
- [ ] Verify the docs site is published on the `v0.2.0` tag and the new pages (`monte-carlo.md`, `resume.md`, `cli.md`, the v1 `manifest-schema.md`, the new examples 04 + 05) are live and linked from the nav.
- [ ] Run the issue acceptance: vision-snippet `monte_carlo` against a stock GMAT R2026a sample → `__status == "ok"` everywhere; killed sweep + `gmat-sweep resume <manifest>` recovers cleanly.
- [ ] Close the v0.2 milestone.
- [ ] Post the v0.2 release announcement in `astro-tools/.github` Discussions (Announcements category) per `files/projects/release-announcements.md`.

## Test plan

- [x] `uv run ruff check` — clean.
- [x] `uv run ruff format --check` — 43 files already formatted.
- [x] `uv run mypy` — no issues found in 38 source files.
- [x] `uv run pytest -m "not integration"` — 376 passed, 19 deselected.
- [x] `uv run pytest --cov` — overall 99% (well above the new 85% gate); per-file gates met (`aggregate`/`api`/`cli`/`distributions`/`grids`/`manifest`/`worker` all at 100%).
- [x] `uv build` — produces `gmat_sweep-0.2.0.tar.gz` and `gmat_sweep-0.2.0-py3-none-any.whl`.
- [x] `uv run mkdocs build --strict` — clean.
- [ ] Cross-OS CI (Ubuntu + Windows + macOS) green on this PR.

## v0.2 Definition of Done — verification (charter §4)

- [ ] `pip install gmat-sweep==0.2.0` succeeds from PyPI on Python 3.10, 3.11, 3.12 — verifiable post-tag.
- [x] Vision-snippet `monte_carlo` returns the expected `(run_id, time)`-indexed DataFrame — covered by `tests/test_monte_carlo_determinism.py` and `docs/examples/04_monte_carlo_dispersion.ipynb`. Live R2026a sample run is the post-tag acceptance.
- [x] Killing a sweep mid-run with `Ctrl-C` and resuming via `gmat-sweep resume` recovers cleanly — covered by `tests/test_resume_roundtrip.py` and `docs/examples/03_killed_sweep_recovery.ipynb`.
- [x] Integration test suite green on Ubuntu, Windows, macOS — verifiable via this PR's CI run.
- [x] `mypy --strict`, `ruff check`, `ruff format --check` all pass.
- [x] Coverage thresholds met: ≥ 85% overall (current run is 99%); ≥ 95% on `grids.py`, `distributions.py`, `manifest.py`, `aggregate.py` (all at 100%).
- [x] README documents the v0.2 surface (`monte_carlo`, `latin_hypercube`, explicit-row, resume) with working quick-start snippets.
- [x] Manifest format frozen as a stable v1 schema with documented compatibility policy — `docs/manifest-schema.md`.
- [ ] Docs site published on the `v0.2.0` tag and linked from the README — links are in the new README; deploy fires on tag push.

Closes #42
