### PR TITLE
Add --backend {local,dask,ray} flag to the gmat-sweep CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ A `gmat-sweep` console script is also installed for shell-script and CI use:
 
 ```bash
 gmat-sweep run         --grid Sat.SMA=7000:7200:3 --workers 8 --out ./sweep mission.script
+gmat-sweep run         --grid Sat.SMA=7000:7200:3 --backend dask --workers 8 --out ./sweep mission.script
 gmat-sweep monte-carlo --n 1000 --perturb 'Sat.SMA=normal:7100:50' --seed 42 --out ./mc mission.script
 gmat-sweep resume      --script mission.script --workers 8 ./mc/manifest.jsonl
 gmat-sweep show        ./sweep/manifest.jsonl

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -38,6 +38,45 @@ prints a one-line summary to stdout when the sweep finishes:
 N runs (A ok[, B failed][, C skipped]) in T.TT s — output: PATH
 ```
 
+## Choosing a backend
+
+The four sweep-running subcommands and `resume` accept `--backend`. `show`
+does not — it never runs anything.
+
+| Value           | Pool                                   | Extras                           |
+|-----------------|----------------------------------------|----------------------------------|
+| `local` (default) | [`LocalJoblibPool`][gmat_sweep.LocalJoblibPool] over loky workers | none |
+| `dask`          | [`DaskPool`][gmat_sweep.backends.DaskPool] over a `LocalCluster` | `pip install gmat-sweep[dask]` |
+| `ray`           | [`RayPool`][gmat_sweep.backends.RayPool] over a local Ray runtime | `pip install gmat-sweep[ray]` |
+
+`--workers N` maps onto each backend in the natural way: `LocalJoblibPool`
+takes it as `workers`, `DaskPool` as `n_workers`, `RayPool` as `num_cpus`.
+The default `-1` means "let the pool pick" (every available core for the
+local pool, `os.cpu_count()` for Dask, Ray's own auto-detect for Ray).
+
+`--backend-arg KEY=VALUE` is an escape hatch for less-common pool
+constructor kwargs. It is repeatable, values are coerced int → float → str,
+and the parsed pairs are forwarded as `**kwargs` to the chosen pool.
+Examples:
+
+```bash
+gmat-sweep run --backend dask \
+    --backend-arg threads_per_worker=2 \
+    --grid Sat.SMA=7000:7200:3 \
+    --out ./sweep mission.script
+
+gmat-sweep run --backend ray \
+    --backend-arg address=ray://head:10001 \
+    --grid Sat.SMA=7000:7200:3 \
+    --out ./sweep mission.script
+```
+
+`--backend-arg` is rejected with `--backend local` (the local pool has no
+extra kwargs to forward). Missing extras (`[dask]` / `[ray]` not installed)
+exit with code `4` and a "pip install gmat-sweep[…]" message on stderr.
+Unknown kwargs surface the same way — they reach the pool constructor and
+are rejected there.
+
 ## Exit codes
 
 | Code | Meaning                                                                        |

--- a/src/gmat_sweep/cli.py
+++ b/src/gmat_sweep/cli.py
@@ -25,7 +25,9 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from gmat_sweep.api import latin_hypercube, monte_carlo, sweep
+from gmat_sweep.backends.dask import DaskPool
 from gmat_sweep.backends.joblib import LocalJoblibPool
+from gmat_sweep.backends.ray import RayPool
 from gmat_sweep.errors import (
     BackendError,
     GmatSweepError,
@@ -37,6 +39,7 @@ from gmat_sweep.manifest import Manifest
 if TYPE_CHECKING:
     import pandas as pd
 
+    from gmat_sweep.backends.base import Pool
     from gmat_sweep.distributions import DistSpec
 
 __all__ = ["main"]
@@ -166,6 +169,55 @@ def _parse_perturb_spec(spec: str) -> tuple[str, DistSpec]:
     return name, (tag, p1, p2)
 
 
+def _parse_backend_arg(spec: str) -> tuple[str, int | float | str]:
+    """Parse one ``--backend-arg`` token into ``(key, coerced_value)``.
+
+    Same int → float → str coercion as :func:`_parse_grid_value`.
+    """
+    if "=" not in spec:
+        raise SweepConfigError(f"--backend-arg must be 'KEY=VALUE': {spec!r}")
+    name, _, rhs = spec.partition("=")
+    name = name.strip()
+    if not name:
+        raise SweepConfigError(f"--backend-arg is missing a key: {spec!r}")
+    if not rhs:
+        raise SweepConfigError(f"--backend-arg for {name!r} has no value: {spec!r}")
+    return name, _parse_grid_value(rhs)
+
+
+def _build_pool(args: argparse.Namespace) -> Pool:
+    """Construct the backend pool selected by ``--backend`` / ``--backend-arg``.
+
+    The four sweep-running subcommands and ``resume`` route through here so
+    the backend wiring lives in one place. ``--backend local`` (default)
+    returns a :class:`LocalJoblibPool` and rejects any ``--backend-arg``;
+    ``dask`` / ``ray`` map ``--workers`` onto ``n_workers`` / ``num_cpus``
+    (with the default ``-1`` meaning "let the pool pick") and forward every
+    ``--backend-arg`` as a kwarg to the pool constructor. Unknown kwargs
+    surface as the pool's own :class:`BackendError`.
+    """
+    backend_kwargs: dict[str, Any] = {}
+    for raw in args.backend_arg:
+        key, value = _parse_backend_arg(raw)
+        if key in backend_kwargs:
+            raise SweepConfigError(f"--backend-arg for {key!r} given more than once")
+        backend_kwargs[key] = value
+
+    if args.backend == "local":
+        if backend_kwargs:
+            raise SweepConfigError(
+                "--backend-arg is not supported with --backend local; "
+                "the local pool only accepts --workers"
+            )
+        return LocalJoblibPool(workers=args.workers)
+    workers = args.workers if args.workers > 0 else None
+    if args.backend == "dask":
+        return DaskPool(n_workers=workers, **backend_kwargs)
+    if args.backend == "ray":
+        return RayPool(num_cpus=workers, **backend_kwargs)
+    raise AssertionError(f"unreachable backend: {args.backend!r}")  # pragma: no cover
+
+
 def _load_samples(path: Path) -> pd.DataFrame:
     """Load an explicit-row samples DataFrame from CSV or Parquet.
 
@@ -220,7 +272,7 @@ def _cmd_run(args: argparse.Namespace) -> int:
         grid[name] = values
 
     out = Path(args.out)
-    with LocalJoblibPool(workers=args.workers) as pool:
+    with _build_pool(args) as pool:
         sweep(script, grid=grid, backend=pool, out=out)
 
     manifest = Manifest.load(out / "manifest.jsonl")
@@ -257,7 +309,7 @@ def _cmd_monte_carlo(args: argparse.Namespace) -> int:
 
     perturb = _collect_perturb(args.perturb)
     out = Path(args.out)
-    with LocalJoblibPool(workers=args.workers) as pool:
+    with _build_pool(args) as pool:
         monte_carlo(
             script,
             n=args.n,
@@ -280,7 +332,7 @@ def _cmd_latin_hypercube(args: argparse.Namespace) -> int:
 
     perturb = _collect_perturb(args.perturb)
     out = Path(args.out)
-    with LocalJoblibPool(workers=args.workers) as pool:
+    with _build_pool(args) as pool:
         latin_hypercube(
             script,
             n=args.n,
@@ -303,7 +355,7 @@ def _cmd_explicit(args: argparse.Namespace) -> int:
 
     samples = _load_samples(Path(args.samples))
     out = Path(args.out)
-    with LocalJoblibPool(workers=args.workers) as pool:
+    with _build_pool(args) as pool:
         sweep(script, samples=samples, backend=pool, out=out)
 
     manifest = Manifest.load(out / "manifest.jsonl")
@@ -324,7 +376,7 @@ def _cmd_resume(args: argparse.Namespace) -> int:
     # Local import: only the resume path drives Sweep directly.
     from gmat_sweep.sweep import Sweep
 
-    with LocalJoblibPool(workers=args.workers) as pool:
+    with _build_pool(args) as pool:
         sweep_obj = Sweep.from_manifest(
             manifest_path,
             script,
@@ -334,6 +386,33 @@ def _cmd_resume(args: argparse.Namespace) -> int:
 
     print(_format_summary(sweep_obj.to_manifest(), manifest_path.parent))
     return EXIT_OK
+
+
+def _add_backend_flag(subparser: argparse.ArgumentParser) -> None:
+    """Attach ``--backend`` / ``--backend-arg`` to a sweep-running subparser."""
+    subparser.add_argument(
+        "--backend",
+        choices=("local", "dask", "ray"),
+        default="local",
+        metavar="NAME",
+        help=(
+            "Execution backend. 'local' (default) runs on this machine via "
+            "joblib/loky workers. 'dask' requires the [dask] extra; 'ray' "
+            "requires the [ray] extra. Missing extras exit 4."
+        ),
+    )
+    subparser.add_argument(
+        "--backend-arg",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help=(
+            "Extra keyword forwarded to the dask/ray pool constructor "
+            "(e.g. 'threads_per_worker=2', 'address=ray://host:port'). "
+            "Repeat for multiple kwargs. Values coerced int → float → str. "
+            "Not allowed with --backend local."
+        ),
+    )
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -382,6 +461,7 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="SCRIPT",
         help="Path to the GMAT .script file.",
     )
+    _add_backend_flag(run)
     run.set_defaults(func=_cmd_run)
 
     show = subparsers.add_parser(
@@ -449,6 +529,7 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="SCRIPT",
         help="Path to the GMAT .script file.",
     )
+    _add_backend_flag(monte)
     monte.set_defaults(func=_cmd_monte_carlo)
 
     lhs = subparsers.add_parser(
@@ -504,6 +585,7 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="SCRIPT",
         help="Path to the GMAT .script file.",
     )
+    _add_backend_flag(lhs)
     lhs.set_defaults(func=_cmd_latin_hypercube)
 
     explicit = subparsers.add_parser(
@@ -539,6 +621,7 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="SCRIPT",
         help="Path to the GMAT .script file.",
     )
+    _add_backend_flag(explicit)
     explicit.set_defaults(func=_cmd_explicit)
 
     resume = subparsers.add_parser(
@@ -580,6 +663,7 @@ def _build_parser() -> argparse.ArgumentParser:
             "Emits a RuntimeWarning."
         ),
     )
+    _add_backend_flag(resume)
     resume.set_defaults(func=_cmd_resume)
 
     return parser

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+import argparse
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 import pandas as pd
 import pytest
 
 from gmat_sweep import cli
+from gmat_sweep.backends.joblib import LocalJoblibPool
 from gmat_sweep.errors import SweepConfigError
 from gmat_sweep.manifest import Manifest
 from tests.conftest import FakeGmatRun, FakeResults
@@ -937,3 +939,368 @@ def test_resume_help_lists_allow_script_drift(capsys: pytest.CaptureFixture[str]
     out = capsys.readouterr().out
     assert "--allow-script-drift" in out
     assert "--script" in out
+
+
+# ---- _parse_backend_arg -------------------------------------------------
+
+
+def test_parse_backend_arg_int_value() -> None:
+    assert cli._parse_backend_arg("threads_per_worker=2") == ("threads_per_worker", 2)
+
+
+def test_parse_backend_arg_float_value() -> None:
+    assert cli._parse_backend_arg("memory_limit=1.5") == ("memory_limit", 1.5)
+
+
+def test_parse_backend_arg_string_fallback() -> None:
+    assert cli._parse_backend_arg("address=ray://host:10001") == (
+        "address",
+        "ray://host:10001",
+    )
+
+
+def test_parse_backend_arg_rejects_missing_equals() -> None:
+    with pytest.raises(SweepConfigError, match="must be 'KEY=VALUE'"):
+        cli._parse_backend_arg("threads_per_worker")
+
+
+def test_parse_backend_arg_rejects_empty_key() -> None:
+    with pytest.raises(SweepConfigError, match="missing a key"):
+        cli._parse_backend_arg("=2")
+
+
+def test_parse_backend_arg_rejects_empty_value() -> None:
+    with pytest.raises(SweepConfigError, match="has no value"):
+        cli._parse_backend_arg("threads_per_worker=")
+
+
+# ---- _build_pool / --backend wiring -------------------------------------
+
+# A recording fake stands in for DaskPool / RayPool: subclasses LocalJoblibPool
+# so the rest of the CLI pipeline (submit / as_completed / manifest write)
+# still runs in-process via joblib(n_jobs=1), but every constructor kwarg the
+# CLI passed is captured for assertion. Tests opt into the recording behavior
+# by monkey-patching cli.DaskPool / cli.RayPool to a fresh subclass per test
+# (so .calls doesn't bleed across tests).
+
+
+def _make_recording_pool_class() -> Any:
+    """Return a fresh recording-fake Pool class. Each call yields a new class.
+
+    The returned class records every constructor kwargs dict on its
+    ``calls`` attribute and routes execution through
+    :class:`LocalJoblibPool` with ``workers=1`` so the surrounding CLI
+    pipeline (sweep → submit → as_completed → manifest write) runs
+    synchronously in the test process.
+    """
+
+    class _RecordingPool(LocalJoblibPool):
+        calls: ClassVar[list[dict[str, Any]]] = []
+
+        def __init__(self, **kwargs: Any) -> None:
+            type(self).calls.append(dict(kwargs))
+            super().__init__(workers=1)
+
+    return _RecordingPool
+
+
+def _make_missing_extra_pool_class(message: str) -> Any:
+    """Return a fake that raises :class:`BackendError` on construction."""
+    from gmat_sweep.errors import BackendError as _BackendError
+
+    class _MissingExtraPool:
+        def __init__(self, **_kwargs: Any) -> None:
+            raise _BackendError(message)
+
+    return _MissingExtraPool
+
+
+def test_build_pool_local_default_returns_local_joblib_pool() -> None:
+    args = argparse.Namespace(backend="local", workers=-1, backend_arg=[])
+    with cli._build_pool(args) as pool:
+        assert isinstance(pool, LocalJoblibPool)
+
+
+def test_build_pool_local_rejects_backend_arg() -> None:
+    args = argparse.Namespace(backend="local", workers=-1, backend_arg=["foo=1"])
+    with pytest.raises(SweepConfigError, match="not supported with --backend local"):
+        cli._build_pool(args)
+
+
+def test_build_pool_dask_constructs_dask_pool_with_workers_and_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _make_recording_pool_class()
+    monkeypatch.setattr(cli, "DaskPool", fake)
+
+    args = argparse.Namespace(
+        backend="dask",
+        workers=4,
+        backend_arg=["threads_per_worker=2"],
+    )
+    with cli._build_pool(args):
+        pass
+
+    assert fake.calls == [{"n_workers": 4, "threads_per_worker": 2}]
+
+
+def test_build_pool_dask_negative_workers_maps_to_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _make_recording_pool_class()
+    monkeypatch.setattr(cli, "DaskPool", fake)
+
+    args = argparse.Namespace(backend="dask", workers=-1, backend_arg=[])
+    with cli._build_pool(args):
+        pass
+
+    assert fake.calls == [{"n_workers": None}]
+
+
+def test_build_pool_ray_constructs_ray_pool_with_num_cpus_and_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _make_recording_pool_class()
+    monkeypatch.setattr(cli, "RayPool", fake)
+
+    args = argparse.Namespace(
+        backend="ray",
+        workers=8,
+        backend_arg=["address=ray://host:10001"],
+    )
+    with cli._build_pool(args):
+        pass
+
+    assert fake.calls == [{"num_cpus": 8, "address": "ray://host:10001"}]
+
+
+def test_build_pool_rejects_duplicate_backend_arg() -> None:
+    args = argparse.Namespace(
+        backend="dask",
+        workers=-1,
+        backend_arg=["threads_per_worker=2", "threads_per_worker=4"],
+    )
+    with pytest.raises(SweepConfigError, match="given more than once"):
+        cli._build_pool(args)
+
+
+@pytest.mark.parametrize(
+    "subcommand,extra_args",
+    [
+        ("run", ["--grid", "Sat.SMA=7000:8000:2"]),
+        ("monte-carlo", ["--n", "2", "--perturb", "Sat.SMA=normal:7100:50", "--seed", "0"]),
+        ("latin-hypercube", ["--n", "2", "--perturb", "Sat.SMA=normal:7100:50", "--seed", "0"]),
+    ],
+)
+@pytest.mark.parametrize(
+    "backend,fake_attr,worker_kw",
+    [
+        ("dask", "DaskPool", "n_workers"),
+        ("ray", "RayPool", "num_cpus"),
+    ],
+)
+def test_sweep_running_subcommands_route_through_selected_backend(
+    tmp_path: Path,
+    fake_gmat_run: FakeGmatRun,
+    monkeypatch: pytest.MonkeyPatch,
+    subcommand: str,
+    extra_args: list[str],
+    backend: str,
+    fake_attr: str,
+    worker_kw: str,
+) -> None:
+    fake = _make_recording_pool_class()
+    monkeypatch.setattr(cli, fake_attr, fake)
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+
+    rc = cli.main(
+        [
+            subcommand,
+            *extra_args,
+            "--workers",
+            "1",
+            "--backend",
+            backend,
+            "--out",
+            str(out),
+            str(script),
+        ]
+    )
+
+    assert rc == 0
+    assert fake.calls == [{worker_kw: 1}]
+
+
+def test_explicit_subcommand_routes_through_selected_backend(
+    tmp_path: Path,
+    fake_gmat_run: FakeGmatRun,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _make_recording_pool_class()
+    monkeypatch.setattr(cli, "DaskPool", fake)
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+    samples = tmp_path / "samples.csv"
+    samples.write_text("Sat.SMA\n7000\n7100\n", encoding="utf-8")
+
+    rc = cli.main(
+        [
+            "explicit",
+            "--samples",
+            str(samples),
+            "--workers",
+            "1",
+            "--backend",
+            "dask",
+            "--backend-arg",
+            "threads_per_worker=2",
+            "--out",
+            str(out),
+            str(script),
+        ]
+    )
+
+    assert rc == 0
+    assert fake.calls == [{"n_workers": 1, "threads_per_worker": 2}]
+
+
+def test_run_with_backend_dask_missing_extra_exits_backend_code(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        cli,
+        "DaskPool",
+        _make_missing_extra_pool_class(
+            "DaskPool requires the [dask] extra: pip install gmat-sweep[dask]"
+        ),
+    )
+
+    script = _write_script(tmp_path)
+
+    rc = cli.main(
+        [
+            "run",
+            "--grid",
+            "Sat.SMA=7000:8000:2",
+            "--backend",
+            "dask",
+            "--out",
+            str(tmp_path / "out"),
+            str(script),
+        ]
+    )
+    assert rc == cli.EXIT_BACKEND
+    err = capsys.readouterr().err
+    assert "backend error" in err
+    assert "[dask]" in err
+
+
+def test_run_with_backend_ray_missing_extra_exits_backend_code(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        cli,
+        "RayPool",
+        _make_missing_extra_pool_class(
+            "RayPool requires the [ray] extra: pip install gmat-sweep[ray]"
+        ),
+    )
+
+    script = _write_script(tmp_path)
+
+    rc = cli.main(
+        [
+            "run",
+            "--grid",
+            "Sat.SMA=7000:8000:2",
+            "--backend",
+            "ray",
+            "--out",
+            str(tmp_path / "out"),
+            str(script),
+        ]
+    )
+    assert rc == cli.EXIT_BACKEND
+    err = capsys.readouterr().err
+    assert "backend error" in err
+    assert "[ray]" in err
+
+
+def test_show_does_not_accept_backend_flag(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["show", "--backend", "dask", "/tmp/manifest.jsonl"])
+    assert exc_info.value.code == 2
+    assert "unrecognized arguments" in capsys.readouterr().err
+
+
+def test_run_with_invalid_backend_choice_rejected_by_argparse(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(
+            [
+                "run",
+                "--grid",
+                "a=1,2",
+                "--backend",
+                "spark",
+                "--out",
+                "/tmp/out",
+                "/tmp/m.script",
+            ]
+        )
+    assert exc_info.value.code == 2
+    assert "invalid choice" in capsys.readouterr().err
+
+
+def test_resume_subcommand_accepts_backend_flag(
+    tmp_path: Path,
+    fake_gmat_run: FakeGmatRun,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _make_recording_pool_class()
+    monkeypatch.setattr(cli, "DaskPool", fake)
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+
+    # First, run a sweep to produce a manifest the resume can pick up.
+    rc = cli.main(
+        [
+            "run",
+            "--grid",
+            "Sat.SMA=7000:8000:2",
+            "--workers",
+            "1",
+            "--out",
+            str(out),
+            str(script),
+        ]
+    )
+    assert rc == 0
+    fake.calls.clear()  # discard any local-path noise (none expected, but be defensive)
+
+    rc = cli.main(
+        [
+            "resume",
+            str(out / "manifest.jsonl"),
+            "--script",
+            str(script),
+            "--workers",
+            "1",
+            "--backend",
+            "dask",
+        ]
+    )
+    assert rc == 0
+    assert fake.calls == [{"n_workers": 1}]


### PR DESCRIPTION
## Summary
- Adds `--backend {local,dask,ray}` (default `local`) and a repeatable `--backend-arg KEY=VALUE` escape hatch to the four sweep-running subcommands (`run`, `monte-carlo`, `latin-hypercube`, `explicit`) plus `resume`. `show` does not get the flag.
- Centralises pool construction in `_build_pool(args)`: `local` → `LocalJoblibPool(workers=...)`, `dask` → `DaskPool(n_workers=...)`, `ray` → `RayPool(num_cpus=...)`. `--workers -1` (default) maps to `None` for the dask/ray cases so each pool's own auto-detect picks the worker count. `--backend-arg` values are coerced int → float → str and forwarded to the pool constructor; combining `--backend-arg` with `--backend local` is rejected at parse time (exit `2`) since `LocalJoblibPool` only accepts `workers`.
- Missing extras (`[dask]` / `[ray]` not installed) surface as the pool's own `BackendError` on construction → exit `4`, matching the existing exit-code surface.
- `docs/cli.md` gains a "Choosing a backend" subsection covering the three values, `--backend-arg` shape, install-the-extra prerequisite, and worked dask/ray examples. README CLI block gains a `--backend dask` line.

## Test plan
- [x] `uv run pytest` — 454 passed, 22 deselected
- [x] `uv run ruff check`, `uv run ruff format --check`
- [x] `uv run mypy src tests`
- [x] `uv run mkdocs build --strict`
- [x] New unit tests cover the four sweep-running subcommands × `{dask, ray}` routing through a recording fake pool; both missing-extra branches; `show` still rejecting `--backend` (argparse exit 2); `resume` picking up `--backend`; `--backend-arg threads_per_worker=2` reaching `DaskPool.__init__` (asserted via fake-pool fixture).

Closes #59