### PR TITLE
Add --detail and --run modes to gmat-sweep show

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -212,11 +212,61 @@ mismatch exits with code `2`.
 
 ## `show`
 
-Print the one-line summary line for a manifest produced by any of the
-sweep-running subcommands.
+Inspect a manifest produced by any of the sweep-running subcommands. Three
+modes:
+
+- default — one-line summary.
+- `--detail` — per-run table sorted with `failed` first, then `skipped`, then
+  `ok`, plus the same one-line summary at the bottom.
+- `--run N` — full record for `run_id=N`: header fields, override dict, and
+  the unsuppressed `stderr`.
+
+`--detail` and `--run` are mutually exclusive.
 
 ```bash
 gmat-sweep show ./sweep-out/manifest.jsonl
 ```
 
-A missing or unparseable manifest exits with code `3`.
+```text
+5 runs (4 ok, 1 failed) in 53.41 s — output: ./sweep-out
+```
+
+### `--detail`
+
+```bash
+gmat-sweep show --detail ./sweep-out/manifest.jsonl
+```
+
+```text
+run_id  status   duration_s  stderr_summary                  log_path
+1       failed   0.21        ValueError: Sat.SMA out of...   ./sweep-out/run-1/worker.log
+0       ok       12.43       —                               ./sweep-out/run-0/worker.log
+2       ok       11.97       —                               ./sweep-out/run-2/worker.log
+3       ok       14.02       —                               ./sweep-out/run-3/worker.log
+4       ok       14.78       —                               ./sweep-out/run-4/worker.log
+5 runs (4 ok, 1 failed) in 53.41 s — output: ./sweep-out
+```
+
+`stderr_summary` is the first line of the run's captured `stderr`, truncated
+to 60 characters with a `...` ellipsis. `ok` rows show `—` (no captured
+`stderr`).
+
+`--filter STATUS` narrows the table to one of `ok`, `failed`, `skipped`. The
+trailing summary line still reflects the full manifest. `--filter` requires
+`--detail`.
+
+### `--run N`
+
+```bash
+gmat-sweep show --run 1 ./sweep-out/manifest.jsonl
+```
+
+Prints `run_id=1`'s full record (status, duration, timestamps, log path,
+override dict, full unsuppressed `stderr`). Exit code `0`. If `N` is not in
+the manifest, exits with code `3` and a `gmat-sweep: run_id N not found in
+manifest` message on stderr.
+
+### Exit codes
+
+A missing or unparseable manifest, or a `--run N` for an `N` not in the
+manifest, exits with code `3`.

--- a/src/gmat_sweep/cli.py
+++ b/src/gmat_sweep/cli.py
@@ -34,7 +34,7 @@ from gmat_sweep.errors import (
     ManifestCorruptError,
     SweepConfigError,
 )
-from gmat_sweep.manifest import Manifest
+from gmat_sweep.manifest import Manifest, ManifestEntry
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -51,6 +51,11 @@ EXIT_MANIFEST = 3
 EXIT_BACKEND = 4
 
 _PERTURB_TAGS = ("normal", "uniform", "lognormal")
+
+_DETAIL_HEADERS = ("run_id", "status", "duration_s", "stderr_summary", "log_path")
+_STDERR_SUMMARY_WIDTH = 60
+_EMPTY_CELL = "—"
+_STATUS_BUCKETS: dict[str, int] = {"failed": 0, "skipped": 1, "ok": 2}
 
 
 def _parse_grid_value(token: str) -> int | float | str:
@@ -280,12 +285,121 @@ def _cmd_run(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
+def _truncate_stderr_summary(stderr: str | None) -> str:
+    """First line of ``stderr`` truncated to ``_STDERR_SUMMARY_WIDTH`` chars.
+
+    Returns ``""`` for ``None`` or empty input. Strings longer than the window
+    are cut so the visible result (text + ``"..."``) totals at most
+    ``_STDERR_SUMMARY_WIDTH`` characters.
+    """
+    if not stderr:
+        return ""
+    first = stderr.splitlines()[0] if stderr.splitlines() else ""
+    if len(first) <= _STDERR_SUMMARY_WIDTH:
+        return first
+    return first[: _STDERR_SUMMARY_WIDTH - 3] + "..."
+
+
+def _detail_row(entry: ManifestEntry) -> tuple[str, str, str, str, str]:
+    """Render one manifest entry as the five string cells of a detail-table row."""
+    summary = _truncate_stderr_summary(entry.stderr) or _EMPTY_CELL
+    log = _EMPTY_CELL if entry.log_path is None else str(entry.log_path)
+    return (
+        str(entry.run_id),
+        entry.status,
+        f"{entry.duration_s:.2f}",
+        summary,
+        log,
+    )
+
+
+def _format_detail_table(
+    manifest: Manifest, output_dir: Path, *, status_filter: str | None = None
+) -> str:
+    """Render the per-run detail table plus the trailing one-line summary.
+
+    Rows are sorted with ``failed`` first, then ``skipped``, then ``ok``;
+    within each bucket by ``run_id`` ascending. ``status_filter`` (if given)
+    keeps only rows of that status; the summary line still reflects the
+    full manifest.
+    """
+    entries = manifest.entries
+    if status_filter is not None:
+        entries = [e for e in entries if e.status == status_filter]
+    sorted_entries = sorted(entries, key=lambda e: (_STATUS_BUCKETS.get(e.status, 99), e.run_id))
+    rows = [_detail_row(e) for e in sorted_entries]
+
+    widths = [len(h) for h in _DETAIL_HEADERS]
+    for row in rows:
+        for i, cell in enumerate(row):
+            if len(cell) > widths[i]:
+                widths[i] = len(cell)
+
+    def _format_row(cells: tuple[str, ...] | list[str]) -> str:
+        return "  ".join(cell.ljust(widths[i]) for i, cell in enumerate(cells)).rstrip()
+
+    lines = [_format_row(_DETAIL_HEADERS)]
+    lines.extend(_format_row(row) for row in rows)
+    lines.append(_format_summary(manifest, output_dir))
+    return "\n".join(lines)
+
+
+def _format_run_detail(entry: ManifestEntry) -> str:
+    """Render one run's full record: header fields, full stderr, override dict."""
+    header_fields = (
+        ("status", entry.status),
+        ("duration_s", f"{entry.duration_s:.2f}"),
+        ("started_at", entry.started_at.isoformat()),
+        ("ended_at", entry.ended_at.isoformat()),
+        ("log_path", _EMPTY_CELL if entry.log_path is None else str(entry.log_path)),
+    )
+    label_width = max(len(label) for label, _ in header_fields)
+    lines = [f"run_id: {entry.run_id}"]
+    lines.extend(f"{label.ljust(label_width)}  {value}" for label, value in header_fields)
+
+    lines.append("")
+    lines.append("overrides:")
+    if entry.overrides:
+        key_width = max(len(k) for k in entry.overrides)
+        for key in sorted(entry.overrides):
+            lines.append(f"  {key.ljust(key_width)}  {entry.overrides[key]!r}")
+    else:
+        lines.append("  (none)")
+
+    lines.append("")
+    lines.append("stderr:")
+    if entry.stderr:
+        lines.extend(entry.stderr.splitlines() or [entry.stderr])
+    else:
+        lines.append("(no stderr)")
+    return "\n".join(lines)
+
+
 def _cmd_show(args: argparse.Namespace) -> int:
     manifest_path = Path(args.manifest)
     if not manifest_path.is_file():
         print(f"gmat-sweep: manifest not found: {manifest_path}", file=sys.stderr)
         return EXIT_MANIFEST
+    if args.filter is not None and not args.detail:
+        raise SweepConfigError("--filter requires --detail")
+
     manifest = Manifest.load(manifest_path)
+
+    if args.run is not None:
+        for entry in manifest.entries:
+            if entry.run_id == args.run:
+                print(_format_run_detail(entry))
+                return EXIT_OK
+        print(
+            f"gmat-sweep: run_id {args.run} not found in manifest",
+            file=sys.stderr,
+        )
+        return EXIT_MANIFEST
+
+    if args.detail:
+        print(_format_detail_table(manifest, manifest_path.parent, status_filter=args.filter))
+        return EXIT_OK
+
     print(_format_summary(manifest, manifest_path.parent))
     return EXIT_OK
 
@@ -467,12 +581,42 @@ def _build_parser() -> argparse.ArgumentParser:
     show = subparsers.add_parser(
         "show",
         help="Print a one-line summary of a sweep manifest.",
-        description="Load a manifest.jsonl file and print a one-line summary.",
+        description=(
+            "Load a manifest.jsonl file and print either a one-line summary "
+            "(default), a per-run detail table (--detail), or one run's full "
+            "record (--run N)."
+        ),
     )
     show.add_argument(
         "manifest",
         metavar="MANIFEST",
         help="Path to a manifest.jsonl produced by 'gmat-sweep run'.",
+    )
+    show_mode = show.add_mutually_exclusive_group()
+    show_mode.add_argument(
+        "--detail",
+        action="store_true",
+        help=(
+            "Print a per-run table (run_id, status, duration_s, stderr_summary, "
+            "log_path) sorted failed → skipped → ok, then the one-line summary."
+        ),
+    )
+    show_mode.add_argument(
+        "--run",
+        type=int,
+        default=None,
+        metavar="N",
+        help=(
+            "Print run_id=N's full record: header fields, override dict, full "
+            "stderr. Exits 3 if N is not in the manifest."
+        ),
+    )
+    show.add_argument(
+        "--filter",
+        choices=("ok", "failed", "skipped"),
+        default=None,
+        metavar="STATUS",
+        help="With --detail, restrict the table to runs of one status.",
     )
     show.set_defaults(func=_cmd_show)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, ClassVar
 
@@ -12,7 +13,7 @@ import pytest
 from gmat_sweep import cli
 from gmat_sweep.backends.joblib import LocalJoblibPool
 from gmat_sweep.errors import SweepConfigError
-from gmat_sweep.manifest import Manifest
+from gmat_sweep.manifest import Manifest, ManifestEntry
 from tests.conftest import FakeGmatRun, FakeResults
 
 
@@ -303,6 +304,219 @@ def test_show_on_missing_file_exits_manifest_code(
     rc = cli.main(["show", str(missing)])
     assert rc == cli.EXIT_MANIFEST
     assert "not found" in capsys.readouterr().err
+
+
+# ---- show --detail / --run / --filter -----------------------------------
+
+
+def _show_entry(
+    run_id: int,
+    status: str,
+    *,
+    duration_s: float = 1.0,
+    stderr: str | None = None,
+    log_path: Path | None = None,
+    overrides: dict[str, Any] | None = None,
+) -> ManifestEntry:
+    return ManifestEntry(
+        run_id=run_id,
+        overrides=overrides if overrides is not None else {"Sat.SMA": 7000.0 + run_id},
+        status=status,  # type: ignore[arg-type]
+        output_paths={},
+        started_at=datetime(2026, 5, 4, 0, 0, 0, tzinfo=timezone.utc),
+        ended_at=datetime(2026, 5, 4, 0, 0, 1, tzinfo=timezone.utc),
+        duration_s=duration_s,
+        stderr=stderr,
+        log_path=log_path,
+    )
+
+
+def _write_show_manifest(tmp_path: Path, entries: list[ManifestEntry]) -> Path:
+    manifest = Manifest(
+        script_sha256="a" * 64,
+        gmat_sweep_version="0.2.0",
+        gmat_run_version="0.4.0",
+        gmat_install_version="R2026a",
+        python_version="3.12.3",
+        os_platform="Linux-6.6.0",
+        sweep_seed=None,
+        parameter_spec={"_kind": "grid", "Sat.SMA": [7000.0, 7100.0]},
+        run_count=len(entries),
+        entries=entries,
+    )
+    path = tmp_path / "manifest.jsonl"
+    manifest.save(path)
+    return path
+
+
+def test_truncate_stderr_summary_short_unchanged() -> None:
+    assert cli._truncate_stderr_summary("ValueError: boom") == "ValueError: boom"
+
+
+def test_truncate_stderr_summary_long_ellipsised_to_60_chars() -> None:
+    long = "x" * 100
+    out = cli._truncate_stderr_summary(long)
+    assert len(out) == 60
+    assert out.endswith("...")
+
+
+def test_truncate_stderr_summary_takes_first_line_only() -> None:
+    assert cli._truncate_stderr_summary("first line\nsecond line\n") == "first line"
+
+
+def test_truncate_stderr_summary_none_and_empty_return_empty_string() -> None:
+    assert cli._truncate_stderr_summary(None) == ""
+    assert cli._truncate_stderr_summary("") == ""
+
+
+def test_show_detail_orders_failed_before_ok_then_run_id_ascending(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    entries = [
+        _show_entry(0, "ok"),
+        _show_entry(1, "failed", stderr="ValueError: out of range\n"),
+        _show_entry(2, "skipped", stderr="prerequisite missing"),
+        _show_entry(3, "ok"),
+        _show_entry(4, "failed", stderr="other"),
+    ]
+    path = _write_show_manifest(tmp_path, entries)
+
+    rc = cli.main(["show", "--detail", str(path)])
+    assert rc == 0
+    out_lines = capsys.readouterr().out.splitlines()
+    # Header + 5 data rows + summary line.
+    assert len(out_lines) == 7
+    assert out_lines[0].startswith("run_id")
+    statuses_in_order = [line.split()[1] for line in out_lines[1:6]]
+    assert statuses_in_order == ["failed", "failed", "skipped", "ok", "ok"]
+    run_ids_in_order = [int(line.split()[0]) for line in out_lines[1:6]]
+    assert run_ids_in_order == [1, 4, 2, 0, 3]
+    assert out_lines[-1].startswith("5 runs")
+
+
+def test_show_detail_renders_dash_for_ok_stderr_and_missing_log(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path = _write_show_manifest(tmp_path, [_show_entry(0, "ok")])
+    cli.main(["show", "--detail", str(path)])
+    out_lines = capsys.readouterr().out.splitlines()
+    # The data row should carry two em-dash cells: stderr_summary and log_path.
+    # (The summary line below also contains a dash, so we assert on the row only.)
+    data_row = out_lines[1]
+    assert data_row.count("—") == 2
+
+
+def test_show_detail_truncates_long_stderr_in_table(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    long_stderr = "ValueError: " + "x" * 200
+    entries = [_show_entry(0, "failed", stderr=long_stderr)]
+    path = _write_show_manifest(tmp_path, entries)
+
+    cli.main(["show", "--detail", str(path)])
+    out = capsys.readouterr().out
+    assert "..." in out
+    # No single line in the table should exceed header + truncated stderr column +
+    # other columns; in particular, the full 200-char stderr must not appear.
+    assert "x" * 200 not in out
+
+
+def test_show_detail_filter_failed_keeps_only_failed_rows(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    entries = [
+        _show_entry(0, "ok"),
+        _show_entry(1, "failed", stderr="boom"),
+        _show_entry(2, "skipped"),
+        _show_entry(3, "failed", stderr="bang"),
+    ]
+    path = _write_show_manifest(tmp_path, entries)
+
+    rc = cli.main(["show", "--detail", "--filter", "failed", str(path)])
+    assert rc == 0
+    out_lines = capsys.readouterr().out.splitlines()
+    # Header + 2 failed rows + summary (which still reflects all 4 runs).
+    assert len(out_lines) == 4
+    assert all(" failed " in line for line in out_lines[1:3])
+    assert out_lines[-1].startswith("4 runs")
+
+
+def test_show_filter_without_detail_exits_config_error(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path = _write_show_manifest(tmp_path, [_show_entry(0, "ok")])
+    rc = cli.main(["show", "--filter", "ok", str(path)])
+    assert rc == cli.EXIT_CONFIG
+    assert "--filter requires --detail" in capsys.readouterr().err
+
+
+def test_show_detail_and_run_are_mutually_exclusive(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path = _write_show_manifest(tmp_path, [_show_entry(0, "ok")])
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["show", "--detail", "--run", "0", str(path)])
+    assert exc_info.value.code == 2
+    assert "not allowed with" in capsys.readouterr().err
+
+
+def test_show_run_prints_full_record(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    multiline_stderr = "ValueError: out of range\nTraceback details here"
+    entries = [
+        _show_entry(0, "ok"),
+        _show_entry(
+            7,
+            "failed",
+            stderr=multiline_stderr,
+            log_path=Path("/o/run-7/worker.log"),
+            overrides={"Sat.SMA": 8000.0, "Sat.ECC": 0.1},
+        ),
+    ]
+    path = _write_show_manifest(tmp_path, entries)
+
+    rc = cli.main(["show", "--run", "7", str(path)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "run_id: 7" in out
+    assert "status" in out and "failed" in out
+    assert "/o/run-7/worker.log" in out
+    # Full unsuppressed stderr — both lines must be present.
+    assert "ValueError: out of range" in out
+    assert "Traceback details here" in out
+    # Override dict, sorted keys, repr values.
+    assert "Sat.ECC" in out
+    assert "Sat.SMA" in out
+    assert "8000.0" in out
+
+
+def test_show_run_for_ok_entry_reports_no_stderr(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path = _write_show_manifest(tmp_path, [_show_entry(0, "ok")])
+    rc = cli.main(["show", "--run", "0", str(path)])
+    assert rc == 0
+    assert "(no stderr)" in capsys.readouterr().out
+
+
+def test_show_run_unknown_run_id_exits_manifest_code(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path = _write_show_manifest(tmp_path, [_show_entry(0, "ok"), _show_entry(1, "ok")])
+    rc = cli.main(["show", "--run", "999", str(path)])
+    assert rc == cli.EXIT_MANIFEST
+    assert "run_id 999 not found in manifest" in capsys.readouterr().err
+
+
+def test_show_no_flags_byte_for_byte_matches_format_summary(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    entries = [_show_entry(0, "ok"), _show_entry(1, "failed", stderr="boom")]
+    path = _write_show_manifest(tmp_path, entries)
+
+    rc = cli.main(["show", str(path)])
+    assert rc == 0
+    expected = cli._format_summary(Manifest.load(path), path.parent)
+    assert capsys.readouterr().out == expected + "\n"
 
 
 def test_run_maps_backend_error_to_exit_code(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -462,13 +462,14 @@ def test_show_detail_and_run_are_mutually_exclusive(
 
 def test_show_run_prints_full_record(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     multiline_stderr = "ValueError: out of range\nTraceback details here"
+    log_path = tmp_path / "run-7" / "worker.log"
     entries = [
         _show_entry(0, "ok"),
         _show_entry(
             7,
             "failed",
             stderr=multiline_stderr,
-            log_path=Path("/o/run-7/worker.log"),
+            log_path=log_path,
             overrides={"Sat.SMA": 8000.0, "Sat.ECC": 0.1},
         ),
     ]
@@ -479,7 +480,8 @@ def test_show_run_prints_full_record(tmp_path: Path, capsys: pytest.CaptureFixtu
     out = capsys.readouterr().out
     assert "run_id: 7" in out
     assert "status" in out and "failed" in out
-    assert "/o/run-7/worker.log" in out
+    # str(Path) uses native separators (\\ on Windows, / elsewhere); compare on str.
+    assert str(log_path) in out
     # Full unsuppressed stderr — both lines must be present.
     assert "ValueError: out of range" in out
     assert "Traceback details here" in out


### PR DESCRIPTION
## Summary

- `gmat-sweep show` gains a per-run detail table (`--detail`), a single-run drill-in (`--run N`), and a `--filter {ok,failed,skipped}` narrower for `--detail`. Default no-flag invocation is unchanged and asserted byte-for-byte against the v0.2 one-line summary.
- `stderr_summary` in the table is the first line of the run's `stderr`, truncated at 60 chars with `...`; `ok` rows render as `—`. `--run N` for an unknown N exits `3` with a clear stderr message.
- `docs/cli.md`'s `show` section gains worked examples for all three modes.

## Test plan

- [x] `uv run pytest` — 468 passed, 22 deselected
- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean
- [x] `uv run mypy` — clean
- [x] Manual: `gmat-sweep show --help` lists the new flags; mutex group enforced on `--detail`/`--run`; `--filter` without `--detail` exits 2 with a usable message.

Closes #60