### PR TITLE
Add DaskPool and RayPool backends behind [dask]/[ray] extras

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,11 @@ jobs:
           cache: true
 
       - name: Install project
-        run: uv sync --all-groups
+        # `--extra dask --extra ray` so the `@pytest.mark.integration` tests
+        # under `tests/test_backends_{dask,ray}.py` can spin up a real
+        # `distributed.LocalCluster` / `ray.init()`. The lint, typecheck, and
+        # minimal-install jobs deliberately keep their syncs narrower.
+        run: uv sync --all-groups --extra dask --extra ray
 
       - name: Run pytest
         # `-m "integration or not integration"` overrides the default
@@ -122,6 +126,10 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
+      # mypy walks the backends/dask.py and backends/ray.py modules; their
+      # `if TYPE_CHECKING: import distributed` / `import ray` references are
+      # silenced by the ignore_missing_imports overrides, so the typecheck job
+      # does not need the runtime extras.
       - run: uv sync --all-groups
       - run: uv run mypy
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -20,6 +20,10 @@ auto-generated from docstrings via
 
 ::: gmat_sweep.LocalJoblibPool
 
+::: gmat_sweep.backends.DaskPool
+
+::: gmat_sweep.backends.RayPool
+
 ## Specs and outcomes
 
 ::: gmat_sweep.RunSpec

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -1,0 +1,112 @@
+# Backends
+
+Every gmat-sweep run is dispatched through a `Pool` — the abstraction that
+takes a `RunSpec`, runs it, and returns a `RunOutcome`. Three concrete
+pools ship in the box:
+
+| Pool | Install | When to pick it |
+|---|---|---|
+| [`LocalJoblibPool`][gmat_sweep.LocalJoblibPool] | core (no extras) | Default. One machine, one Python, joblib's loky workers spawn one fresh interpreter per task. The right choice for nearly every laptop or single-box server sweep. |
+| [`DaskPool`][gmat_sweep.backends.DaskPool] | `pip install gmat-sweep[dask]` | Multi-host sweeps, or a sweep that fits on one machine but needs to plug into an existing `dask.distributed` cluster (Slurm, Kubernetes, or a long-lived dev scheduler). |
+| [`RayPool`][gmat_sweep.backends.RayPool] | `pip install gmat-sweep[ray]` | Multi-host sweeps on a Ray runtime — local, autoscaling, or remote via the Ray Client. |
+
+All three honour the same per-run subprocess-isolation contract: each
+`RunSpec` runs in a freshly-spawned Python interpreter, so the `gmatpy`
+bootstrap and GMAT's process-global singletons cannot leak between runs.
+Loky gives you that for free; Dask and Ray reuse worker processes by
+default, so gmat-sweep adds an explicit subprocess hop inside each task.
+
+## `LocalJoblibPool` — the default
+
+```python
+from gmat_sweep import LocalJoblibPool, sweep
+
+df = sweep(
+    "mission.script",
+    grid={"Sat.SMA": [7000.0, 7100.0, 7200.0, 7300.0]},
+    backend=LocalJoblibPool(workers=4),
+    out="./sweep",
+)
+```
+
+`workers=-1` (the default) uses every core. See
+[Choosing a backend](parameter-spec.md#choosing-a-backend) on the parameter
+spec page for the full set of LocalJoblibPool patterns (capping
+parallelism, sharing one pool across several sweeps).
+
+## `DaskPool` — `dask.distributed`
+
+```python
+from gmat_sweep import sweep
+from gmat_sweep.backends import DaskPool
+
+with DaskPool(n_workers=4) as pool:
+    df = sweep(
+        "mission.script",
+        grid={"Sat.SMA": [7000.0, 7100.0, 7200.0, 7300.0]},
+        backend=pool,
+        out="./sweep",
+    )
+```
+
+With no arguments, `DaskPool` spawns a `distributed.LocalCluster` and a
+`Client` connected to it, and tears both down on `close()`. Pass an
+existing client to dispatch through a cluster the rest of your code is
+already using:
+
+```python
+from dask.distributed import Client
+from gmat_sweep import sweep
+from gmat_sweep.backends import DaskPool
+
+client = Client("tcp://scheduler:8786")
+with DaskPool(client=client) as pool:
+    df = sweep("mission.script", grid={...}, backend=pool, out="./sweep")
+# `client` is still open — DaskPool only closes resources it created.
+```
+
+## `RayPool` — Ray
+
+```python
+from gmat_sweep import sweep
+from gmat_sweep.backends import RayPool
+
+with RayPool(num_cpus=4) as pool:
+    df = sweep(
+        "mission.script",
+        grid={"Sat.SMA": [7000.0, 7100.0, 7200.0, 7300.0]},
+        backend=pool,
+        out="./sweep",
+    )
+```
+
+`RayPool` calls `ray.init` for you when constructed. Pass an `address`
+to connect to a pre-existing cluster instead — ``"auto"`` for a local
+runtime started elsewhere on the same machine, or
+``"ray://host:port"`` for a remote Ray Client server:
+
+```python
+from gmat_sweep.backends import RayPool
+
+with RayPool(address="ray://head:10001") as pool:
+    df = sweep("mission.script", grid={...}, backend=pool, out="./sweep")
+```
+
+`RayPool` only calls `ray.shutdown()` on `close()` if its own `__init__`
+was what initialised the runtime. If you called `ray.init()` yourself
+before constructing the pool, the pool leaves your runtime alone.
+
+## Failed runs
+
+A single failed run never aborts the sweep, regardless of backend. The
+worker subprocess catches the exception, the outcome lands in the
+manifest with `status="failed"`, and the aggregated DataFrame gets one
+NaN-filled row with `__status="failed"`. The
+[killed-sweep recovery example](examples/03_killed_sweep_recovery.ipynb)
+shows the resume flow end-to-end.
+
+## Cluster recipes
+
+Slurm `srun` recipes for `DaskPool`, Kubernetes pod-per-worker setup, and
+Ray autoscaling cluster configuration are tracked separately and will
+land alongside the cluster-recipes documentation page.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
   - Home: index.md
   - Getting started: getting-started.md
   - Parameter spec: parameter-spec.md
+  - Backends: backends.md
   - Monte Carlo: monte-carlo.md
   - Aggregation: aggregation.md
   - Resume: resume.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,24 @@ ignore_missing_imports = true
 module = ["scipy", "scipy.*"]
 ignore_missing_imports = true
 
+# distributed (Dask) is an optional [dask]-extra dependency; backends/dask.py
+# treats the surface used (LocalCluster, Client, as_completed) as Any.
+# `follow_imports = "skip"` is needed alongside `ignore_missing_imports`
+# because distributed ships a `py.typed` marker — without skip, mypy --strict
+# imports the package's types and rejects calls to its (loosely typed) surface
+# under disallow_untyped_calls.
+[[tool.mypy.overrides]]
+module = ["distributed", "distributed.*"]
+ignore_missing_imports = true
+follow_imports = "skip"
+
+# ray is an optional [ray]-extra dependency; same handling as distributed
+# above (ray also ships `py.typed`).
+[[tool.mypy.overrides]]
+module = ["ray", "ray.*"]
+ignore_missing_imports = true
+follow_imports = "skip"
+
 [tool.pytest.ini_options]
 minversion = "8.0"
 testpaths = ["tests"]

--- a/src/gmat_sweep/backends/__init__.py
+++ b/src/gmat_sweep/backends/__init__.py
@@ -1,8 +1,44 @@
-"""Execution backends behind a single Pool abstraction."""
+"""Execution backends behind a single Pool abstraction.
+
+:class:`gmat_sweep.backends.joblib.LocalJoblibPool` is the always-available
+default. :class:`DaskPool` and :class:`RayPool` live behind the optional
+``[dask]`` and ``[ray]`` extras and are exposed lazily through this
+package's :func:`__getattr__` — accessing them when the underlying extra
+is not installed raises :class:`AttributeError` with an install hint, so a
+minimal install never imports ``distributed`` or ``ray`` at package-import
+time.
+"""
 
 from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING, Any
 
 from gmat_sweep.backends.base import Pool
 from gmat_sweep.backends.joblib import LocalJoblibPool
 
-__all__ = ["LocalJoblibPool", "Pool"]
+if TYPE_CHECKING:
+    from gmat_sweep.backends.dask import DaskPool
+    from gmat_sweep.backends.ray import RayPool
+
+__all__ = ["DaskPool", "LocalJoblibPool", "Pool", "RayPool"]
+
+
+_OPTIONAL_BACKENDS = {
+    "DaskPool": ("distributed", "gmat_sweep.backends.dask", "dask"),
+    "RayPool": ("ray", "gmat_sweep.backends.ray", "ray"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    entry = _OPTIONAL_BACKENDS.get(name)
+    if entry is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    probe_module, backend_module, extra = entry
+    try:
+        importlib.import_module(probe_module)
+    except ImportError as exc:
+        raise AttributeError(
+            f"{name} requires the [{extra}] extra: pip install gmat-sweep[{extra}]"
+        ) from exc
+    return getattr(importlib.import_module(backend_module), name)

--- a/src/gmat_sweep/backends/dask.py
+++ b/src/gmat_sweep/backends/dask.py
@@ -1,0 +1,152 @@
+"""DaskPool: distributed execution backend using ``dask.distributed``.
+
+The pool fans :class:`gmat_sweep.spec.RunSpec` work across a Dask cluster.
+Dask reuses worker processes for successive tasks, so the
+:class:`gmat_sweep.backends.base.Pool` per-run fresh-interpreter contract is
+honoured by an explicit subprocess hop inside each task: the top-level
+:func:`_dask_run_one` callable delegates to
+:func:`gmat_sweep.backends._subprocess.run_spec_in_subprocess`, which spawns
+``python -m gmat_sweep._run_subprocess`` for the actual GMAT load. The Dask
+worker process itself never imports ``gmatpy``.
+
+Lifecycle
+---------
+
+``DaskPool`` accepts an existing ``distributed.Client`` or, when given none,
+spins up a local ``distributed.LocalCluster`` and a ``Client`` connected to
+it. :meth:`close` shuts down only what the pool owns:
+
+- ``client=None``, ``n_workers=None`` — own the LocalCluster and the Client.
+- ``client=None``, ``n_workers=K`` — own the LocalCluster and the Client.
+- ``client=<Client>`` — own neither; ``close`` does not touch the client.
+
+Submission semantics match :class:`gmat_sweep.backends.joblib.LocalJoblibPool`:
+:meth:`submit` parks the spec under a placeholder
+:class:`concurrent.futures.Future` and returns immediately; dispatch happens
+inside :meth:`as_completed`, which submits one Dask task per parked spec and
+drains via :func:`distributed.as_completed`.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable, Iterator
+from concurrent.futures import Future
+from typing import TYPE_CHECKING, Any
+
+from gmat_sweep.backends._subprocess import run_spec_in_subprocess
+from gmat_sweep.backends.base import Pool
+from gmat_sweep.errors import BackendError
+from gmat_sweep.spec import RunOutcome, RunSpec
+
+if TYPE_CHECKING:
+    import distributed
+
+__all__ = ["DaskPool"]
+
+
+def _dask_run_one(spec: RunSpec) -> RunOutcome:
+    """Top-level Dask task body — delegates to the subprocess hop.
+
+    Defined at module scope so Dask's serialiser can pickle it. Crucially,
+    this function does **not** import ``gmatpy``: the subprocess hop is what
+    loads GMAT, in a fresh interpreter.
+    """
+    return run_spec_in_subprocess(spec)
+
+
+class DaskPool(Pool):
+    """Distributed pool backed by ``dask.distributed``.
+
+    Parameters
+    ----------
+    client:
+        An existing :class:`distributed.Client` to dispatch through. When
+        supplied, the pool does not create or own a cluster, and
+        :meth:`close` does not shut the client down.
+    n_workers:
+        Number of workers in the auto-spawned :class:`distributed.LocalCluster`.
+        Ignored when ``client`` is supplied. ``None`` (default) uses
+        :func:`os.cpu_count`.
+    threads_per_worker:
+        Threads per worker for the auto-spawned :class:`distributed.LocalCluster`.
+        Ignored when ``client`` is supplied. Defaults to ``1`` so each worker
+        is a single-threaded subprocess shell.
+    """
+
+    def __init__(
+        self,
+        *,
+        client: distributed.Client | None = None,
+        n_workers: int | None = None,
+        threads_per_worker: int = 1,
+    ) -> None:
+        try:
+            import distributed as _distributed
+        except ImportError as exc:
+            raise BackendError(
+                "DaskPool requires the [dask] extra: pip install gmat-sweep[dask]"
+            ) from exc
+
+        self._owns_client = False
+        self._owns_cluster = False
+        self._cluster: Any = None
+
+        if client is None:
+            workers = n_workers if n_workers is not None else os.cpu_count() or 1
+            self._cluster = _distributed.LocalCluster(
+                n_workers=workers,
+                threads_per_worker=threads_per_worker,
+            )
+            self._client = _distributed.Client(self._cluster)
+            self._owns_client = True
+            self._owns_cluster = True
+        else:
+            self._client = client
+
+        self._pending: dict[Future[RunOutcome], RunSpec] = {}
+        self._closed = False
+        self._distributed = _distributed
+
+    def submit(self, spec: RunSpec) -> Future[RunOutcome]:
+        if self._closed:
+            raise BackendError("DaskPool is closed; cannot submit new specs")
+        future: Future[RunOutcome] = Future()
+        self._pending[future] = spec
+        return future
+
+    def as_completed(self, futures: Iterable[Future[RunOutcome]]) -> Iterator[RunOutcome]:
+        if self._closed:
+            raise BackendError("DaskPool is closed; cannot drain futures")
+
+        wanted = list(futures)
+        future_by_run_id: dict[int, Future[RunOutcome]] = {}
+        dask_futures: list[Any] = []
+        for f in wanted:
+            spec = self._pending.pop(f, None)
+            if spec is None:
+                raise BackendError(
+                    "Future was not submitted to this pool, or has already been drained"
+                )
+            future_by_run_id[spec.run_id] = f
+            dask_futures.append(self._client.submit(_dask_run_one, spec, pure=False))
+
+        for dask_future in self._distributed.as_completed(dask_futures):
+            outcome: RunOutcome = dask_future.result()
+            f = future_by_run_id.pop(outcome.run_id)
+            f.set_result(outcome)
+            yield outcome
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            for f in self._pending:
+                f.cancel()
+            self._pending.clear()
+        finally:
+            if self._owns_client:
+                self._client.close()
+            if self._owns_cluster and self._cluster is not None:
+                self._cluster.close()

--- a/src/gmat_sweep/backends/ray.py
+++ b/src/gmat_sweep/backends/ray.py
@@ -1,0 +1,151 @@
+"""RayPool: distributed execution backend using Ray.
+
+The pool fans :class:`gmat_sweep.spec.RunSpec` work across a Ray cluster.
+Ray reuses worker processes for successive tasks, so the
+:class:`gmat_sweep.backends.base.Pool` per-run fresh-interpreter contract is
+honoured by an explicit subprocess hop inside each task: the top-level
+:func:`_ray_run_one_impl` callable (registered as a Ray remote function once
+``ray`` is importable) delegates to
+:func:`gmat_sweep.backends._subprocess.run_spec_in_subprocess`, which spawns
+``python -m gmat_sweep._run_subprocess`` for the actual GMAT load. The Ray
+worker process itself never imports ``gmatpy``.
+
+Lifecycle
+---------
+
+``RayPool`` connects to a Ray runtime by calling :func:`ray.init` (with
+``address`` and any extra keyword arguments forwarded). :meth:`close` calls
+:func:`ray.shutdown` only if the pool's ``__init__`` was what initialised
+the runtime — that is, Ray reported uninitialised when the pool was
+constructed. If the user had already called :func:`ray.init` before
+constructing the pool, the pool does not own the runtime and leaves it
+alone on close.
+
+This rule applies regardless of ``address``: ``ray.shutdown`` only severs
+the local handle, so even a remote-cluster connection is safe to drop on
+close — as long as the pool was the caller that opened it.
+
+Object-store note
+-----------------
+
+Ray serialises task arguments through cloudpickle into its plasma object
+store. :class:`RunSpec` is :func:`dataclasses.dataclass` with
+JSON-encodable fields, well within Ray's serialisation surface; values
+inside ``overrides`` and ``run_options`` must already be JSON-encodable
+per the v0.1 spec contract.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from concurrent.futures import Future
+from typing import TYPE_CHECKING, Any
+
+from gmat_sweep.backends._subprocess import run_spec_in_subprocess
+from gmat_sweep.backends.base import Pool
+from gmat_sweep.errors import BackendError
+from gmat_sweep.spec import RunOutcome, RunSpec
+
+if TYPE_CHECKING:
+    import ray as _ray_typing  # noqa: F401
+
+__all__ = ["RayPool"]
+
+
+def _ray_run_one_impl(spec: RunSpec) -> RunOutcome:
+    """Body of the Ray remote task — delegates to the subprocess hop.
+
+    Defined at module scope so Ray's serialiser can pickle it. Crucially,
+    this function does **not** import ``gmatpy``: the subprocess hop is what
+    loads GMAT, in a fresh interpreter.
+    """
+    return run_spec_in_subprocess(spec)
+
+
+class RayPool(Pool):
+    """Distributed pool backed by Ray.
+
+    Parameters
+    ----------
+    address:
+        Forwarded to :func:`ray.init` to connect to an existing cluster
+        (``"auto"`` for a local cluster, ``"ray://host:port"`` for a remote
+        Ray Client server, or a raw GCS address). ``None`` (default) starts
+        a local Ray runtime.
+    num_cpus:
+        Forwarded to :func:`ray.init` for the local-runtime case. Ignored
+        when connecting to an existing cluster via ``address``.
+    **ray_init_kwargs:
+        Extra keyword arguments forwarded verbatim to :func:`ray.init`.
+    """
+
+    def __init__(
+        self,
+        *,
+        address: str | None = None,
+        num_cpus: int | None = None,
+        **ray_init_kwargs: Any,
+    ) -> None:
+        try:
+            import ray as _ray
+        except ImportError as exc:
+            raise BackendError(
+                "RayPool requires the [ray] extra: pip install gmat-sweep[ray]"
+            ) from exc
+
+        self._owns_runtime = not _ray.is_initialized()
+        if self._owns_runtime:
+            init_kwargs: dict[str, Any] = dict(ray_init_kwargs)
+            if address is not None:
+                init_kwargs["address"] = address
+            if num_cpus is not None:
+                init_kwargs["num_cpus"] = num_cpus
+            _ray.init(**init_kwargs)
+
+        self._ray = _ray
+        self._remote_run_one = _ray.remote(_ray_run_one_impl)
+        self._pending: dict[Future[RunOutcome], RunSpec] = {}
+        self._closed = False
+
+    def submit(self, spec: RunSpec) -> Future[RunOutcome]:
+        if self._closed:
+            raise BackendError("RayPool is closed; cannot submit new specs")
+        future: Future[RunOutcome] = Future()
+        self._pending[future] = spec
+        return future
+
+    def as_completed(self, futures: Iterable[Future[RunOutcome]]) -> Iterator[RunOutcome]:
+        if self._closed:
+            raise BackendError("RayPool is closed; cannot drain futures")
+
+        wanted = list(futures)
+        future_by_run_id: dict[int, Future[RunOutcome]] = {}
+        object_refs: list[Any] = []
+        for f in wanted:
+            spec = self._pending.pop(f, None)
+            if spec is None:
+                raise BackendError(
+                    "Future was not submitted to this pool, or has already been drained"
+                )
+            future_by_run_id[spec.run_id] = f
+            object_refs.append(self._remote_run_one.remote(spec))
+
+        unready: list[Any] = list(object_refs)
+        while unready:
+            ready, unready = self._ray.wait(unready, num_returns=1)
+            outcome: RunOutcome = self._ray.get(ready[0])
+            f = future_by_run_id.pop(outcome.run_id)
+            f.set_result(outcome)
+            yield outcome
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            for f in self._pending:
+                f.cancel()
+            self._pending.clear()
+        finally:
+            if self._owns_runtime:
+                self._ray.shutdown()

--- a/tests/test_backends_dask.py
+++ b/tests/test_backends_dask.py
@@ -1,0 +1,270 @@
+"""Tests for gmat_sweep.backends.dask.DaskPool — submit/as_completed semantics + ownership."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from collections.abc import Iterable, Iterator
+from concurrent.futures import Future
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, ClassVar
+
+import pytest
+
+from gmat_sweep.backends.base import Pool
+from gmat_sweep.errors import BackendError
+from gmat_sweep.spec import RunOutcome, RunSpec
+
+distributed = pytest.importorskip("distributed")
+
+
+from gmat_sweep.backends.dask import DaskPool, _dask_run_one  # noqa: E402
+
+
+def _make_spec(*, output_dir: Path, run_id: int = 0) -> RunSpec:
+    return RunSpec(
+        script_path=Path("/missions/m.script"),
+        overrides={},
+        output_dir=output_dir,
+        run_id=run_id,
+        seed=None,
+        run_options={},
+    )
+
+
+def _ok_outcome(run_id: int) -> RunOutcome:
+    now = datetime.now(timezone.utc)
+    return RunOutcome.ok(run_id=run_id, output_paths={}, started_at=now, ended_at=now)
+
+
+class _StubFuture:
+    """Minimal stand-in for ``distributed.Future`` carrying a precomputed result."""
+
+    def __init__(self, value: RunOutcome) -> None:
+        self._value = value
+
+    def result(self) -> RunOutcome:
+        return self._value
+
+
+class _StubClient:
+    """Stand-in for ``distributed.Client`` covering only the surface DaskPool uses."""
+
+    def __init__(self) -> None:
+        self.submitted: list[RunSpec] = []
+        self.closed = False
+
+    def submit(self, fn: Any, spec: RunSpec, *, pure: bool = True) -> _StubFuture:
+        self.submitted.append(spec)
+        return _StubFuture(fn(spec))
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _StubCluster:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _patch_distributed_with_stubs(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    cluster_factory: Any = None,
+    client_factory: Any = None,
+) -> None:
+    """Replace distributed.LocalCluster, distributed.Client, distributed.as_completed."""
+    if cluster_factory is None:
+        cluster_factory = lambda **kwargs: _StubCluster()  # noqa: E731
+    if client_factory is None:
+        client_factory = lambda *args, **kwargs: _StubClient()  # noqa: E731
+
+    monkeypatch.setattr(distributed, "LocalCluster", cluster_factory, raising=True)
+    monkeypatch.setattr(distributed, "Client", client_factory, raising=True)
+    monkeypatch.setattr(
+        distributed,
+        "as_completed",
+        lambda futures: iter(futures),
+        raising=True,
+    )
+
+
+def test_daskpool_is_pool_subclass() -> None:
+    assert issubclass(DaskPool, Pool)
+    assert DaskPool.subprocess_isolated is True
+
+
+def test_subclass_setting_subprocess_isolated_false_rejected() -> None:
+    """The Pool ABC's contract still applies to DaskPool subclasses."""
+    with pytest.raises(BackendError):
+
+        class _Bad(DaskPool):  # pragma: no cover - body never runs
+            subprocess_isolated: ClassVar[bool] = False
+
+            def submit(self, spec: RunSpec) -> Future[RunOutcome]:
+                return Future()
+
+            def as_completed(self, futures: Iterable[Future[RunOutcome]]) -> Iterator[RunOutcome]:
+                return iter([])
+
+            def close(self) -> None:
+                pass
+
+
+def test_lazy_import_raises_backenderror_when_extra_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If `distributed` cannot be imported, DaskPool() raises BackendError from ImportError."""
+    monkeypatch.setitem(sys.modules, "distributed", None)
+    with pytest.raises(BackendError) as ei:
+        DaskPool()
+    assert "[dask]" in str(ei.value)
+    assert isinstance(ei.value.__cause__, ImportError)
+
+
+def test_default_init_owns_cluster_and_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    cluster = _StubCluster()
+    client = _StubClient()
+    _patch_distributed_with_stubs(
+        monkeypatch,
+        cluster_factory=lambda **kwargs: cluster,
+        client_factory=lambda *_args, **_kwargs: client,
+    )
+    pool = DaskPool()
+    assert pool._owns_cluster is True
+    assert pool._owns_client is True
+    pool.close()
+    assert cluster.closed
+    assert client.closed
+
+
+def test_close_does_not_touch_user_supplied_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_distributed_with_stubs(monkeypatch)
+    user_client = _StubClient()
+    pool = DaskPool(client=user_client)
+    assert pool._owns_cluster is False
+    assert pool._owns_client is False
+    pool.close()
+    assert user_client.closed is False
+
+
+def test_close_is_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_distributed_with_stubs(monkeypatch)
+    pool = DaskPool()
+    pool.close()
+    pool.close()
+
+
+def test_submit_returns_pending_future(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _patch_distributed_with_stubs(monkeypatch)
+    pool = DaskPool(client=_StubClient())
+    f = pool.submit(_make_spec(output_dir=tmp_path / "run_0"))
+    assert not f.done()
+    assert not f.cancelled()
+    pool.close()
+
+
+def test_submit_after_close_raises(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _patch_distributed_with_stubs(monkeypatch)
+    pool = DaskPool(client=_StubClient())
+    pool.close()
+    with pytest.raises(BackendError):
+        pool.submit(_make_spec(output_dir=tmp_path / "run_0"))
+
+
+def test_as_completed_after_close_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_distributed_with_stubs(monkeypatch)
+    pool = DaskPool(client=_StubClient())
+    pool.close()
+    with pytest.raises(BackendError):
+        list(pool.as_completed([]))
+
+
+def test_close_cancels_pending_futures(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _patch_distributed_with_stubs(monkeypatch)
+    pool = DaskPool(client=_StubClient())
+    f = pool.submit(_make_spec(output_dir=tmp_path / "run_0"))
+    pool.close()
+    assert f.cancelled()
+
+
+def test_as_completed_dispatches_via_client_and_yields_in_order(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """as_completed submits one Dask task per parked spec; futures resolve in completion order."""
+    submitted: list[RunSpec] = []
+
+    class _RecordingClient:
+        def submit(self, fn: Any, spec: RunSpec, *, pure: bool = True) -> _StubFuture:
+            submitted.append(spec)
+            return _StubFuture(_ok_outcome(spec.run_id))
+
+        def close(self) -> None:
+            pass
+
+    _patch_distributed_with_stubs(monkeypatch)
+    pool = DaskPool(client=_RecordingClient())
+    futures = [
+        pool.submit(_make_spec(output_dir=tmp_path / f"run_{i}", run_id=i)) for i in range(3)
+    ]
+    outcomes = list(pool.as_completed(futures))
+
+    assert {s.run_id for s in submitted} == {0, 1, 2}
+    assert {o.run_id for o in outcomes} == {0, 1, 2}
+    for f in futures:
+        assert f.done()
+        assert f.result().status == "ok"
+    pool.close()
+
+
+def test_as_completed_rejects_unknown_future(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _patch_distributed_with_stubs(monkeypatch)
+    pool = DaskPool(client=_StubClient())
+    f = pool.submit(_make_spec(output_dir=tmp_path / "run_0"))
+    list(pool.as_completed([f]))
+    with pytest.raises(BackendError):
+        list(pool.as_completed([f]))
+    pool.close()
+
+
+def test_dask_run_one_delegates_to_subprocess_helper(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """_dask_run_one is a thin wrapper around run_spec_in_subprocess."""
+    captured: dict[str, RunSpec] = {}
+
+    def _fake(spec: RunSpec) -> RunOutcome:
+        captured["spec"] = spec
+        return _ok_outcome(spec.run_id)
+
+    monkeypatch.setattr("gmat_sweep.backends.dask.run_spec_in_subprocess", _fake)
+    spec = _make_spec(output_dir=tmp_path / "run_0", run_id=42)
+    outcome = _dask_run_one(spec)
+    assert captured["spec"] is spec
+    assert outcome.run_id == 42
+
+
+def test_importing_dask_module_does_not_import_gmatpy() -> None:
+    """Loading gmat_sweep.backends.dask in a fresh interpreter must not import gmatpy.
+
+    The Dask worker process inherits whatever the module top-level imports
+    pulled in. If anything in the import chain triggered gmatpy, the
+    subprocess-isolation contract would be silently violated.
+    """
+    code = (
+        "import sys\n"
+        "import gmat_sweep.backends.dask  # noqa: F401\n"
+        "assert 'gmatpy' not in sys.modules, sorted(m for m in sys.modules if 'gmat' in m)\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, check=False
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/test_backends_ray.py
+++ b/tests/test_backends_ray.py
@@ -1,0 +1,294 @@
+"""Tests for gmat_sweep.backends.ray.RayPool — submit/as_completed semantics + ownership."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from collections.abc import Iterable, Iterator
+from concurrent.futures import Future
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, ClassVar
+
+import pytest
+
+from gmat_sweep.backends.base import Pool
+from gmat_sweep.errors import BackendError
+from gmat_sweep.spec import RunOutcome, RunSpec
+
+ray = pytest.importorskip("ray")
+
+
+from gmat_sweep.backends.ray import RayPool, _ray_run_one_impl  # noqa: E402
+
+
+def _make_spec(*, output_dir: Path, run_id: int = 0) -> RunSpec:
+    return RunSpec(
+        script_path=Path("/missions/m.script"),
+        overrides={},
+        output_dir=output_dir,
+        run_id=run_id,
+        seed=None,
+        run_options={},
+    )
+
+
+def _ok_outcome(run_id: int) -> RunOutcome:
+    now = datetime.now(timezone.utc)
+    return RunOutcome.ok(run_id=run_id, output_paths={}, started_at=now, ended_at=now)
+
+
+class _ObjectRef:
+    """Stand-in for a Ray ObjectRef carrying a precomputed outcome."""
+
+    def __init__(self, value: RunOutcome) -> None:
+        self.value = value
+
+
+class _Remote:
+    """Stand-in for a `ray.remote`-decorated function."""
+
+    def __init__(self, fn: Any) -> None:
+        self._fn = fn
+
+    def remote(self, spec: RunSpec) -> _ObjectRef:
+        return _ObjectRef(self._fn(spec))
+
+
+def _patch_ray_with_stubs(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    is_initialized: bool,
+    init_log: list[dict[str, Any]] | None = None,
+    shutdown_log: list[None] | None = None,
+) -> None:
+    """Replace the ray surface used by RayPool with controllable stubs."""
+    state = {"initialized": is_initialized}
+    init_log = init_log if init_log is not None else []
+    shutdown_log = shutdown_log if shutdown_log is not None else []
+
+    def _is_initialized() -> bool:
+        return state["initialized"]
+
+    def _init(**kwargs: Any) -> None:
+        init_log.append(kwargs)
+        state["initialized"] = True
+
+    def _shutdown() -> None:
+        shutdown_log.append(None)
+        state["initialized"] = False
+
+    def _remote(fn: Any) -> _Remote:
+        return _Remote(fn)
+
+    def _wait(
+        refs: list[_ObjectRef], *, num_returns: int = 1
+    ) -> tuple[list[_ObjectRef], list[_ObjectRef]]:
+        ready = refs[:num_returns]
+        unready = refs[num_returns:]
+        return ready, unready
+
+    def _get(ref: _ObjectRef) -> RunOutcome:
+        return ref.value
+
+    monkeypatch.setattr(ray, "is_initialized", _is_initialized, raising=True)
+    monkeypatch.setattr(ray, "init", _init, raising=True)
+    monkeypatch.setattr(ray, "shutdown", _shutdown, raising=True)
+    monkeypatch.setattr(ray, "remote", _remote, raising=True)
+    monkeypatch.setattr(ray, "wait", _wait, raising=True)
+    monkeypatch.setattr(ray, "get", _get, raising=True)
+
+
+def test_raypool_is_pool_subclass() -> None:
+    assert issubclass(RayPool, Pool)
+    assert RayPool.subprocess_isolated is True
+
+
+def test_subclass_setting_subprocess_isolated_false_rejected() -> None:
+    """The Pool ABC's contract still applies to RayPool subclasses."""
+    with pytest.raises(BackendError):
+
+        class _Bad(RayPool):  # pragma: no cover - body never runs
+            subprocess_isolated: ClassVar[bool] = False
+
+            def submit(self, spec: RunSpec) -> Future[RunOutcome]:
+                return Future()
+
+            def as_completed(self, futures: Iterable[Future[RunOutcome]]) -> Iterator[RunOutcome]:
+                return iter([])
+
+            def close(self) -> None:
+                pass
+
+
+def test_lazy_import_raises_backenderror_when_extra_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If `ray` cannot be imported, RayPool() raises BackendError chained from ImportError."""
+    monkeypatch.setitem(sys.modules, "ray", None)
+    with pytest.raises(BackendError) as ei:
+        RayPool()
+    assert "[ray]" in str(ei.value)
+    assert isinstance(ei.value.__cause__, ImportError)
+
+
+def test_owns_runtime_when_ray_was_uninitialised(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    init_log: list[dict[str, Any]] = []
+    shutdown_log: list[None] = []
+    _patch_ray_with_stubs(
+        monkeypatch, is_initialized=False, init_log=init_log, shutdown_log=shutdown_log
+    )
+    pool = RayPool(num_cpus=2)
+    assert pool._owns_runtime is True
+    assert init_log == [{"num_cpus": 2}]
+    pool.close()
+    assert shutdown_log == [None]
+
+
+def test_owns_runtime_when_address_supplied_and_ray_uninitialised(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Per #58: pool owns the local handle iff Ray was uninitialised at construction."""
+    init_log: list[dict[str, Any]] = []
+    shutdown_log: list[None] = []
+    _patch_ray_with_stubs(
+        monkeypatch, is_initialized=False, init_log=init_log, shutdown_log=shutdown_log
+    )
+    pool = RayPool(address="ray://example:10001", num_cpus=4)
+    assert pool._owns_runtime is True
+    assert init_log == [{"address": "ray://example:10001", "num_cpus": 4}]
+    pool.close()
+    assert shutdown_log == [None]
+
+
+def test_does_not_own_runtime_when_already_initialised(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    init_log: list[dict[str, Any]] = []
+    shutdown_log: list[None] = []
+    _patch_ray_with_stubs(
+        monkeypatch, is_initialized=True, init_log=init_log, shutdown_log=shutdown_log
+    )
+    pool = RayPool()
+    assert pool._owns_runtime is False
+    assert init_log == []
+    pool.close()
+    assert shutdown_log == []
+
+
+def test_close_is_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
+    shutdown_log: list[None] = []
+    _patch_ray_with_stubs(monkeypatch, is_initialized=False, shutdown_log=shutdown_log)
+    pool = RayPool()
+    pool.close()
+    pool.close()
+    assert shutdown_log == [None]
+
+
+def test_submit_returns_pending_future(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _patch_ray_with_stubs(monkeypatch, is_initialized=True)
+    pool = RayPool()
+    f = pool.submit(_make_spec(output_dir=tmp_path / "run_0"))
+    assert not f.done()
+    assert not f.cancelled()
+    pool.close()
+
+
+def test_submit_after_close_raises(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _patch_ray_with_stubs(monkeypatch, is_initialized=True)
+    pool = RayPool()
+    pool.close()
+    with pytest.raises(BackendError):
+        pool.submit(_make_spec(output_dir=tmp_path / "run_0"))
+
+
+def test_as_completed_after_close_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_ray_with_stubs(monkeypatch, is_initialized=True)
+    pool = RayPool()
+    pool.close()
+    with pytest.raises(BackendError):
+        list(pool.as_completed([]))
+
+
+def test_close_cancels_pending_futures(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _patch_ray_with_stubs(monkeypatch, is_initialized=True)
+    pool = RayPool()
+    f = pool.submit(_make_spec(output_dir=tmp_path / "run_0"))
+    pool.close()
+    assert f.cancelled()
+
+
+def test_as_completed_dispatches_via_remote_and_drains(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """as_completed builds one ObjectRef per spec and drains via ray.wait/get."""
+    submitted: list[RunSpec] = []
+
+    def _capturing_impl(spec: RunSpec) -> RunOutcome:
+        submitted.append(spec)
+        return _ok_outcome(spec.run_id)
+
+    _patch_ray_with_stubs(monkeypatch, is_initialized=True)
+    pool = RayPool()
+    monkeypatch.setattr(pool, "_remote_run_one", _Remote(_capturing_impl))
+
+    futures = [
+        pool.submit(_make_spec(output_dir=tmp_path / f"run_{i}", run_id=i)) for i in range(3)
+    ]
+    outcomes = list(pool.as_completed(futures))
+
+    assert {s.run_id for s in submitted} == {0, 1, 2}
+    assert {o.run_id for o in outcomes} == {0, 1, 2}
+    for f in futures:
+        assert f.done()
+        assert f.result().status == "ok"
+    pool.close()
+
+
+def test_as_completed_rejects_unknown_future(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _patch_ray_with_stubs(monkeypatch, is_initialized=True)
+    pool = RayPool()
+    f = pool.submit(_make_spec(output_dir=tmp_path / "run_0"))
+    list(pool.as_completed([f]))
+    with pytest.raises(BackendError):
+        list(pool.as_completed([f]))
+    pool.close()
+
+
+def test_ray_run_one_impl_delegates_to_subprocess_helper(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """_ray_run_one_impl is a thin wrapper around run_spec_in_subprocess."""
+    captured: dict[str, RunSpec] = {}
+
+    def _fake(spec: RunSpec) -> RunOutcome:
+        captured["spec"] = spec
+        return _ok_outcome(spec.run_id)
+
+    monkeypatch.setattr("gmat_sweep.backends.ray.run_spec_in_subprocess", _fake)
+    spec = _make_spec(output_dir=tmp_path / "run_0", run_id=99)
+    outcome = _ray_run_one_impl(spec)
+    assert captured["spec"] is spec
+    assert outcome.run_id == 99
+
+
+def test_importing_ray_module_does_not_import_gmatpy() -> None:
+    """Loading gmat_sweep.backends.ray in a fresh interpreter must not import gmatpy.
+
+    The Ray worker process inherits whatever the module top-level imports
+    pulled in. If anything in the import chain triggered gmatpy, the
+    subprocess-isolation contract would be silently violated.
+    """
+    code = (
+        "import sys\n"
+        "import gmat_sweep.backends.ray  # noqa: F401\n"
+        "assert 'gmatpy' not in sys.modules, sorted(m for m in sys.modules if 'gmat' in m)\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, check=False
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

- `DaskPool` (`gmat_sweep.backends.dask`) — fans runs across a `dask.distributed` cluster. Spawns its own `LocalCluster` + `Client` when constructed with no arguments; accepts a user-supplied `distributed.Client` to plug into an existing scheduler. Ownership tracked so `close()` only tears down what the pool created.
- `RayPool` (`gmat_sweep.backends.ray`) — fans runs across a Ray runtime. Calls `ray.init(...)` for you (with `address` / `num_cpus` / extra kwargs forwarded). `close()` calls `ray.shutdown()` only when the pool's `__init__` is what initialised the runtime — supplying an `address` to a still-uninitialised Ray follows the same rule.
- Both pools satisfy the `Pool` subprocess-isolation contract by routing each task through `run_spec_in_subprocess`, so the Dask/Ray worker process itself never imports `gmatpy`.
- Lazy re-export from `gmat_sweep.backends` via module-level `__getattr__`: `import gmat_sweep` does not pull in `distributed` or `ray` when the corresponding extra is not installed.
- New `docs/backends.md` with a choosing-a-backend matrix and worked examples; `DaskPool` / `RayPool` picked up in `docs/api.md` via mkdocstrings.
- Mypy overrides for `distributed.*` and `ray.*` use `follow_imports = "skip"` because both packages ship `py.typed`.
- CI's test job now syncs with `--extra dask --extra ray` so the integration tests for these pools have what they need; lint / typecheck / minimal-install jobs remain narrower.

## Notes

- One PR for two issues — deliberate departure from `CONTRIBUTING.md`'s "one issue per branch" rule because the two pools share enough scaffolding (re-export plumbing, mypy overrides, docs page, CI extras toggle) that splitting buys nothing.
- `from gmat_sweep.backends import DaskPool` (or `RayPool`) without the extra installed surfaces as a stock `ImportError` rather than the `__getattr__`-raised `AttributeError`. Python's `from … import …` collapses `AttributeError` to `ImportError` and discards the message; the install hint is preserved on `__cause__`. Attribute access (`gmat_sweep.backends.DaskPool`) keeps the helpful message.

## Test plan

- [x] `uv run ruff check`
- [x] `uv run ruff format --check`
- [x] `uv run mypy` (strict)
- [x] `uv run pytest` — 430 unit tests pass (29 new under `test_backends_dask.py` / `test_backends_ray.py`)
- [x] `import gmat_sweep` does not pull `distributed` or `ray` into `sys.modules`
- [x] Module-level access of `DaskPool` / `RayPool` raises `AttributeError` with install hint when extra missing
- [ ] Integration tests against a real `LocalCluster` and `ray.init()` (deferred to CI; the GMAT-backed worker subprocess is needed and CI has it)
- [ ] Notebook smoke job

Closes #57
Closes #58