### PR TITLE
Configurable GMAT context isolation: reuse vs. per-task fresh bootstrap

### DIFF
--- a/docs/backends.md
+++ b/docs/backends.md
@@ -10,11 +10,22 @@ pools ship in the box:
 | [`DaskPool`][gmat_sweep.backends.DaskPool] | `pip install gmat-sweep[dask]` | Multi-host sweeps, or a sweep that fits on one machine but needs to plug into an existing `dask.distributed` cluster (Slurm, Kubernetes, or a long-lived dev scheduler). |
 | [`RayPool`][gmat_sweep.backends.RayPool] | `pip install gmat-sweep[ray]` | Multi-host sweeps on a Ray runtime — local, autoscaling, or remote via the Ray Client. |
 
-All three honour the same per-run subprocess-isolation contract: each
-`RunSpec` runs in a freshly-spawned Python interpreter, so the `gmatpy`
-bootstrap and GMAT's process-global singletons cannot leak between runs.
-Loky gives you that for free; Dask and Ray reuse worker processes by
-default, so gmat-sweep adds an explicit subprocess hop inside each task.
+All three accept the same `reuse_gmat_context` keyword controlling how the
+GMAT bootstrap cost is amortised across the runs in a sweep:
+
+- `reuse_gmat_context=True` (the default) — a worker process imports
+  `gmat_run` once and reuses the resulting state across many tasks. Bootstrap
+  cost is paid once per worker, then amortised. **Safe only when every task
+  dispatched through the pool loads the same script** — GMAT relies on
+  process-global singletons that cannot be reused across runs that load
+  different scripts.
+- `reuse_gmat_context=False` — every task spawns a fresh Python interpreter
+  that bootstraps `gmatpy` from scratch. Slower but supports arbitrary
+  heterogeneous scripts in a single sweep.
+
+The default is right for the common case (one mission, many parameter
+combinations). Pass `reuse_gmat_context=False` when you compose a single pool
+across calls that load different `.script` files.
 
 ## `LocalJoblibPool` — the default
 

--- a/src/gmat_sweep/backends/_subprocess.py
+++ b/src/gmat_sweep/backends/_subprocess.py
@@ -1,12 +1,13 @@
 """Internal helper: run a RunSpec in a freshly-spawned Python interpreter.
 
 The execution-backend layer's bridge to :mod:`gmat_sweep._run_subprocess`.
-Backends that reuse worker processes (Dask, Ray) call
-:func:`run_spec_in_subprocess` from inside each task to honour the per-run
-fresh-interpreter contract enforced by
-:class:`gmat_sweep.backends.base.Pool`. ``LocalJoblibPool`` does not — loky
-already gives one fresh interpreter per task and gains nothing from the
-extra hop.
+Every backend uses this helper when a pool is constructed with
+``reuse_gmat_context=False`` — it is the per-task fresh-bootstrap path
+described in :class:`gmat_sweep.backends.base.Pool`. ``LocalJoblibPool``,
+``DaskPool``, and ``RayPool`` each route their submission through this
+function in that mode; in the default ``reuse_gmat_context=True`` mode they
+call :func:`gmat_sweep.worker.run_one` directly inside the worker process
+and pay the gmatpy bootstrap cost only on a worker's first task.
 
 Underscore-prefixed module name keeps this internal to the backends layer;
 nothing here is re-exported from :mod:`gmat_sweep.backends`.

--- a/src/gmat_sweep/backends/base.py
+++ b/src/gmat_sweep/backends/base.py
@@ -1,13 +1,26 @@
-"""Pool ABC: subprocess-isolation contract enforced at class-definition time.
+"""Pool ABC: subprocess-isolation as a configurable per-pool choice.
 
 The :class:`Pool` ABC is the abstraction every gmat-sweep execution backend
-implements. Each backend must guarantee that GMAT runs in a fresh Python
-interpreter — ``gmatpy`` bootstrap is heavy and GMAT itself relies on
-process-global singletons that cannot be safely reused across runs that load
-different scripts. The :attr:`Pool.subprocess_isolated` class attribute is the
-contract; subclasses that try to opt out are rejected at class-definition time
-via :meth:`__init_subclass__` so the misconfiguration surfaces during
-``import``, not after a sweep is half-way through.
+implements. Two modes are exposed via the ``reuse_gmat_context`` keyword on
+each subclass's constructor and stored on the pool instance:
+
+- ``reuse_gmat_context=True`` (default) — the *fast path*. A worker process
+  imports ``gmat_run`` once and reuses the resulting state across many tasks;
+  bootstrap cost is paid once per worker, then amortised across every
+  subsequent task on that worker. Safe **only when every task dispatched
+  through the pool loads the same script** — GMAT relies on process-global
+  singletons that cannot be reused across runs that load different scripts.
+- ``reuse_gmat_context=False`` — the *isolation path*. Every task spawns a
+  fresh Python interpreter that bootstraps ``gmatpy`` from scratch via
+  :func:`gmat_sweep.backends._subprocess.run_spec_in_subprocess`. Slower but
+  allows arbitrary heterogeneous scripts in a single sweep, and is the
+  contract a caller wants when they cannot vouch for same-script discipline.
+
+The :attr:`Pool.subprocess_isolated` class attribute is the structural
+marker that a subclass implements both modes correctly; subclasses that try
+to opt out are rejected at class-definition time via
+:meth:`__init_subclass__` so the misconfiguration surfaces during ``import``,
+not after a sweep is half-way through.
 
 The submission surface is intentionally narrow:
 
@@ -34,13 +47,23 @@ __all__ = ["Pool"]
 
 
 class Pool(ABC):
-    """Abstract execution backend with a subprocess-isolation contract.
+    """Abstract execution backend.
 
-    Subclasses MUST keep :attr:`subprocess_isolated` set to :data:`True`.
-    Setting it to anything else (``False``, ``None``, a truthy non-``True``
-    value) raises :class:`gmat_sweep.errors.BackendError` from
-    :meth:`__init_subclass__` so the error fires when the bad backend's module
-    is imported, not at sweep time.
+    Subclasses MUST keep :attr:`subprocess_isolated` set to :data:`True`,
+    signalling that they implement both the per-worker-reuse and per-task-
+    fresh-bootstrap modes correctly. Setting the attribute to anything else
+    (``False``, ``None``, a truthy non-``True`` value) raises
+    :class:`gmat_sweep.errors.BackendError` from :meth:`__init_subclass__` so
+    the error fires when the bad backend's module is imported, not at sweep
+    time.
+
+    Subclasses accept ``reuse_gmat_context: bool = True`` as a keyword-only
+    parameter on ``__init__`` and store it; concrete dispatch in
+    :meth:`as_completed` reads ``self._reuse_gmat_context`` to choose between
+    calling :func:`gmat_sweep.worker.run_one` directly (fast path) and
+    delegating to
+    :func:`gmat_sweep.backends._subprocess.run_spec_in_subprocess` (isolation
+    path).
     """
 
     subprocess_isolated: ClassVar[bool] = True
@@ -50,8 +73,8 @@ class Pool(ABC):
         if cls.subprocess_isolated is not True:
             raise BackendError(
                 f"{cls.__name__}.subprocess_isolated is "
-                f"{cls.subprocess_isolated!r}; Pool subclasses must guarantee "
-                "one fresh Python interpreter per run (set to True or omit)."
+                f"{cls.subprocess_isolated!r}; Pool subclasses must implement "
+                "both reuse and isolation modes (set to True or omit)."
             )
 
     @abstractmethod

--- a/src/gmat_sweep/backends/dask.py
+++ b/src/gmat_sweep/backends/dask.py
@@ -1,13 +1,19 @@
 """DaskPool: distributed execution backend using ``dask.distributed``.
 
 The pool fans :class:`gmat_sweep.spec.RunSpec` work across a Dask cluster.
-Dask reuses worker processes for successive tasks, so the
-:class:`gmat_sweep.backends.base.Pool` per-run fresh-interpreter contract is
-honoured by an explicit subprocess hop inside each task: the top-level
-:func:`_dask_run_one` callable delegates to
-:func:`gmat_sweep.backends._subprocess.run_spec_in_subprocess`, which spawns
-``python -m gmat_sweep._run_subprocess`` for the actual GMAT load. The Dask
-worker process itself never imports ``gmatpy``.
+Dask reuses worker processes for successive tasks; the
+``reuse_gmat_context`` flag (see :class:`gmat_sweep.backends.base.Pool`)
+chooses how that reuse interacts with GMAT bootstrap:
+
+- ``reuse_gmat_context=True`` (default) — each task runs
+  :func:`gmat_sweep.worker.run_one` directly inside the Dask worker. The
+  first task per worker bootstraps ``gmatpy``; subsequent tasks reuse it.
+  The Dask worker process holds gmatpy state across tasks.
+- ``reuse_gmat_context=False`` — each task runs the top-level
+  :func:`_dask_run_one` callable, which delegates to
+  :func:`gmat_sweep.backends._subprocess.run_spec_in_subprocess` and spawns
+  ``python -m gmat_sweep._run_subprocess`` for the actual GMAT load. The
+  Dask worker process itself never imports ``gmatpy``.
 
 Lifecycle
 ---------
@@ -38,6 +44,7 @@ from gmat_sweep.backends._subprocess import run_spec_in_subprocess
 from gmat_sweep.backends.base import Pool
 from gmat_sweep.errors import BackendError
 from gmat_sweep.spec import RunOutcome, RunSpec
+from gmat_sweep.worker import run_one
 
 if TYPE_CHECKING:
     import distributed
@@ -72,6 +79,14 @@ class DaskPool(Pool):
         Threads per worker for the auto-spawned :class:`distributed.LocalCluster`.
         Ignored when ``client`` is supplied. Defaults to ``1`` so each worker
         is a single-threaded subprocess shell.
+    reuse_gmat_context:
+        ``True`` (default) lets Dask workers reuse a single ``gmatpy`` import
+        across tasks — fast, but only safe when every spec dispatched
+        through this pool loads the same script. ``False`` runs each task
+        through :func:`_dask_run_one`, which spawns a fresh Python
+        interpreter per task and bootstraps ``gmatpy`` from scratch — slower,
+        but supports cross-script sweeps. See
+        :class:`gmat_sweep.backends.base.Pool` for the contract.
     """
 
     def __init__(
@@ -80,6 +95,7 @@ class DaskPool(Pool):
         client: distributed.Client | None = None,
         n_workers: int | None = None,
         threads_per_worker: int = 1,
+        reuse_gmat_context: bool = True,
     ) -> None:
         try:
             import distributed as _distributed
@@ -88,6 +104,7 @@ class DaskPool(Pool):
                 "DaskPool requires the [dask] extra: pip install gmat-sweep[dask]"
             ) from exc
 
+        self._reuse_gmat_context = reuse_gmat_context
         self._owns_client = False
         self._owns_cluster = False
         self._cluster: Any = None
@@ -122,6 +139,7 @@ class DaskPool(Pool):
         wanted = list(futures)
         future_by_run_id: dict[int, Future[RunOutcome]] = {}
         dask_futures: list[Any] = []
+        task_fn = run_one if self._reuse_gmat_context else _dask_run_one
         for f in wanted:
             spec = self._pending.pop(f, None)
             if spec is None:
@@ -129,7 +147,7 @@ class DaskPool(Pool):
                     "Future was not submitted to this pool, or has already been drained"
                 )
             future_by_run_id[spec.run_id] = f
-            dask_futures.append(self._client.submit(_dask_run_one, spec, pure=False))
+            dask_futures.append(self._client.submit(task_fn, spec, pure=False))
 
         for dask_future in self._distributed.as_completed(dask_futures):
             outcome: RunOutcome = dask_future.result()

--- a/src/gmat_sweep/backends/joblib.py
+++ b/src/gmat_sweep/backends/joblib.py
@@ -3,29 +3,34 @@
 The pool drives a long-lived :class:`joblib.Parallel` instance configured with
 ``backend="loky"`` and ``return_as="generator_unordered"``. Loky spawns fresh
 Python interpreters as worker processes so the driver's ``gmatpy`` state never
-leaks into a worker, satisfying the
-:class:`gmat_sweep.backends.base.Pool` subprocess-isolation contract.
+leaks into a worker.
 
-Submission semantics match the issue:
+Submission semantics:
 
 - :meth:`submit` parks the spec under a placeholder
   :class:`concurrent.futures.Future` and returns immediately. Nothing is
   dispatched to a worker yet.
 - :meth:`as_completed` is the dispatch point. It hands the parked specs to the
-  underlying ``Parallel`` context as :func:`joblib.delayed` calls of
-  :func:`gmat_sweep.worker.run_one` and yields :class:`RunOutcome` values in
+  underlying ``Parallel`` context as :func:`joblib.delayed` calls of either
+  :func:`gmat_sweep.worker.run_one` (when ``reuse_gmat_context=True``) or
+  :func:`gmat_sweep.backends._subprocess.run_spec_in_subprocess` (when
+  ``reuse_gmat_context=False``), and yields :class:`RunOutcome` values in
   completion order, marking each future done as it goes.
 - :meth:`close` exits the underlying ``Parallel`` context, terminating loky
   workers, and cancels any still-pending futures.
+
+See :class:`gmat_sweep.backends.base.Pool` for the semantics of
+``reuse_gmat_context``.
 """
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from concurrent.futures import Future
 
 import joblib
 
+from gmat_sweep.backends._subprocess import run_spec_in_subprocess
 from gmat_sweep.backends.base import Pool
 from gmat_sweep.errors import BackendError
 from gmat_sweep.spec import RunOutcome, RunSpec
@@ -43,14 +48,26 @@ class LocalJoblibPool(Pool):
         Number of loky worker processes. ``-1`` (the default) uses every
         available core. Any other negative value or ``0`` is rejected with
         :class:`gmat_sweep.errors.BackendError`.
+    reuse_gmat_context:
+        ``True`` (default) dispatches each task as
+        :func:`gmat_sweep.worker.run_one`, which imports ``gmat_run`` once
+        per loky worker and reuses the import across tasks — fast, but only
+        safe when every spec dispatched through this pool loads the same
+        script. ``False`` dispatches each task through
+        :func:`gmat_sweep.backends._subprocess.run_spec_in_subprocess`,
+        spawning a fresh Python interpreter inside the loky worker so each
+        task bootstraps ``gmatpy`` from scratch — slower, but supports
+        cross-script sweeps. See
+        :class:`gmat_sweep.backends.base.Pool` for the contract.
     """
 
-    def __init__(self, workers: int = -1) -> None:
+    def __init__(self, workers: int = -1, *, reuse_gmat_context: bool = True) -> None:
         if workers == 0 or workers < -1:
             raise BackendError(
                 f"workers must be -1 (all cores) or a positive integer, got {workers!r}"
             )
         self._workers = workers
+        self._reuse_gmat_context = reuse_gmat_context
         self._pending: dict[Future[RunOutcome], RunSpec] = {}
         self._closed = False
         self._parallel = joblib.Parallel(
@@ -83,7 +100,10 @@ class LocalJoblibPool(Pool):
             specs.append(spec)
             future_by_run_id[spec.run_id] = f
 
-        for outcome in self._parallel(joblib.delayed(run_one)(s) for s in specs):
+        task_fn: Callable[[RunSpec], RunOutcome] = (
+            run_one if self._reuse_gmat_context else run_spec_in_subprocess
+        )
+        for outcome in self._parallel(joblib.delayed(task_fn)(s) for s in specs):
             f = future_by_run_id.pop(outcome.run_id)
             f.set_result(outcome)
             yield outcome

--- a/src/gmat_sweep/backends/ray.py
+++ b/src/gmat_sweep/backends/ray.py
@@ -1,14 +1,20 @@
 """RayPool: distributed execution backend using Ray.
 
 The pool fans :class:`gmat_sweep.spec.RunSpec` work across a Ray cluster.
-Ray reuses worker processes for successive tasks, so the
-:class:`gmat_sweep.backends.base.Pool` per-run fresh-interpreter contract is
-honoured by an explicit subprocess hop inside each task: the top-level
-:func:`_ray_run_one_impl` callable (registered as a Ray remote function once
-``ray`` is importable) delegates to
-:func:`gmat_sweep.backends._subprocess.run_spec_in_subprocess`, which spawns
-``python -m gmat_sweep._run_subprocess`` for the actual GMAT load. The Ray
-worker process itself never imports ``gmatpy``.
+Ray reuses worker processes for successive tasks; the ``reuse_gmat_context``
+flag (see :class:`gmat_sweep.backends.base.Pool`) chooses how that reuse
+interacts with GMAT bootstrap:
+
+- ``reuse_gmat_context=True`` (default) — each task runs
+  :func:`gmat_sweep.worker.run_one` directly inside the Ray worker. The
+  first task per worker bootstraps ``gmatpy``; subsequent tasks reuse it.
+  The Ray worker process holds gmatpy state across tasks.
+- ``reuse_gmat_context=False`` — each task runs the top-level
+  :func:`_ray_run_one_impl` callable (registered as a Ray remote function
+  at construction time), which delegates to
+  :func:`gmat_sweep.backends._subprocess.run_spec_in_subprocess` and spawns
+  ``python -m gmat_sweep._run_subprocess`` for the actual GMAT load. The
+  Ray worker process itself never imports ``gmatpy``.
 
 Lifecycle
 ---------
@@ -45,6 +51,7 @@ from gmat_sweep.backends._subprocess import run_spec_in_subprocess
 from gmat_sweep.backends.base import Pool
 from gmat_sweep.errors import BackendError
 from gmat_sweep.spec import RunOutcome, RunSpec
+from gmat_sweep.worker import run_one
 
 if TYPE_CHECKING:
     import ray as _ray_typing  # noqa: F401
@@ -75,6 +82,14 @@ class RayPool(Pool):
     num_cpus:
         Forwarded to :func:`ray.init` for the local-runtime case. Ignored
         when connecting to an existing cluster via ``address``.
+    reuse_gmat_context:
+        ``True`` (default) lets Ray workers reuse a single ``gmatpy``
+        import across tasks — fast, but only safe when every spec
+        dispatched through this pool loads the same script. ``False``
+        binds the Ray remote to :func:`_ray_run_one_impl`, which spawns a
+        fresh Python interpreter per task and bootstraps ``gmatpy`` from
+        scratch — slower, but supports cross-script sweeps. See
+        :class:`gmat_sweep.backends.base.Pool` for the contract.
     **ray_init_kwargs:
         Extra keyword arguments forwarded verbatim to :func:`ray.init`.
     """
@@ -84,6 +99,7 @@ class RayPool(Pool):
         *,
         address: str | None = None,
         num_cpus: int | None = None,
+        reuse_gmat_context: bool = True,
         **ray_init_kwargs: Any,
     ) -> None:
         try:
@@ -93,6 +109,7 @@ class RayPool(Pool):
                 "RayPool requires the [ray] extra: pip install gmat-sweep[ray]"
             ) from exc
 
+        self._reuse_gmat_context = reuse_gmat_context
         self._owns_runtime = not _ray.is_initialized()
         if self._owns_runtime:
             init_kwargs: dict[str, Any] = dict(ray_init_kwargs)
@@ -103,7 +120,8 @@ class RayPool(Pool):
             _ray.init(**init_kwargs)
 
         self._ray = _ray
-        self._remote_run_one = _ray.remote(_ray_run_one_impl)
+        impl = run_one if reuse_gmat_context else _ray_run_one_impl
+        self._remote_run_one = _ray.remote(impl)
         self._pending: dict[Future[RunOutcome], RunSpec] = {}
         self._closed = False
 

--- a/tests/test_backends_dask.py
+++ b/tests/test_backends_dask.py
@@ -252,6 +252,58 @@ def test_dask_run_one_delegates_to_subprocess_helper(
     assert outcome.run_id == 42
 
 
+def test_default_dispatches_run_one_directly(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Default ``reuse_gmat_context=True`` submits ``run_one`` to the Dask client."""
+    calls: list[tuple[str, int]] = []
+
+    def _fake_run_one(spec: RunSpec) -> RunOutcome:
+        calls.append(("run_one", spec.run_id))
+        return _ok_outcome(spec.run_id)
+
+    def _fake_dask_run_one(spec: RunSpec) -> RunOutcome:
+        calls.append(("_dask_run_one", spec.run_id))
+        return _ok_outcome(spec.run_id)
+
+    _patch_distributed_with_stubs(monkeypatch)
+    monkeypatch.setattr("gmat_sweep.backends.dask.run_one", _fake_run_one)
+    monkeypatch.setattr("gmat_sweep.backends.dask._dask_run_one", _fake_dask_run_one)
+
+    pool = DaskPool()
+    f = pool.submit(_make_spec(output_dir=tmp_path / "run_0", run_id=0))
+    list(pool.as_completed([f]))
+    pool.close()
+
+    assert calls == [("run_one", 0)]
+
+
+def test_reuse_gmat_context_false_dispatches_subprocess_hop(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``reuse_gmat_context=False`` submits ``_dask_run_one`` to the Dask client."""
+    calls: list[tuple[str, int]] = []
+
+    def _fake_run_one(spec: RunSpec) -> RunOutcome:
+        calls.append(("run_one", spec.run_id))
+        return _ok_outcome(spec.run_id)
+
+    def _fake_dask_run_one(spec: RunSpec) -> RunOutcome:
+        calls.append(("_dask_run_one", spec.run_id))
+        return _ok_outcome(spec.run_id)
+
+    _patch_distributed_with_stubs(monkeypatch)
+    monkeypatch.setattr("gmat_sweep.backends.dask.run_one", _fake_run_one)
+    monkeypatch.setattr("gmat_sweep.backends.dask._dask_run_one", _fake_dask_run_one)
+
+    pool = DaskPool(reuse_gmat_context=False)
+    f = pool.submit(_make_spec(output_dir=tmp_path / "run_0", run_id=0))
+    list(pool.as_completed([f]))
+    pool.close()
+
+    assert calls == [("_dask_run_one", 0)]
+
+
 def test_importing_dask_module_does_not_import_gmatpy() -> None:
     """Loading gmat_sweep.backends.dask in a fresh interpreter must not import gmatpy.
 

--- a/tests/test_backends_joblib.py
+++ b/tests/test_backends_joblib.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -10,7 +11,7 @@ import pytest
 from gmat_sweep.backends.base import Pool
 from gmat_sweep.backends.joblib import LocalJoblibPool
 from gmat_sweep.errors import BackendError
-from gmat_sweep.spec import RunSpec
+from gmat_sweep.spec import RunOutcome, RunSpec
 from tests.conftest import FakeGmatRun
 
 
@@ -142,3 +143,60 @@ def test_close_cancels_pending_futures(tmp_path: Path) -> None:
     f = pool.submit(_make_spec(output_dir=tmp_path / "run_0"))
     pool.close()
     assert f.cancelled()
+
+
+def _ok_outcome(run_id: int) -> RunOutcome:
+    now = datetime.now(timezone.utc)
+    return RunOutcome.ok(run_id=run_id, output_paths={}, started_at=now, ended_at=now)
+
+
+def test_default_dispatches_run_one_directly(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Default ``reuse_gmat_context=True`` calls ``run_one`` per task — fast path."""
+    calls: list[tuple[str, int]] = []
+
+    def _fake_run_one(spec: RunSpec) -> RunOutcome:
+        calls.append(("run_one", spec.run_id))
+        return _ok_outcome(spec.run_id)
+
+    def _fake_run_spec_in_subprocess(spec: RunSpec) -> RunOutcome:
+        calls.append(("run_spec_in_subprocess", spec.run_id))
+        return _ok_outcome(spec.run_id)
+
+    monkeypatch.setattr("gmat_sweep.backends.joblib.run_one", _fake_run_one)
+    monkeypatch.setattr(
+        "gmat_sweep.backends.joblib.run_spec_in_subprocess", _fake_run_spec_in_subprocess
+    )
+
+    with LocalJoblibPool(workers=1) as pool:
+        f = pool.submit(_make_spec(output_dir=tmp_path / "run_0", run_id=0))
+        list(pool.as_completed([f]))
+
+    assert calls == [("run_one", 0)]
+
+
+def test_reuse_gmat_context_false_dispatches_subprocess_hop(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``reuse_gmat_context=False`` calls ``run_spec_in_subprocess`` per task."""
+    calls: list[tuple[str, int]] = []
+
+    def _fake_run_one(spec: RunSpec) -> RunOutcome:
+        calls.append(("run_one", spec.run_id))
+        return _ok_outcome(spec.run_id)
+
+    def _fake_run_spec_in_subprocess(spec: RunSpec) -> RunOutcome:
+        calls.append(("run_spec_in_subprocess", spec.run_id))
+        return _ok_outcome(spec.run_id)
+
+    monkeypatch.setattr("gmat_sweep.backends.joblib.run_one", _fake_run_one)
+    monkeypatch.setattr(
+        "gmat_sweep.backends.joblib.run_spec_in_subprocess", _fake_run_spec_in_subprocess
+    )
+
+    with LocalJoblibPool(workers=1, reuse_gmat_context=False) as pool:
+        f = pool.submit(_make_spec(output_dir=tmp_path / "run_0", run_id=0))
+        list(pool.as_completed([f]))
+
+    assert calls == [("run_spec_in_subprocess", 0)]

--- a/tests/test_backends_ray.py
+++ b/tests/test_backends_ray.py
@@ -20,6 +20,7 @@ ray = pytest.importorskip("ray")
 
 
 from gmat_sweep.backends.ray import RayPool, _ray_run_one_impl  # noqa: E402
+from gmat_sweep.worker import run_one  # noqa: E402
 
 
 def _make_spec(*, output_dir: Path, run_id: int = 0) -> RunSpec:
@@ -256,6 +257,27 @@ def test_as_completed_rejects_unknown_future(
     list(pool.as_completed([f]))
     with pytest.raises(BackendError):
         list(pool.as_completed([f]))
+    pool.close()
+
+
+def test_default_binds_run_one_as_remote(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default ``reuse_gmat_context=True`` binds ``run_one`` as the Ray remote impl."""
+    _patch_ray_with_stubs(monkeypatch, is_initialized=False)
+    pool = RayPool()
+    # `_Remote` (the ray.remote stub) captures the impl in `_fn`; the stub's
+    # behaviour mirrors `ray.remote(fn).remote(...) -> ObjectRef(fn(...))`,
+    # so checking `_fn` is the right way to verify the binding.
+    assert pool._remote_run_one._fn is run_one
+    pool.close()
+
+
+def test_reuse_gmat_context_false_binds_subprocess_impl_as_remote(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``reuse_gmat_context=False`` binds ``_ray_run_one_impl`` (subprocess hop) as the remote."""
+    _patch_ray_with_stubs(monkeypatch, is_initialized=False)
+    pool = RayPool(reuse_gmat_context=False)
+    assert pool._remote_run_one._fn is _ray_run_one_impl
     pool.close()
 
 


### PR DESCRIPTION
## Summary

- Every Pool (`LocalJoblibPool`, `DaskPool`, `RayPool`) now accepts a `reuse_gmat_context: bool = True` keyword. When `True` (default), tasks share a worker's gmatpy import — bootstrap cost is paid once per worker, then amortised across every task on that worker. Safe only when every spec dispatched through the pool loads the same script. When `False`, every task spawns a fresh Python interpreter via `run_spec_in_subprocess` and bootstraps gmatpy from scratch — slower but supports heterogeneous-script sweeps.
- Pool ABC docstring (`backends/base.py`) describes both modes explicitly; `subprocess_isolated` ClassVar keeps its role as the "this backend implements both modes correctly" structural marker.
- `_subprocess.py` and `docs/backends.md` updated to drop the previous (inaccurate) "all three pools always isolate per task" framing.
- Six new unit tests cover the dispatch decision: each backend has a test for the default (run_one path) and one for `reuse_gmat_context=False` (subprocess hop path), all stub-based so no GMAT install is required.
- Behaviour change for `DaskPool` and `RayPool`: their previous default was per-task fresh bootstrap; new default is per-worker reuse. Existing callers who relied on cross-script safety on a shared dask/ray pool need to pass `reuse_gmat_context=False`. Acceptable under the alpha contract (`Development Status :: 3 - Alpha` in pyproject); CHANGELOG note lands at the next release cut.

## Test plan

- [x] `uv run ruff check` and `uv run ruff format --check` green locally.
- [x] `uv run mypy` green locally.
- [x] `uv run pytest -m "not integration"` green (474 passing, including the 6 new dispatch tests).
- [x] `uv run pytest tests/test_backends_ray.py -m "integration or not integration"` green locally including the existing real-Ray integration test from #76 with the new default flag.
- [x] Cross-script integration test (real GMAT, mixed `.script` files) — left for a follow-up; not blocking.
- [ ] After this lands, follow up with a PR that bumps `tests/data/throughput_floor.json` on PR #75's branch (or a successor) to reflect the ~10× dask/ray speedup the new default delivers.

Closes #78