### PR TITLE
Replace workers= with backend= on sweep/monte_carlo/latin_hypercube

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,12 @@ pip install gmat-sweep[examples]
 ## Quick start
 
 ```python
-from gmat_sweep import sweep
+from gmat_sweep import LocalJoblibPool, sweep
 
 df = sweep(
     "mission.script",
     grid={"Sat.SMA": [7000, 7100, 7200]},
-    workers=8,
+    backend=LocalJoblibPool(workers=8),
 )
 print(df)
 ```
@@ -102,13 +102,13 @@ for [`monte_carlo`](https://astro-tools.github.io/gmat-sweep/monte-carlo/) and p
 `perturb` mapping of named distributions:
 
 ```python
-from gmat_sweep import monte_carlo
+from gmat_sweep import LocalJoblibPool, monte_carlo
 
 df = monte_carlo(
     "mission.script",
     n=1000,
     perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
-    workers=8,
+    backend=LocalJoblibPool(workers=8),
     seed=42,
 )
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -18,6 +18,8 @@ auto-generated from docstrings via
 
 ::: gmat_sweep.Pool
 
+::: gmat_sweep.LocalJoblibPool
+
 ## Specs and outcomes
 
 ::: gmat_sweep.RunSpec

--- a/docs/examples/01_sma_scan.ipynb
+++ b/docs/examples/01_sma_scan.ipynb
@@ -248,7 +248,7 @@
     }
    ],
    "source": [
-    "df = sweep(script_path, grid={\"Sat.SMA\": sma_values}, workers=-1, progress=False)\n",
+    "df = sweep(script_path, grid={\"Sat.SMA\": sma_values}, progress=False)\n",
     "df.head()"
    ]
   },
@@ -297,7 +297,7 @@
    "source": [
     "## Derive altitude and overlay\n",
     "\n",
-    "The script's ReportFile records inertial position only (`Sat.X`, `Sat.Y`, `Sat.Z`) — altitude is a derived quantity. For a spherical Earth it's $|\\mathbf{r}| - R_\\oplus$. We compute it on the whole frame in one vectorised pass; the `(run_id, time)` MultiIndex carries through unchanged."
+    "The script's ReportFile records inertial position only (`Sat.X`, `Sat.Y`, `Sat.Z`) \u2014 altitude is a derived quantity. For a spherical Earth it's $|\\mathbf{r}| - R_\\oplus$. We compute it on the whole frame in one vectorised pass; the `(run_id, time)` MultiIndex carries through unchanged."
    ]
   },
   {
@@ -383,7 +383,7 @@
    "source": [
     "## Where to next\n",
     "\n",
-    "- **Two-axis grids.** [Notebook 02](https://astro-tools.github.io/gmat-sweep/examples/02_epoch_arrival_grid/) adds a second sweep axis (launch epoch × time-of-flight) and contours a per-run scalar across the grid.\n",
+    "- **Two-axis grids.** [Notebook 02](https://astro-tools.github.io/gmat-sweep/examples/02_epoch_arrival_grid/) adds a second sweep axis (launch epoch \u00d7 time-of-flight) and contours a per-run scalar across the grid.\n",
     "- **Inspect a partial sweep after a kill.** [Notebook 03](https://astro-tools.github.io/gmat-sweep/examples/03_killed_sweep_recovery/) demonstrates that the JSON Lines manifest survives a mid-sweep `Ctrl-C` and can be loaded back from disk.\n",
     "- **Keep the per-run Parquet files.** Pass `out=Path(\"./sweep-out\")` to [`sweep()`](https://astro-tools.github.io/gmat-sweep/api/#gmat_sweep.sweep) to anchor the per-run artefacts under an explicit directory instead of a temp dir.\n",
     "- **CLI alternative.** The [`gmat-sweep run`](https://astro-tools.github.io/gmat-sweep/parameter-spec/) shell command wraps the same call for non-Python pipelines."

--- a/docs/examples/02_epoch_arrival_grid.ipynb
+++ b/docs/examples/02_epoch_arrival_grid.ipynb
@@ -5,9 +5,9 @@
    "id": "c1d2a4f0",
    "metadata": {},
    "source": [
-    "# Two-axis epoch × time-of-flight grid\n",
+    "# Two-axis epoch \u00d7 time-of-flight grid\n",
     "\n",
-    "Two-parameter cartesian product over launch epoch (`Sat.Epoch`) and time-of-flight (a script-level `Variable TOF` that drives the `Propagate` stopping condition). The per-run scalar — distance from the final inertial position to a fixed reference point — is reshaped into a 2D matrix and contoured.\n",
+    "Two-parameter cartesian product over launch epoch (`Sat.Epoch`) and time-of-flight (a script-level `Variable TOF` that drives the `Propagate` stopping condition). The per-run scalar \u2014 distance from the final inertial position to a fixed reference point \u2014 is reshaped into a 2D matrix and contoured.\n",
     "\n",
     "This is the smallest end-to-end exercise of the *two-axis* surface: the same [`sweep()`](https://astro-tools.github.io/gmat-sweep/api/#gmat_sweep.sweep) call accepts a grid with multiple keys; the cartesian product is expanded internally and dispatched in parallel.\n",
     "\n",
@@ -133,7 +133,7 @@
    "source": [
     "## Run the sweep\n",
     "\n",
-    "Pass `out=` so the per-run Parquet files and the JSON Lines manifest survive past the call — we'll reload the manifest below to map each `run_id` back to its `(epoch, TOF)` cell. The default `out=None` would tie everything to the DataFrame's lifetime."
+    "Pass `out=` so the per-run Parquet files and the JSON Lines manifest survive past the call \u2014 we'll reload the manifest below to map each `run_id` back to its `(epoch, TOF)` cell. The default `out=None` would tie everything to the DataFrame's lifetime."
    ]
   },
   {
@@ -170,7 +170,6 @@
     "    script_path,\n",
     "    grid={\"Sat.Epoch\": epochs, \"TOF.Value\": tof_seconds},\n",
     "    out=out_dir,\n",
-    "    workers=-1,\n",
     "    progress=False,\n",
     ")\n",
     "df[\"__status\"].value_counts()"
@@ -185,7 +184,7 @@
     "\n",
     "The per-run scalar of interest is the Euclidean distance from the spacecraft's final inertial position to a fixed reference point. The DataFrame is indexed by `(run_id, time)` so we group by `run_id` and take the last row per group; the final timestep is the propagation end-state.\n",
     "\n",
-    "The target point is picked off the orbit's reachable region so the contour shows interesting structure — there is no orbital-mechanics significance."
+    "The target point is picked off the orbit's reachable region so the contour shows interesting structure \u2014 there is no orbital-mechanics significance."
    ]
   },
   {
@@ -236,7 +235,7 @@
    "source": [
     "## Reshape into a 2D matrix\n",
     "\n",
-    "[`Manifest.load`](https://astro-tools.github.io/gmat-sweep/api/#gmat_sweep.Manifest.load) reads back the JSON Lines manifest the sweep wrote. Each entry's `overrides` dict carries the parameters applied to that run — using it to rebuild the `(epoch, TOF)` index avoids relying on the (deterministic but undocumented at the call site) `run_id` ordering convention."
+    "[`Manifest.load`](https://astro-tools.github.io/gmat-sweep/api/#gmat_sweep.Manifest.load) reads back the JSON Lines manifest the sweep wrote. Each entry's `overrides` dict carries the parameters applied to that run \u2014 using it to rebuild the `(epoch, TOF)` index avoids relying on the (deterministic but undocumented at the call site) `run_id` ordering convention."
    ]
   },
   {
@@ -396,7 +395,7 @@
    "source": [
     "## Contour\n",
     "\n",
-    "The contour shows how the arrival miss distance varies across the launch-epoch × time-of-flight grid. The dark band is the locus of `(epoch, TOF)` pairs where the spacecraft's final position is closest to the synthetic target."
+    "The contour shows how the arrival miss distance varies across the launch-epoch \u00d7 time-of-flight grid. The dark band is the locus of `(epoch, TOF)` pairs where the spacecraft's final position is closest to the synthetic target."
    ]
   },
   {
@@ -445,7 +444,7 @@
     "## Where to next\n",
     "\n",
     "- **Survive a kill mid-sweep.** [Notebook 03](https://astro-tools.github.io/gmat-sweep/examples/03_killed_sweep_recovery/) walks through interrupting a sweep with `SIGINT` and reading the partial manifest back from disk.\n",
-    "- **Real porkchop plots** require Lambert targeting and a moving target body — gmat-sweep is a parallel evaluator, not an optimiser. The 2D-grid mechanism shown here is the building block; the targeting layer that turns it into a true porkchop is out of scope (see [`CONTRIBUTING.md`](https://github.com/astro-tools/gmat-sweep/blob/main/CONTRIBUTING.md#scope-discipline)).\n",
+    "- **Real porkchop plots** require Lambert targeting and a moving target body \u2014 gmat-sweep is a parallel evaluator, not an optimiser. The 2D-grid mechanism shown here is the building block; the targeting layer that turns it into a true porkchop is out of scope (see [`CONTRIBUTING.md`](https://github.com/astro-tools/gmat-sweep/blob/main/CONTRIBUTING.md#scope-discipline)).\n",
     "- **Manifest schema.** [Manifest schema](https://astro-tools.github.io/gmat-sweep/manifest-schema/) documents every field the JSON Lines records carry."
    ]
   }

--- a/docs/examples/04_monte_carlo_dispersion.ipynb
+++ b/docs/examples/04_monte_carlo_dispersion.ipynb
@@ -7,9 +7,9 @@
    "source": [
     "# Monte Carlo dispersion\n",
     "\n",
-    "A 1000-run Monte Carlo around a nominal injection burn. The four perturbed axes are a launch-time-slip proxy (`CoastTime.Value` — extra time on the parking orbit before the burn fires) and the three components of the injection delta-V in the spacecraft's VNB local frame (`Inj.Element1/2/3`). Each run propagates from the parking orbit, applies the perturbed burn, propagates a fixed 1200 s, and reports its final inertial position.\n",
+    "A 1000-run Monte Carlo around a nominal injection burn. The four perturbed axes are a launch-time-slip proxy (`CoastTime.Value` \u2014 extra time on the parking orbit before the burn fires) and the three components of the injection delta-V in the spacecraft's VNB local frame (`Inj.Element1/2/3`). Each run propagates from the parking orbit, applies the perturbed burn, propagates a fixed 1200 s, and reports its final inertial position.\n",
     "\n",
-    "The aggregated DataFrame carries one row per `(run_id, time)` — final-step rows give the per-run arrival point, and the empirical covariance of those arrival points yields the 3-sigma ellipse in the (X, Y) plane.\n",
+    "The aggregated DataFrame carries one row per `(run_id, time)` \u2014 final-step rows give the per-run arrival point, and the empirical covariance of those arrival points yields the 3-sigma ellipse in the (X, Y) plane.\n",
     "\n",
     "**Prerequisites.** A local GMAT install (R2026a is the primary development target; see [Supported versions](https://astro-tools.github.io/gmat-sweep/supported-versions/)) and `pip install gmat-sweep[examples]` for the matplotlib dependency."
    ]
@@ -73,8 +73,8 @@
     "\n",
     "Four independent perturbed axes:\n",
     "\n",
-    "- `CoastTime.Value` — normal, mean 600 s, 1-sigma 30 s. Models a launch-time slip as extra time on the parking orbit before the burn. Operationally a 30-second slip translates to a 30-second extra coast in the same orbital geometry.\n",
-    "- `Inj.Element1/2/3` — normal, mean (1.0, 0.0, 0.0) km/s, 1-sigma 5 m/s on each axis. The (V, N, B) components of the injection delta-V; the nominal is a 1 km/s burn along the velocity vector and per-axis dispersions are 0.5 % of the along-track magnitude.\n",
+    "- `CoastTime.Value` \u2014 normal, mean 600 s, 1-sigma 30 s. Models a launch-time slip as extra time on the parking orbit before the burn. Operationally a 30-second slip translates to a 30-second extra coast in the same orbital geometry.\n",
+    "- `Inj.Element1/2/3` \u2014 normal, mean (1.0, 0.0, 0.0) km/s, 1-sigma 5 m/s on each axis. The (V, N, B) components of the injection delta-V; the nominal is a 1 km/s burn along the velocity vector and per-axis dispersions are 0.5 % of the along-track magnitude.\n",
     "\n",
     "The seed is recorded on the manifest the sweep writes; two calls at the same `(n, perturb, seed)` produce bit-equal draws, regardless of process or machine."
    ]
@@ -148,7 +148,6 @@
     "    n=N,\n",
     "    perturb=perturb,\n",
     "    seed=SEED,\n",
-    "    workers=-1,\n",
     "    progress=False,\n",
     ")\n",
     "df[\"__status\"].value_counts()"
@@ -324,7 +323,7 @@
     "\n",
     "[`monte_carlo()`](https://astro-tools.github.io/gmat-sweep/api/#gmat_sweep.monte_carlo) is deterministic in `(mission, n, perturb, seed)`. Two calls at the same seed produce bit-equal draws at every `run_id`; switching to a different seed produces a different draw set.\n",
     "\n",
-    "[`expand_monte_carlo_to_run_specs()`](https://astro-tools.github.io/gmat-sweep/api/#gmat_sweep.expand_monte_carlo_to_run_specs) exposes the per-run `RunSpec.overrides` dict the workers would receive — useful for inspecting a draw set without paying the cost of running it. Two calls at the same `(perturb, n, seed)` build identical specs."
+    "[`expand_monte_carlo_to_run_specs()`](https://astro-tools.github.io/gmat-sweep/api/#gmat_sweep.expand_monte_carlo_to_run_specs) exposes the per-run `RunSpec.overrides` dict the workers would receive \u2014 useful for inspecting a draw set without paying the cost of running it. Two calls at the same `(perturb, n, seed)` build identical specs."
    ]
   },
   {
@@ -391,7 +390,7 @@
     "- **Variance reduction at small `n`.** [Notebook 05](https://astro-tools.github.io/gmat-sweep/examples/05_latin_hypercube/) compares plain Monte Carlo against Latin hypercube sampling at the same `perturb` and the same `n=64`, showing the stratification visually in a pair plot of the unit-cube samples.\n",
     "- **Manifest-driven replay.** Pass `out=Path(\"./mc-run\")` to anchor the per-run Parquet files and the `manifest.jsonl` under an explicit directory; [`Manifest.load`](https://astro-tools.github.io/gmat-sweep/api/#gmat_sweep.Manifest.load) reads the per-run overrides back without re-running.\n",
     "- **Resume after a failure.** [Notebook 03](https://astro-tools.github.io/gmat-sweep/examples/03_killed_sweep_recovery/) walks through a kill mid-sweep followed by a programmatic [`Sweep.from_manifest(...).resume()`](https://astro-tools.github.io/gmat-sweep/resume/) that re-runs only the missing cells.\n",
-    "- **Distribution shapes outside the three shorthands.** [Parameter spec → Stochastic specs](https://astro-tools.github.io/gmat-sweep/parameter-spec/#stochastic-specs) documents the pre-frozen [`scipy.stats`](https://docs.scipy.org/doc/scipy/reference/stats.html) pass-through for triangular, beta, truncated normal, and so on."
+    "- **Distribution shapes outside the three shorthands.** [Parameter spec \u2192 Stochastic specs](https://astro-tools.github.io/gmat-sweep/parameter-spec/#stochastic-specs) documents the pre-frozen [`scipy.stats`](https://docs.scipy.org/doc/scipy/reference/stats.html) pass-through for triangular, beta, truncated normal, and so on."
    ]
   }
  ],

--- a/docs/examples/05_latin_hypercube.ipynb
+++ b/docs/examples/05_latin_hypercube.ipynb
@@ -19,7 +19,7 @@
    "source": [
     "## Set up the run\n",
     "\n",
-    "Same fixture as [notebook 04](https://astro-tools.github.io/gmat-sweep/examples/04_monte_carlo_dispersion/) — a parking orbit, an injection burn `Inj` in VNB, a `CoastTime` variable for the parking-orbit phase, and a fixed post-burn propagation."
+    "Same fixture as [notebook 04](https://astro-tools.github.io/gmat-sweep/examples/04_monte_carlo_dispersion/) \u2014 a parking orbit, an injection burn `Inj` in VNB, a `CoastTime` variable for the parking-orbit phase, and a fixed post-burn propagation."
    ]
   },
   {
@@ -70,10 +70,10 @@
    "source": [
     "## Define the 4-axis perturbation cube\n",
     "\n",
-    "Four independent axes — same shape as [notebook 04](https://astro-tools.github.io/gmat-sweep/examples/04_monte_carlo_dispersion/), so the contrast is purely about how the samples are drawn:\n",
+    "Four independent axes \u2014 same shape as [notebook 04](https://astro-tools.github.io/gmat-sweep/examples/04_monte_carlo_dispersion/), so the contrast is purely about how the samples are drawn:\n",
     "\n",
-    "- `CoastTime.Value` — normal, mean 600 s, 1-sigma 30 s.\n",
-    "- `Inj.Element1/2/3` — normal, mean (1.0, 0.0, 0.0) km/s, 1-sigma 5 m/s on each axis."
+    "- `CoastTime.Value` \u2014 normal, mean 600 s, 1-sigma 30 s.\n",
+    "- `Inj.Element1/2/3` \u2014 normal, mean (1.0, 0.0, 0.0) km/s, 1-sigma 5 m/s on each axis."
    ]
   },
   {
@@ -114,7 +114,7 @@
     "\n",
     "Draw `n=64` unit-cube samples from a Latin hypercube on `d=4` and `n=64` samples from a plain pseudo-random uniform on the same hypercube. Every Latin hypercube column has exactly one sample per `1/n`-wide bin; the pseudo-random columns do not.\n",
     "\n",
-    "The pair plot below shows two of the four axes against each other for both methods. The Latin hypercube panel shows a marginal grid pattern: every horizontal and every vertical strip carries exactly one point. The Monte Carlo panel shows clustering and gaps — the law of large numbers fixes that, but only at much larger `n`."
+    "The pair plot below shows two of the four axes against each other for both methods. The Latin hypercube panel shows a marginal grid pattern: every horizontal and every vertical strip carries exactly one point. The Monte Carlo panel shows clustering and gaps \u2014 the law of large numbers fixes that, but only at much larger `n`."
    ]
   },
   {
@@ -172,7 +172,7 @@
    "source": [
     "## Run both sweeps\n",
     "\n",
-    "[`latin_hypercube()`](https://astro-tools.github.io/gmat-sweep/api/#gmat_sweep.latin_hypercube) and [`monte_carlo()`](https://astro-tools.github.io/gmat-sweep/api/#gmat_sweep.monte_carlo) share their public surface — same script, same perturb, same `n`, same seed. The only difference is how the per-run draws come out of the unit cube before being mapped through each distribution's quantile function."
+    "[`latin_hypercube()`](https://astro-tools.github.io/gmat-sweep/api/#gmat_sweep.latin_hypercube) and [`monte_carlo()`](https://astro-tools.github.io/gmat-sweep/api/#gmat_sweep.monte_carlo) share their public surface \u2014 same script, same perturb, same `n`, same seed. The only difference is how the per-run draws come out of the unit cube before being mapped through each distribution's quantile function."
    ]
   },
   {
@@ -205,8 +205,8 @@
     }
    ],
    "source": [
-    "df_lh = latin_hypercube(script_path, n=N, perturb=perturb, seed=SEED, workers=-1, progress=False)\n",
-    "df_mc = monte_carlo(script_path, n=N, perturb=perturb, seed=SEED, workers=-1, progress=False)\n",
+    "df_lh = latin_hypercube(script_path, n=N, perturb=perturb, seed=SEED, progress=False)\n",
+    "df_mc = monte_carlo(script_path, n=N, perturb=perturb, seed=SEED, progress=False)\n",
     "\n",
     "print(\"LH status counts:\")\n",
     "print(df_lh[\"__status\"].value_counts())\n",
@@ -221,7 +221,7 @@
    "source": [
     "## Arrival-cloud spread comparison\n",
     "\n",
-    "For each method, take the final-step row per run, compute the miss distance to the method's own mean arrival point, and stack the two distributions. The Latin hypercube histogram is tighter and more centred — the variance-reduction case is visible at the same `n`.\n",
+    "For each method, take the final-step row per run, compute the miss distance to the method's own mean arrival point, and stack the two distributions. The Latin hypercube histogram is tighter and more centred \u2014 the variance-reduction case is visible at the same `n`.\n",
     "\n",
     "The two methods estimate the *same* underlying dispersion, so the means line up. The spread of empirical estimators (the histogram tails) is what improves with stratification."
    ]
@@ -305,7 +305,7 @@
     "## Where to next\n",
     "\n",
     "- **Larger samples on the same surface.** [Notebook 04](https://astro-tools.github.io/gmat-sweep/examples/04_monte_carlo_dispersion/) runs the same perturbation cube as a 1000-run Monte Carlo and walks through the histogram + 3-sigma ellipse plus the determinism contract.\n",
-    "- **Stratification details.** [Parameter spec → Monte Carlo vs Latin hypercube](https://astro-tools.github.io/gmat-sweep/parameter-spec/#monte-carlo-vs-latin-hypercube) documents when to reach for each.\n",
+    "- **Stratification details.** [Parameter spec \u2192 Monte Carlo vs Latin hypercube](https://astro-tools.github.io/gmat-sweep/parameter-spec/#monte-carlo-vs-latin-hypercube) documents when to reach for each.\n",
     "- **Distribution shapes.** Both wrappers accept any pre-frozen [`scipy.stats`](https://docs.scipy.org/doc/scipy/reference/stats.html) distribution as a perturb value; the three shorthand tuples are an ergonomic surface, not a hard limit."
    ]
   }

--- a/docs/manifest-schema.md
+++ b/docs/manifest-schema.md
@@ -42,7 +42,8 @@ report more runs than the file actually contains during and after a
   "os_platform":         "<platform.platform()>",
   "sweep_seed":          null,
   "parameter_spec":      { "_kind": "grid", "<dotted-path>": [<value>, ...], ... },
-  "run_count":           <int>
+  "run_count":           <int>,
+  "backend":             "<Pool subclass name>"
 }
 ```
 
@@ -58,6 +59,7 @@ report more runs than the file actually contains during and after a
 | `sweep_seed`           | The seed passed to [`sweep(seed=...)`][gmat_sweep.sweep], [`monte_carlo(seed=...)`][gmat_sweep.monte_carlo], or [`latin_hypercube(seed=...)`][gmat_sweep.latin_hypercube], or `null`. |
 | `parameter_spec`       | The run set the sweep expanded, tagged with a `_kind` discriminator. One of four shapes — see [`parameter_spec` shapes](#parameter_spec-shapes) below. |
 | `run_count`            | The number of runs in the sweep at launch.                                                       |
+| `backend`              | The execution backend's class name (`pool.__class__.__name__`) — e.g. `"LocalJoblibPool"`, `"DaskPool"`, `"RayPool"`, or any third-party `Pool` subclass. Optional on load: manifests written before this field landed report `"unknown"`. |
 
 ### `parameter_spec` shapes
 

--- a/docs/monte-carlo.md
+++ b/docs/monte-carlo.md
@@ -99,7 +99,7 @@ distributes:
 import math
 import pandas as pd
 
-from gmat_sweep import monte_carlo
+from gmat_sweep import LocalJoblibPool, monte_carlo
 
 df = monte_carlo(
     "transfer_porkchop.script",
@@ -112,7 +112,7 @@ df = monte_carlo(
         "Sat.DryMass": ("lognormal", math.log(1200.0), 0.02),
     },
     seed=20260504,
-    workers=8,
+    backend=LocalJoblibPool(workers=8),
     out="./launch-dispersion",
 )
 

--- a/docs/parameter-spec.md
+++ b/docs/parameter-spec.md
@@ -319,6 +319,62 @@ A grid name may only appear once per CLI invocation; passing the same name
 twice raises [`SweepConfigError`][gmat_sweep.SweepConfigError]. There is no
 way to mix linspace and explicit notation on the same axis — pick one.
 
+## Choosing a backend
+
+By default [`sweep()`][gmat_sweep.sweep],
+[`monte_carlo()`][gmat_sweep.monte_carlo], and
+[`latin_hypercube()`][gmat_sweep.latin_hypercube] dispatch runs through a
+fresh [`LocalJoblibPool`][gmat_sweep.LocalJoblibPool] over every available
+core. Pass an explicit pool via `backend=` to:
+
+- **Cap parallelism** for a long-running sweep so the box stays responsive:
+
+    ```python
+    from gmat_sweep import LocalJoblibPool, sweep
+
+    df = sweep(
+        "mission.script",
+        grid={"Sat.SMA": [7000.0, 7100.0, 7200.0, 7300.0]},
+        backend=LocalJoblibPool(workers=4),
+        out="./sweep",
+    )
+    ```
+
+- **Share one pool across several sweeps** — the worker bootstrap cost
+  (fresh interpreter + `gmatpy` import per worker) is paid once instead of
+  once per `sweep()` call:
+
+    ```python
+    from gmat_sweep import LocalJoblibPool, monte_carlo, sweep
+
+    with LocalJoblibPool(workers=8) as pool:
+        baseline = sweep(
+            "mission.script",
+            grid={"Sat.DryMass": [100.0, 150.0, 200.0]},
+            backend=pool,
+            out="./baseline",
+        )
+        dispersion = monte_carlo(
+            "mission.script",
+            n=200,
+            perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
+            seed=42,
+            backend=pool,
+            out="./dispersion",
+        )
+    ```
+
+- **Use a different execution backend** — any [`Pool`][gmat_sweep.Pool]
+  subclass works, including third-party ones. The pool's class name is
+  recorded on the manifest header so a later loader can tell which
+  backend produced the sweep.
+
+When you supply `backend=`, you own the pool's lifecycle —
+[`sweep()`][gmat_sweep.sweep] will not call
+[`Pool.close()`][gmat_sweep.Pool.close] on it. Wrap it in a `with` block,
+or call `close()` yourself when the pool is done. The `backend=None`
+default closes the pool it built when `sweep()` returns.
+
 ## See also
 
 - [API reference: `sweep`](api.md#gmat_sweep.sweep)

--- a/src/gmat_sweep/__init__.py
+++ b/src/gmat_sweep/__init__.py
@@ -5,7 +5,7 @@ from importlib.metadata import PackageNotFoundError, version
 
 from gmat_sweep.aggregate import lazy_contacts, lazy_ephemerides, lazy_multiindex
 from gmat_sweep.api import latin_hypercube, monte_carlo, sweep
-from gmat_sweep.backends import Pool
+from gmat_sweep.backends import LocalJoblibPool, Pool
 from gmat_sweep.errors import (
     BackendError,
     GmatSweepError,
@@ -48,6 +48,7 @@ __all__ = [
     "MANIFEST_SCHEMA_VERSION",
     "BackendError",
     "GmatSweepError",
+    "LocalJoblibPool",
     "Manifest",
     "ManifestCorruptError",
     "ManifestEntry",

--- a/src/gmat_sweep/api.py
+++ b/src/gmat_sweep/api.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import contextlib
 import tempfile
 import weakref
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Iterable, Iterator, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from gmat_sweep.backends.base import Pool
 from gmat_sweep.backends.joblib import LocalJoblibPool
 from gmat_sweep.distributions import DistSpec, _serialise_perturb
 from gmat_sweep.errors import SweepConfigError
@@ -36,7 +38,7 @@ def sweep(
     *,
     grid: Mapping[str, Iterable[Any]] | None = None,
     samples: pd.DataFrame | None = None,
-    workers: int = -1,
+    backend: Pool | None = None,
     out: Path | None = None,
     seed: int | None = None,
     progress: bool = True,
@@ -47,9 +49,10 @@ def sweep(
     full-factorial cartesian product, or ``samples=`` for an explicit
     pre-built DataFrame (one run per row, columns are dotted-path field
     names). Exactly one must be provided. The expanded run set is dispatched
-    through a fresh :class:`LocalJoblibPool`, each completion is appended to
-    a JSON Lines manifest under ``out``, and the aggregated
-    ``(run_id, time)``-MultiIndexed :class:`pandas.DataFrame` is returned.
+    through ``backend`` (defaulting to a fresh :class:`LocalJoblibPool` over
+    every available core), each completion is appended to a JSON Lines
+    manifest under ``out``, and the aggregated ``(run_id, time)``-MultiIndexed
+    :class:`pandas.DataFrame` is returned.
 
     Parameters
     ----------
@@ -66,10 +69,15 @@ def sweep(
         becomes ``run_id``; non-default indices raise. Mutually exclusive with
         ``grid``. Use this when you have already built a sample design (Latin
         hypercube, Halton/Sobol, custom) and want to hand it in directly.
-    workers:
-        Number of subprocess workers. ``-1`` (default) uses every available
-        core; positive integers cap the pool. Forwarded to
-        :class:`LocalJoblibPool`.
+    backend:
+        A constructed :class:`Pool` to dispatch runs through. ``None``
+        (default) constructs a fresh :class:`LocalJoblibPool` over every
+        available core for the duration of the call and closes it on the way
+        out. Pass an explicit pool to cap parallelism
+        (``LocalJoblibPool(workers=4)``), to use a different execution
+        backend (Dask, Ray, a custom subclass), or to share one pool across
+        several sweeps — when supplied, the caller owns the pool's lifecycle
+        and ``sweep()`` does not call :meth:`Pool.close`.
     out:
         Sweep output directory. ``None`` (default) creates a fresh
         :class:`tempfile.TemporaryDirectory` whose lifetime is tied to the
@@ -144,7 +152,7 @@ def sweep(
         build_runs=build_runs,
         parameter_spec=parameter_spec,
         sweep_seed=seed,
-        workers=workers,
+        backend=backend,
         out=out,
         progress=progress,
     )
@@ -156,7 +164,7 @@ def monte_carlo(
     n: int,
     perturb: Mapping[str, DistSpec],
     seed: int | None = None,
-    workers: int = -1,
+    backend: Pool | None = None,
     out: Path | None = None,
     progress: bool = True,
 ) -> pd.DataFrame:
@@ -185,8 +193,8 @@ def monte_carlo(
         Optional integer parent seed. ``None`` falls back to OS entropy and
         is **not** reproducible. With an integer seed two calls at the same
         ``(mission, n, perturb, seed)`` produce bit-equal DataFrames.
-    workers:
-        Number of subprocess workers; same semantics as :func:`sweep`.
+    backend:
+        Execution backend; same semantics as :func:`sweep`.
     out:
         Sweep output directory; same semantics as :func:`sweep`.
     progress:
@@ -224,7 +232,7 @@ def monte_carlo(
         build_runs=build_runs,
         parameter_spec=parameter_spec,
         sweep_seed=seed,
-        workers=workers,
+        backend=backend,
         out=out,
         progress=progress,
     )
@@ -236,7 +244,7 @@ def latin_hypercube(
     n: int,
     perturb: Mapping[str, DistSpec],
     seed: int | None = None,
-    workers: int = -1,
+    backend: Pool | None = None,
     out: Path | None = None,
     progress: bool = True,
 ) -> pd.DataFrame:
@@ -264,7 +272,7 @@ def latin_hypercube(
         entropy and is **not** reproducible. With an integer seed two calls
         at the same ``(mission, n, perturb, seed)`` produce bit-equal
         DataFrames.
-    workers:
+    backend:
         Same semantics as :func:`sweep`.
     out:
         Same semantics as :func:`sweep`.
@@ -301,10 +309,25 @@ def latin_hypercube(
         build_runs=build_runs,
         parameter_spec=parameter_spec,
         sweep_seed=seed,
-        workers=workers,
+        backend=backend,
         out=out,
         progress=progress,
     )
+
+
+@contextlib.contextmanager
+def _resolve_pool(backend: Pool | None) -> Iterator[Pool]:
+    """Yield the pool to dispatch through, owning lifecycle iff we built it.
+
+    ``backend is None`` constructs a default :class:`LocalJoblibPool` and
+    closes it on exit; a user-supplied pool is yielded as-is and the caller
+    keeps lifecycle ownership.
+    """
+    if backend is None:
+        with LocalJoblibPool() as pool:
+            yield pool
+    else:
+        yield backend
 
 
 def _run_sweep(
@@ -313,7 +336,7 @@ def _run_sweep(
     build_runs: Callable[[Path], list[RunSpec]],
     parameter_spec: dict[str, Any],
     sweep_seed: int | None,
-    workers: int,
+    backend: Pool | None,
     out: Path | None,
     progress: bool,
 ) -> pd.DataFrame:
@@ -321,9 +344,10 @@ def _run_sweep(
 
     Resolves the output directory (creating a sweep-scoped temp dir when
     ``out`` is ``None``), builds the run set against that directory, runs
-    them through a fresh :class:`LocalJoblibPool`, and returns the
-    aggregated DataFrame. When a temp dir was created its cleanup is
-    deferred to the moment the returned DataFrame is garbage-collected.
+    them through ``backend`` (or a default :class:`LocalJoblibPool` when
+    ``backend is None``), and returns the aggregated DataFrame. When a temp
+    dir was created its cleanup is deferred to the moment the returned
+    DataFrame is garbage-collected.
     """
     tempdir: tempfile.TemporaryDirectory[str] | None
     if out is None:
@@ -337,7 +361,7 @@ def _run_sweep(
     runs = build_runs(output_dir)
     manifest_path = output_dir / _MANIFEST_FILENAME
 
-    with LocalJoblibPool(workers=workers) as pool:
+    with _resolve_pool(backend) as pool:
         df = (
             Sweep(
                 runs=runs,

--- a/src/gmat_sweep/cli.py
+++ b/src/gmat_sweep/cli.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from gmat_sweep.api import latin_hypercube, monte_carlo, sweep
+from gmat_sweep.backends.joblib import LocalJoblibPool
 from gmat_sweep.errors import (
     BackendError,
     GmatSweepError,
@@ -219,7 +220,8 @@ def _cmd_run(args: argparse.Namespace) -> int:
         grid[name] = values
 
     out = Path(args.out)
-    sweep(script, grid=grid, workers=args.workers, out=out)
+    with LocalJoblibPool(workers=args.workers) as pool:
+        sweep(script, grid=grid, backend=pool, out=out)
 
     manifest = Manifest.load(out / "manifest.jsonl")
     print(_format_summary(manifest, out))
@@ -255,14 +257,15 @@ def _cmd_monte_carlo(args: argparse.Namespace) -> int:
 
     perturb = _collect_perturb(args.perturb)
     out = Path(args.out)
-    monte_carlo(
-        script,
-        n=args.n,
-        perturb=perturb,
-        seed=args.seed,
-        workers=args.workers,
-        out=out,
-    )
+    with LocalJoblibPool(workers=args.workers) as pool:
+        monte_carlo(
+            script,
+            n=args.n,
+            perturb=perturb,
+            seed=args.seed,
+            backend=pool,
+            out=out,
+        )
 
     manifest = Manifest.load(out / "manifest.jsonl")
     print(_format_summary(manifest, out))
@@ -277,14 +280,15 @@ def _cmd_latin_hypercube(args: argparse.Namespace) -> int:
 
     perturb = _collect_perturb(args.perturb)
     out = Path(args.out)
-    latin_hypercube(
-        script,
-        n=args.n,
-        perturb=perturb,
-        seed=args.seed,
-        workers=args.workers,
-        out=out,
-    )
+    with LocalJoblibPool(workers=args.workers) as pool:
+        latin_hypercube(
+            script,
+            n=args.n,
+            perturb=perturb,
+            seed=args.seed,
+            backend=pool,
+            out=out,
+        )
 
     manifest = Manifest.load(out / "manifest.jsonl")
     print(_format_summary(manifest, out))
@@ -299,7 +303,8 @@ def _cmd_explicit(args: argparse.Namespace) -> int:
 
     samples = _load_samples(Path(args.samples))
     out = Path(args.out)
-    sweep(script, samples=samples, workers=args.workers, out=out)
+    with LocalJoblibPool(workers=args.workers) as pool:
+        sweep(script, samples=samples, backend=pool, out=out)
 
     manifest = Manifest.load(out / "manifest.jsonl")
     print(_format_summary(manifest, out))
@@ -316,9 +321,7 @@ def _cmd_resume(args: argparse.Namespace) -> int:
         print(f"gmat-sweep: script not found: {script}", file=sys.stderr)
         return EXIT_CONFIG
 
-    # Local imports keep gmat_sweep.cli's import-time surface narrow — these
-    # are only needed by the resume path.
-    from gmat_sweep.backends.joblib import LocalJoblibPool
+    # Local import: only the resume path drives Sweep directly.
     from gmat_sweep.sweep import Sweep
 
     with LocalJoblibPool(workers=args.workers) as pool:

--- a/src/gmat_sweep/manifest.py
+++ b/src/gmat_sweep/manifest.py
@@ -146,6 +146,7 @@ class Manifest:
     sweep_seed: int | None
     parameter_spec: dict[str, Any]
     run_count: int
+    backend: str = "unknown"
     schema_version: int = MANIFEST_SCHEMA_VERSION
     entries: list[ManifestEntry] = field(default_factory=list)
     _path: Path | None = field(default=None, init=False, repr=False, compare=False)
@@ -162,6 +163,7 @@ class Manifest:
             "sweep_seed": self.sweep_seed,
             "parameter_spec": dict(self.parameter_spec),
             "run_count": self.run_count,
+            "backend": self.backend,
         }
 
     @classmethod
@@ -169,7 +171,8 @@ class Manifest:
         # schema_version is absent on manifests written before the field was
         # introduced; default to 1 so they keep loading. Manifest.load() guards
         # against versions newer than this gmat-sweep supports before getting
-        # here.
+        # here. ``backend`` is additive — manifests that omit it load with
+        # ``backend == "unknown"``.
         return cls(
             script_sha256=str(data["script_sha256"]),
             gmat_sweep_version=str(data["gmat_sweep_version"]),
@@ -180,6 +183,7 @@ class Manifest:
             sweep_seed=None if data["sweep_seed"] is None else int(data["sweep_seed"]),
             parameter_spec=dict(data["parameter_spec"]),
             run_count=int(data["run_count"]),
+            backend=str(data.get("backend", "unknown")),
             schema_version=int(data.get("schema_version", 1)),
             entries=[],
         )

--- a/src/gmat_sweep/sweep.py
+++ b/src/gmat_sweep/sweep.py
@@ -324,6 +324,7 @@ class Sweep:
             sweep_seed=self._sweep_seed,
             parameter_spec=self._parameter_spec,
             run_count=len(self._runs),
+            backend=self._backend.__class__.__name__,
         )
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,6 +10,7 @@ import pandas as pd
 import pytest
 
 from gmat_sweep.api import latin_hypercube, monte_carlo, sweep
+from gmat_sweep.backends.joblib import LocalJoblibPool
 from gmat_sweep.errors import SweepConfigError
 from gmat_sweep.manifest import Manifest
 from tests.conftest import FakeGmatRun, FakeResults
@@ -42,7 +43,7 @@ def test_sweep_returns_multiindexed_dataframe(tmp_path: Path, fake_gmat_run: Fak
     df = sweep(
         script,
         grid={"Sat.SMA": [7000.0, 7100.0]},
-        workers=1,
+        backend=LocalJoblibPool(workers=1),
         out=out,
     )
 
@@ -62,7 +63,7 @@ def test_sweep_writes_manifest_with_grid_in_header(
     sweep(
         script,
         grid={"Sat.SMA": [7000.0, 7100.0]},
-        workers=1,
+        backend=LocalJoblibPool(workers=1),
         out=out,
         seed=42,
     )
@@ -85,7 +86,7 @@ def test_sweep_string_path_is_accepted(tmp_path: Path, fake_gmat_run: FakeGmatRu
     df = sweep(
         str(script),
         grid={"Sat.SMA": [7000.0]},
-        workers=1,
+        backend=LocalJoblibPool(workers=1),
         out=out,
     )
 
@@ -101,7 +102,7 @@ def test_sweep_creates_out_directory_when_missing(
 
     fake_gmat_run.install_loader(run_hook=_payload_run_hook())
 
-    sweep(script, grid={"Sat.SMA": [7000.0]}, workers=1, out=out)
+    sweep(script, grid={"Sat.SMA": [7000.0]}, backend=LocalJoblibPool(workers=1), out=out)
 
     assert out.is_dir()
     assert (out / "manifest.jsonl").exists()
@@ -122,7 +123,7 @@ def test_sweep_with_no_out_returns_usable_dataframe(
     df = sweep(
         script,
         grid={"Sat.SMA": [7000.0]},
-        workers=1,
+        backend=LocalJoblibPool(workers=1),
         out=None,
     )
 
@@ -149,7 +150,7 @@ def test_sweep_with_no_out_cleans_up_temp_dir_after_df_dropped(
     script = _write_script(tmp_path)
     fake_gmat_run.install_loader(run_hook=_payload_run_hook())
 
-    df = sweep(script, grid={"Sat.SMA": [7000.0]}, workers=1, out=None)
+    df = sweep(script, grid={"Sat.SMA": [7000.0]}, backend=LocalJoblibPool(workers=1), out=None)
 
     assert len(captured_paths) == 1
     sweep_dir = captured_paths[0]
@@ -179,7 +180,7 @@ def test_sweep_with_failing_run_includes_failed_row(
     df = sweep(
         script,
         grid={"Sat.SMA": [7000.0, 7100.0]},
-        workers=1,
+        backend=LocalJoblibPool(workers=1),
         out=out,
     )
 
@@ -197,7 +198,7 @@ def test_sweep_with_empty_grid_runs_once(tmp_path: Path, fake_gmat_run: FakeGmat
 
     fake_gmat_run.install_loader(run_hook=_payload_run_hook())
 
-    df = sweep(script, grid={}, workers=1, out=out)
+    df = sweep(script, grid={}, backend=LocalJoblibPool(workers=1), out=out)
 
     run_ids = sorted(df.index.get_level_values("run_id").unique().tolist())
     assert run_ids == [0]
@@ -220,11 +221,123 @@ def test_sweep_progress_false_quiet_on_stderr(
 
     fake_gmat_run.install_loader(run_hook=_payload_run_hook())
 
-    sweep(script, grid={"Sat.SMA": [7000.0, 7100.0]}, workers=1, out=out, progress=False)
+    sweep(
+        script,
+        grid={"Sat.SMA": [7000.0, 7100.0]},
+        backend=LocalJoblibPool(workers=1),
+        out=out,
+        progress=False,
+    )
 
     captured = capsys.readouterr()
     assert "gmat-sweep" not in captured.err
     assert "%" not in captured.err
+
+
+# ---- backend= plumbing ---------------------------------------------------
+
+
+def test_sweep_default_backend_constructs_local_joblib_pool(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When ``backend=`` is omitted, ``_run_sweep`` builds a LocalJoblibPool
+    and dispatches through it. Verified by intercepting the constructor and
+    forcing ``workers=1`` so the fake ``gmat_run`` is visible to the
+    in-process worker."""
+    captured: list[LocalJoblibPool] = []
+
+    def _intercept(*_args: Any, **_kwargs: Any) -> LocalJoblibPool:
+        instance = LocalJoblibPool(workers=1)
+        captured.append(instance)
+        return instance
+
+    monkeypatch.setattr("gmat_sweep.api.LocalJoblibPool", _intercept)
+
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    sweep(script, grid={"Sat.SMA": [7000.0]}, out=out)
+
+    assert len(captured) == 1
+    assert Manifest.load(out / "manifest.jsonl").backend == "LocalJoblibPool"
+
+
+def test_sweep_user_supplied_backend_records_pool_class_name_on_manifest(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    """A user-supplied pool's ``__class__.__name__`` lands on the manifest
+    header verbatim — the contract third-party Pool subclasses rely on."""
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    class _CustomLabelPool(LocalJoblibPool):
+        pass
+
+    with _CustomLabelPool(workers=1) as pool:
+        sweep(script, grid={"Sat.SMA": [7000.0]}, backend=pool, out=out)
+
+    manifest = Manifest.load(out / "manifest.jsonl")
+    assert manifest.backend == "_CustomLabelPool"
+
+
+def test_sweep_user_supplied_backend_is_not_closed_by_sweep(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    """Caller owns the supplied pool's lifecycle: sweep() must not call
+    close() on it. Two consecutive sweeps share one pool."""
+    script = _write_script(tmp_path)
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    pool = LocalJoblibPool(workers=1)
+    try:
+        sweep(script, grid={"Sat.SMA": [7000.0]}, backend=pool, out=tmp_path / "out-a")
+        # If sweep() had closed the pool, this second call would fail.
+        sweep(script, grid={"Sat.SMA": [7100.0]}, backend=pool, out=tmp_path / "out-b")
+    finally:
+        pool.close()
+
+
+def test_monte_carlo_user_backend_records_pool_class_on_manifest(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    with LocalJoblibPool(workers=1) as pool:
+        monte_carlo(
+            script,
+            n=4,
+            perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
+            seed=42,
+            backend=pool,
+            out=out,
+        )
+
+    assert Manifest.load(out / "manifest.jsonl").backend == "LocalJoblibPool"
+
+
+def test_latin_hypercube_user_backend_records_pool_class_on_manifest(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    with LocalJoblibPool(workers=1) as pool:
+        latin_hypercube(
+            script,
+            n=4,
+            perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
+            seed=42,
+            backend=pool,
+            out=out,
+        )
+
+    assert Manifest.load(out / "manifest.jsonl").backend == "LocalJoblibPool"
 
 
 # ---- module-import-time logger config -----------------------------------
@@ -259,7 +372,7 @@ def test_sweep_with_samples_returns_one_run_per_row(
     fake_gmat_run.install_loader(setitem_hook=_setitem, run_hook=_payload_run_hook())
 
     samples = pd.DataFrame({"Sat.SMA": [7000, 7100, 7200, 7300]})
-    df = sweep(script, samples=samples, workers=1, out=out)
+    df = sweep(script, samples=samples, backend=LocalJoblibPool(workers=1), out=out)
 
     run_ids = sorted(df.index.get_level_values("run_id").unique().tolist())
     assert run_ids == [0, 1, 2, 3]
@@ -281,7 +394,7 @@ def test_sweep_with_both_grid_and_samples_raises(
             script,
             grid={"Sat.SMA": [7000.0]},
             samples=pd.DataFrame({"Sat.SMA": [7000.0]}),
-            workers=1,
+            backend=LocalJoblibPool(workers=1),
             out=tmp_path / "out",
         )
 
@@ -293,7 +406,7 @@ def test_sweep_with_neither_grid_nor_samples_raises(
     fake_gmat_run.install_loader(run_hook=_payload_run_hook())
 
     with pytest.raises(SweepConfigError, match="one of grid= or samples="):
-        sweep(script, workers=1, out=tmp_path / "out")
+        sweep(script, backend=LocalJoblibPool(workers=1), out=tmp_path / "out")
 
 
 def test_sweep_with_samples_non_default_index_raises(
@@ -307,7 +420,7 @@ def test_sweep_with_samples_non_default_index_raises(
         index=pd.RangeIndex(10, 14),
     )
     with pytest.raises(SweepConfigError, match="default RangeIndex"):
-        sweep(script, samples=samples, workers=1, out=tmp_path / "out")
+        sweep(script, samples=samples, backend=LocalJoblibPool(workers=1), out=tmp_path / "out")
 
 
 def test_sweep_with_grid_writes_grid_kind_in_manifest(
@@ -323,7 +436,7 @@ def test_sweep_with_grid_writes_grid_kind_in_manifest(
     sweep(
         script,
         grid={"Sat.SMA": [7000.0, 7100.0], "Sat.ECC": [0.001, 0.002]},
-        workers=1,
+        backend=LocalJoblibPool(workers=1),
         out=out,
     )
 
@@ -350,7 +463,7 @@ def test_sweep_with_samples_writes_explicit_kind_in_manifest(
             "Sat.ECC": [0.001, 0.002],
         }
     )
-    sweep(script, samples=samples, workers=1, out=out)
+    sweep(script, samples=samples, backend=LocalJoblibPool(workers=1), out=out)
 
     manifest = Manifest.load(out / "manifest.jsonl")
     spec = manifest.parameter_spec
@@ -375,7 +488,7 @@ def test_sweep_with_samples_manifest_round_trips_to_dataframe(
             "Sat.ECC": [0.001, 0.002, 0.003],
         }
     )
-    sweep(script, samples=samples, workers=1, out=out)
+    sweep(script, samples=samples, backend=LocalJoblibPool(workers=1), out=out)
 
     manifest = Manifest.load(out / "manifest.jsonl")
     spec = manifest.parameter_spec
@@ -400,7 +513,7 @@ def test_monte_carlo_returns_n_run_dataframe(tmp_path: Path, fake_gmat_run: Fake
         n=100,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
         seed=42,
-        workers=1,
+        backend=LocalJoblibPool(workers=1),
         out=out,
     )
 
@@ -426,7 +539,7 @@ def test_monte_carlo_two_calls_at_same_seed_produce_equal_overrides(
         n=20,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
         seed=42,
-        workers=1,
+        backend=LocalJoblibPool(workers=1),
         out=out_a,
     )
     monte_carlo(
@@ -434,7 +547,7 @@ def test_monte_carlo_two_calls_at_same_seed_produce_equal_overrides(
         n=20,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
         seed=42,
-        workers=1,
+        backend=LocalJoblibPool(workers=1),
         out=out_b,
     )
 
@@ -457,7 +570,7 @@ def test_monte_carlo_different_seed_produces_different_overrides(
         n=20,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
         seed=42,
-        workers=1,
+        backend=LocalJoblibPool(workers=1),
         out=out_a,
     )
     monte_carlo(
@@ -465,7 +578,7 @@ def test_monte_carlo_different_seed_produces_different_overrides(
         n=20,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
         seed=43,
-        workers=1,
+        backend=LocalJoblibPool(workers=1),
         out=out_b,
     )
 
@@ -491,7 +604,7 @@ def test_monte_carlo_adding_a_perturbed_parameter_preserves_other_draws(
         n=20,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
         seed=42,
-        workers=1,
+        backend=LocalJoblibPool(workers=1),
         out=out_one,
     )
     monte_carlo(
@@ -502,7 +615,7 @@ def test_monte_carlo_adding_a_perturbed_parameter_preserves_other_draws(
             "Sat.INC": ("uniform", 0.0, 90.0),
         },
         seed=42,
-        workers=1,
+        backend=LocalJoblibPool(workers=1),
         out=out_two,
     )
 
@@ -527,7 +640,7 @@ def test_monte_carlo_accepts_pre_frozen_rv(tmp_path: Path, fake_gmat_run: FakeGm
         n=10,
         perturb={"x": stats.beta(2, 5)},
         seed=42,
-        workers=1,
+        backend=LocalJoblibPool(workers=1),
         out=out,
     )
     assert sorted(df.index.get_level_values("run_id").unique().tolist()) == list(range(10))
@@ -556,7 +669,7 @@ def test_monte_carlo_failed_run_lands_as_nan_row(
         n=8,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
         seed=42,
-        workers=1,
+        backend=LocalJoblibPool(workers=1),
         out=out,
     )
 
@@ -578,7 +691,7 @@ def test_monte_carlo_writes_tagged_parameter_spec(
         n=10,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
         seed=42,
-        workers=1,
+        backend=LocalJoblibPool(workers=1),
         out=out,
     )
 
@@ -596,7 +709,14 @@ def test_monte_carlo_rejects_empty_perturb(tmp_path: Path, fake_gmat_run: FakeGm
     fake_gmat_run.install_loader(run_hook=_payload_run_hook())
 
     with pytest.raises(SweepConfigError, match="non-empty perturb"):
-        monte_carlo(script, n=10, perturb={}, seed=42, workers=1, out=tmp_path / "out")
+        monte_carlo(
+            script,
+            n=10,
+            perturb={},
+            seed=42,
+            backend=LocalJoblibPool(workers=1),
+            out=tmp_path / "out",
+        )
 
 
 def test_monte_carlo_rejects_n_less_than_one(tmp_path: Path, fake_gmat_run: FakeGmatRun) -> None:
@@ -609,7 +729,7 @@ def test_monte_carlo_rejects_n_less_than_one(tmp_path: Path, fake_gmat_run: Fake
             n=0,
             perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
             seed=42,
-            workers=1,
+            backend=LocalJoblibPool(workers=1),
             out=tmp_path / "out",
         )
 
@@ -635,7 +755,7 @@ def test_latin_hypercube_returns_n_run_dataframe(
             "Sat.INC": ("uniform", 0.0, 90.0),
         },
         seed=42,
-        workers=1,
+        backend=LocalJoblibPool(workers=1),
         out=out,
     )
 
@@ -656,8 +776,12 @@ def test_latin_hypercube_two_calls_at_same_seed_produce_equal_overrides(
         "Sat.SMA": ("normal", 7100.0, 50.0),
         "Sat.INC": ("uniform", 0.0, 90.0),
     }
-    latin_hypercube(script, n=16, perturb=perturb, seed=42, workers=1, out=out_a)
-    latin_hypercube(script, n=16, perturb=perturb, seed=42, workers=1, out=out_b)
+    latin_hypercube(
+        script, n=16, perturb=perturb, seed=42, backend=LocalJoblibPool(workers=1), out=out_a
+    )
+    latin_hypercube(
+        script, n=16, perturb=perturb, seed=42, backend=LocalJoblibPool(workers=1), out=out_b
+    )
 
     a = {e.run_id: e.overrides for e in Manifest.load(out_a / "manifest.jsonl").entries}
     b = {e.run_id: e.overrides for e in Manifest.load(out_b / "manifest.jsonl").entries}
@@ -682,7 +806,7 @@ def test_latin_hypercube_writes_tagged_parameter_spec(
             "Sat.INC": ("uniform", 0.0, 90.0),
         },
         seed=42,
-        workers=1,
+        backend=LocalJoblibPool(workers=1),
         out=out,
     )
 
@@ -703,7 +827,14 @@ def test_latin_hypercube_rejects_empty_perturb(tmp_path: Path, fake_gmat_run: Fa
     fake_gmat_run.install_loader(run_hook=_payload_run_hook())
 
     with pytest.raises(SweepConfigError, match="non-empty perturb"):
-        latin_hypercube(script, n=10, perturb={}, seed=42, workers=1, out=tmp_path / "out")
+        latin_hypercube(
+            script,
+            n=10,
+            perturb={},
+            seed=42,
+            backend=LocalJoblibPool(workers=1),
+            out=tmp_path / "out",
+        )
 
 
 def test_latin_hypercube_rejects_n_less_than_one(
@@ -718,6 +849,6 @@ def test_latin_hypercube_rejects_n_less_than_one(
             n=0,
             perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
             seed=42,
-            workers=1,
+            backend=LocalJoblibPool(workers=1),
             out=tmp_path / "out",
         )

--- a/tests/test_ephemeris_contact_aggregation.py
+++ b/tests/test_ephemeris_contact_aggregation.py
@@ -21,6 +21,7 @@ import pytest
 
 from gmat_sweep.aggregate import lazy_contacts, lazy_ephemerides
 from gmat_sweep.api import sweep
+from gmat_sweep.backends.joblib import LocalJoblibPool
 from gmat_sweep.errors import SweepConfigError
 from gmat_sweep.manifest import Manifest
 from tests.conftest import FakeGmatRun, FakeMission, FakeResults
@@ -103,7 +104,7 @@ def test_4_run_sweep_aggregates_ephemeris_and_contact_into_indexed_frames(
     sweep(
         script,
         grid={"Sat.SMA": [7000.0, 7100.0, 7200.0, 7300.0]},
-        workers=1,
+        backend=LocalJoblibPool(workers=1),
         out=out,
         progress=False,
     )
@@ -139,7 +140,7 @@ def test_failed_run_lands_as_nan_row_in_both_aggregators(
     sweep(
         script,
         grid={"Sat.SMA": [7000.0, 7100.0, 7200.0, 7300.0]},
-        workers=1,
+        backend=LocalJoblibPool(workers=1),
         out=out,
         progress=False,
     )
@@ -173,7 +174,13 @@ def test_multi_ephemeris_with_name_none_raises_listing_available_names(
         },
     )
 
-    sweep(script, grid={"Sat.SMA": [7000.0, 7100.0]}, workers=1, out=out, progress=False)
+    sweep(
+        script,
+        grid={"Sat.SMA": [7000.0, 7100.0]},
+        backend=LocalJoblibPool(workers=1),
+        out=out,
+        progress=False,
+    )
 
     manifest = Manifest.load(out / "manifest.jsonl")
     with pytest.raises(SweepConfigError, match=r"GroundEphem.*SatEphem"):
@@ -196,7 +203,13 @@ def test_user_ephemeris_columns_survive_round_trip_through_aggregator(
     out = tmp_path / "out"
     _install_ephem_contact_loader(fake_gmat_run)
 
-    sweep(script, grid={"Sat.SMA": [7000.0, 7100.0]}, workers=1, out=out, progress=False)
+    sweep(
+        script,
+        grid={"Sat.SMA": [7000.0, 7100.0]},
+        backend=LocalJoblibPool(workers=1),
+        out=out,
+        progress=False,
+    )
 
     manifest = Manifest.load(out / "manifest.jsonl")
     eph_df = lazy_ephemerides(manifest, out)

--- a/tests/test_explicit_row_roundtrip.py
+++ b/tests/test_explicit_row_roundtrip.py
@@ -15,6 +15,7 @@ from typing import Any
 import pandas as pd
 
 from gmat_sweep.api import sweep
+from gmat_sweep.backends.joblib import LocalJoblibPool
 from gmat_sweep.manifest import Manifest
 from tests.conftest import FakeGmatRun, FakeMission, FakeResults
 
@@ -67,7 +68,7 @@ def test_each_row_value_observed_via_mission_setitem_before_run(
     fake_gmat_run.module.Mission = SimpleNamespace(load=_load)  # type: ignore[attr-defined]
 
     samples = pd.DataFrame({"Sat.SMA": sma_values})
-    sweep(script, samples=samples, workers=1, out=out, progress=False)
+    sweep(script, samples=samples, backend=LocalJoblibPool(workers=1), out=out, progress=False)
 
     # Every run_id observed exactly its own row's Sat.SMA, set before run().
     assert set(per_run_observations.keys()) == {0, 1, 2, 3}
@@ -99,7 +100,7 @@ def test_manifest_parameter_spec_reconstructs_input_dataframe(
             "Sat.ECC": [0.001, 0.002, 0.003, 0.004],
         }
     )
-    sweep(script, samples=samples, workers=1, out=out, progress=False)
+    sweep(script, samples=samples, backend=LocalJoblibPool(workers=1), out=out, progress=False)
 
     manifest = Manifest.load(out / "manifest.jsonl")
     spec = manifest.parameter_spec

--- a/tests/test_failure_modes.py
+++ b/tests/test_failure_modes.py
@@ -47,6 +47,7 @@ import pytest
 import gmat_sweep
 from gmat_sweep.aggregate import lazy_multiindex
 from gmat_sweep.backends.base import Pool
+from gmat_sweep.backends.joblib import LocalJoblibPool
 from gmat_sweep.grids import expand_grid_to_run_specs
 from gmat_sweep.manifest import Manifest
 from gmat_sweep.spec import RunOutcome, RunSpec
@@ -79,7 +80,7 @@ def test_invalid_override_yields_failed_status_and_completes_sweep(
     df = gmat_sweep.sweep(
         leo_basic_script,
         grid={"Sat.NotARealField": [1.0, 2.0]},
-        workers=1,
+        backend=LocalJoblibPool(workers=1),
         out=out,
     )
 
@@ -101,7 +102,7 @@ def test_one_invalid_override_does_not_abort_other_runs(
     df = gmat_sweep.sweep(
         leo_basic_script,
         grid={"Sat.SMA": [7000.0, 0.0, 7100.0]},
-        workers=2,
+        backend=LocalJoblibPool(workers=2),
         out=out,
     )
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -574,8 +574,41 @@ def test_header_dict_carries_every_documented_field() -> None:
         "sweep_seed",
         "parameter_spec",
         "run_count",
+        "backend",
     }
     assert set(header.keys()) == expected
+
+
+# ---- backend field -------------------------------------------------------
+
+
+def test_manifest_backend_round_trips(tmp_path: Path) -> None:
+    """The pool-class name on the header survives a save+load round-trip."""
+    m = _make_manifest(n_entries=1)
+    m.backend = "DaskPool"
+    path = tmp_path / "manifest.jsonl"
+    m.save(path)
+
+    reloaded = Manifest.load(path)
+    assert reloaded.backend == "DaskPool"
+
+
+def test_load_manifest_without_backend_loads_as_unknown(tmp_path: Path) -> None:
+    """Manifests written before the ``backend`` field landed (v0.1/v0.2)
+    omit it; loading them must yield ``backend == "unknown"`` rather than
+    raise."""
+    m = _make_manifest(n_entries=1)
+    header = m._header_dict()
+    del header["backend"]
+
+    path = tmp_path / "manifest.jsonl"
+    body = json.dumps(header, sort_keys=True) + "\n"
+    body += json.dumps(m.entries[0].to_dict(), sort_keys=True) + "\n"
+    path.write_text(body, encoding="utf-8")
+
+    reloaded = Manifest.load(path)
+    assert reloaded.backend == "unknown"
+    assert reloaded.script_sha256 == m.script_sha256
 
 
 # ---- schema_version freeze ----------------------------------------------

--- a/tests/test_monte_carlo_determinism.py
+++ b/tests/test_monte_carlo_determinism.py
@@ -22,6 +22,7 @@ from typing import Any
 import pandas as pd
 
 from gmat_sweep.api import monte_carlo
+from gmat_sweep.backends.joblib import LocalJoblibPool
 from gmat_sweep.grids import expand_monte_carlo_to_run_specs
 from tests.conftest import FakeGmatRun, FakeMission, FakeResults
 
@@ -73,7 +74,7 @@ def test_two_calls_same_seed_produce_bit_equal_dataframes(
         n=20,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
         seed=42,
-        workers=1,
+        backend=LocalJoblibPool(workers=1),
         out=tmp_path / "out-a",
         progress=False,
     )
@@ -82,7 +83,7 @@ def test_two_calls_same_seed_produce_bit_equal_dataframes(
         n=20,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
         seed=42,
-        workers=1,
+        backend=LocalJoblibPool(workers=1),
         out=tmp_path / "out-b",
         progress=False,
     )
@@ -101,7 +102,7 @@ def test_different_seeds_produce_distinct_dataframes(
         n=20,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
         seed=42,
-        workers=1,
+        backend=LocalJoblibPool(workers=1),
         out=tmp_path / "out-42",
         progress=False,
     )
@@ -110,7 +111,7 @@ def test_different_seeds_produce_distinct_dataframes(
         n=20,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
         seed=43,
-        workers=1,
+        backend=LocalJoblibPool(workers=1),
         out=tmp_path / "out-43",
         progress=False,
     )
@@ -139,7 +140,7 @@ def test_adding_a_second_perturbed_parameter_preserves_first_dataframe_draws(
         n=20,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
         seed=42,
-        workers=1,
+        backend=LocalJoblibPool(workers=1),
         out=tmp_path / "out-one",
         progress=False,
     )
@@ -151,7 +152,7 @@ def test_adding_a_second_perturbed_parameter_preserves_first_dataframe_draws(
             "Sat.INC": ("uniform", 0.0, 90.0),
         },
         seed=42,
-        workers=1,
+        backend=LocalJoblibPool(workers=1),
         out=tmp_path / "out-two",
         progress=False,
     )

--- a/tests/test_reference_sweep.py
+++ b/tests/test_reference_sweep.py
@@ -40,6 +40,7 @@ import pandas as pd
 import pytest
 
 import gmat_sweep
+from gmat_sweep.backends.joblib import LocalJoblibPool
 
 pytestmark = pytest.mark.integration
 
@@ -68,7 +69,7 @@ def _frames_equal(actual: pd.DataFrame, expected: pd.DataFrame) -> None:
 
 def test_reference_sma_sweep_matches_golden_parquet(leo_basic_script: Path, tmp_path: Path) -> None:
     out = tmp_path / "out"
-    df = gmat_sweep.sweep(leo_basic_script, grid=_GRID, workers=2, out=out)
+    df = gmat_sweep.sweep(leo_basic_script, grid=_GRID, backend=LocalJoblibPool(workers=2), out=out)
 
     flat = _normalise_for_comparison(df)
 

--- a/tests/test_resume_roundtrip.py
+++ b/tests/test_resume_roundtrip.py
@@ -94,7 +94,13 @@ def test_16_run_grid_with_3_failures_resumes_to_all_ok(
 
     fake_gmat_run.module.Mission = SimpleNamespace(load=_load)  # type: ignore[attr-defined]
 
-    sweep(script, grid={"Sat.SMA": grid_values}, workers=1, out=out, progress=False)
+    sweep(
+        script,
+        grid={"Sat.SMA": grid_values},
+        backend=LocalJoblibPool(workers=1),
+        out=out,
+        progress=False,
+    )
 
     first_pass = Manifest.load(out / "manifest.jsonl")
     assert sorted(first_pass.find_failed()) == [3, 7, 11]
@@ -152,7 +158,15 @@ def test_monte_carlo_resume_preserves_bit_equal_draws_for_failed_runs(
 
     fake_gmat_run.module.Mission = SimpleNamespace(load=_load)  # type: ignore[attr-defined]
 
-    monte_carlo(script, n=8, perturb=perturb, seed=1729, workers=1, out=out, progress=False)
+    monte_carlo(
+        script,
+        n=8,
+        perturb=perturb,
+        seed=1729,
+        backend=LocalJoblibPool(workers=1),
+        out=out,
+        progress=False,
+    )
 
     pre_resume = Manifest.load(out / "manifest.jsonl")
     assert 3 in pre_resume.find_failed()
@@ -177,7 +191,13 @@ def test_script_drift_raises_sweep_config_error(tmp_path: Path, fake_gmat_run: F
     script = _write_script(tmp_path)
     out = tmp_path / "out"
     fake_gmat_run.install_loader(run_hook=_payload_run_hook())
-    sweep(script, grid={"Sat.SMA": [7000.0, 7100.0]}, workers=1, out=out, progress=False)
+    sweep(
+        script,
+        grid={"Sat.SMA": [7000.0, 7100.0]},
+        backend=LocalJoblibPool(workers=1),
+        out=out,
+        progress=False,
+    )
 
     # Mutate the script: same path, different bytes ⇒ different canonical hash.
     script.write_text("% mission v2\nCreate Spacecraft Sat;\n", encoding="utf-8")
@@ -193,7 +213,13 @@ def test_allow_script_drift_warns_and_proceeds(tmp_path: Path, fake_gmat_run: Fa
     script = _write_script(tmp_path)
     out = tmp_path / "out"
     fake_gmat_run.install_loader(run_hook=_payload_run_hook())
-    sweep(script, grid={"Sat.SMA": [7000.0, 7100.0]}, workers=1, out=out, progress=False)
+    sweep(
+        script,
+        grid={"Sat.SMA": [7000.0, 7100.0]},
+        backend=LocalJoblibPool(workers=1),
+        out=out,
+        progress=False,
+    )
 
     script.write_text("% mission v2\nCreate Spacecraft Sat;\n", encoding="utf-8")
 
@@ -228,7 +254,7 @@ def test_resumed_dataframe_matches_unbroken_sweep_via_sma_echo(
     df_reference = sweep(
         script,
         grid={"Sat.SMA": [7000.0, 7100.0, 7200.0, 7300.0]},
-        workers=1,
+        backend=LocalJoblibPool(workers=1),
         out=tmp_path / "ref",
         progress=False,
     )
@@ -262,7 +288,7 @@ def test_resumed_dataframe_matches_unbroken_sweep_via_sma_echo(
     sweep(
         script,
         grid={"Sat.SMA": [7000.0, 7100.0, 7200.0, 7300.0]},
-        workers=1,
+        backend=LocalJoblibPool(workers=1),
         out=out,
         progress=False,
     )

--- a/tests/test_run_roundtrip.py
+++ b/tests/test_run_roundtrip.py
@@ -22,6 +22,7 @@ import pandas as pd
 import pytest
 
 import gmat_sweep
+from gmat_sweep.backends.joblib import LocalJoblibPool
 
 pytestmark = pytest.mark.integration
 
@@ -37,7 +38,9 @@ def four_run_sweep_df(
 ) -> pd.DataFrame:
     """Run the reference 4-run sweep once and reuse it across the module."""
     out = tmp_path_factory.mktemp("four-run-sweep")
-    return gmat_sweep.sweep(leo_basic_script, grid=_GRID, workers=2, out=out)
+    return gmat_sweep.sweep(
+        leo_basic_script, grid=_GRID, backend=LocalJoblibPool(workers=2), out=out
+    )
 
 
 def _direct_run(script: Path, overrides: dict[str, Any], working_dir: Path) -> pd.DataFrame:

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -402,7 +402,7 @@ def test_from_manifest_tagged_grid_kind_rebuilds_runs(
     sweep_api(
         script,
         grid={"Sat.SMA": [7000.0, 7100.0, 7200.0]},
-        workers=1,
+        backend=LocalJoblibPool(workers=1),
         out=output_dir,
     )
 
@@ -440,7 +440,7 @@ def test_from_manifest_explicit_kind_rebuilds_runs(
     samples = pd.DataFrame({"Sat.SMA": [7000.0, 7100.0, 7200.0], "Sat.ECC": [0.001, 0.002, 0.003]})
 
     fake_gmat_run.install_loader(run_hook=_payload_run_hook(rows=1))
-    sweep_api(script, samples=samples, workers=1, out=output_dir)
+    sweep_api(script, samples=samples, backend=LocalJoblibPool(workers=1), out=output_dir)
 
     fake_gmat_run.install_loader(run_hook=_payload_run_hook(rows=1))
     with LocalJoblibPool(workers=1) as pool:
@@ -474,7 +474,7 @@ def test_from_manifest_monte_carlo_rebuilds_bit_equal_overrides(
         n=8,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0), "Sat.INC": ("uniform", 0.0, 90.0)},
         seed=1729,
-        workers=1,
+        backend=LocalJoblibPool(workers=1),
         out=out,
     )
 
@@ -503,7 +503,7 @@ def test_from_manifest_latin_hypercube_rebuilds_bit_equal_overrides(
         n=8,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0), "Sat.INC": ("uniform", 0.0, 90.0)},
         seed=1729,
-        workers=1,
+        backend=LocalJoblibPool(workers=1),
         out=out,
     )
 


### PR DESCRIPTION
## Summary

- Public API switches from `workers: int = -1` to `backend: Pool | None = None` on `sweep()`, `monte_carlo()`, and `latin_hypercube()`. The default-pool branch keeps current behaviour (a fresh `LocalJoblibPool` over all cores, lifecycle managed by the call); a user-supplied pool is dispatched through directly with no `close()`.
- Manifest header gains additive `backend` string field (`pool.__class__.__name__`). No `schema_version` bump — manifests that omit it load with `backend == "unknown"`, covered by the existing forward-compat policy.
- CLI keeps its `--workers` flag (out of scope per #59); each subcommand now wraps it with a `LocalJoblibPool(workers=args.workers)` before calling the API. `LocalJoblibPool` is re-exported from the top-level package so `from gmat_sweep import LocalJoblibPool` works.

**Breaking change vs. issue body.** The issue called for `workers=` and `backend=` to be mutually exclusive; we agreed offline to drop `workers=` outright instead. Two reasons: (1) once Dask/Ray pools land in #57/#58 the `workers=` shortcut would only apply to one of three backends, and (2) v0.2.0 alpha is the cheap moment to make this change. The "raises `SweepConfigError` when both are passed" acceptance bullet therefore no longer applies; the others are unchanged.

## Test plan

- [x] `uv run pytest` (401 unit tests pass; integration tests gated)
- [x] `uv run ruff check`
- [x] `uv run ruff format --check`
- [x] `uv run mypy --strict`
- [x] CI green across the `{ubuntu, windows, macOS} × {3.10, 3.11, 3.12} × {R2025a, R2026a}` matrix
- [x] Coverage gates hold (manifest ≥ 95%; overall ≥ 85%)

Closes #56