### PR TITLE
Add cluster recipe pages: Slurm, Kubernetes, Ray autoscaling

### DIFF
--- a/docs/backends.md
+++ b/docs/backends.md
@@ -132,6 +132,20 @@ R2026a CI cell on every PR.
 
 ## Cluster recipes
 
-Slurm `srun` recipes for `DaskPool`, Kubernetes pod-per-worker setup, and
-Ray autoscaling cluster configuration are tracked separately and will
-land alongside the cluster-recipes documentation page.
+Worked examples for wiring `DaskPool` and `RayPool` into shared cluster
+infrastructure live under [Recipes](recipes/index.md). One page per
+orchestrator:
+
+- [Slurm with `srun`](recipes/slurm.md) — `DaskPool` over
+  `dask-jobqueue.SLURMCluster`, with the `sbatch` allocation and the
+  driver script.
+- [Kubernetes pod-per-worker](recipes/kubernetes.md) — `DaskPool` over
+  the `dask-kubernetes` operator, with a `KubeCluster` spec and
+  shared-PVC layout.
+- [Ray autoscaling](recipes/ray-autoscaling.md) — `RayPool` over
+  `ray up cluster.yaml`, with an autoscaling worker pool and the Ray
+  Client driver.
+
+If your orchestrator isn't on the list, the [`Pool`][gmat_sweep.backends.Pool]
+ABC is the escape hatch — implement it once and any `sweep()` call
+dispatches through it.

--- a/docs/recipes/index.md
+++ b/docs/recipes/index.md
@@ -1,0 +1,51 @@
+# Cluster recipes
+
+Worked examples for wiring `gmat-sweep` into shared cluster infrastructure
+— one page per orchestrator, each pairing the cluster-side configuration
+with the matching `sweep()` driver.
+
+The recipes document patterns; they don't introduce new APIs. The
+underlying [`DaskPool`][gmat_sweep.backends.DaskPool] and
+[`RayPool`][gmat_sweep.backends.RayPool] surface — and the
+[`Pool`][gmat_sweep.backends.Pool] ABC — are covered on the
+[Backends](../backends.md) page. Reach for a recipe when you've already
+decided on the orchestrator and need the wiring that makes a sweep run
+on it.
+
+## Choosing a recipe
+
+| Recipe | Pool | When to pick it |
+|---|---|---|
+| [Slurm with `srun`](slurm.md) | [`DaskPool`][gmat_sweep.backends.DaskPool] via `dask-jobqueue` | An HPC site with a Slurm scheduler; you submit one driver job and let `SLURMCluster` request worker tasks elastically. |
+| [Kubernetes pod-per-worker](kubernetes.md) | [`DaskPool`][gmat_sweep.backends.DaskPool] via `dask-kubernetes` | A Kubernetes cluster (managed or self-hosted) where each worker is a Pod. Best paired with the Dask Operator. |
+| [Ray autoscaling](ray-autoscaling.md) | [`RayPool`][gmat_sweep.backends.RayPool] via `ray up` | A Ray cluster — local, on-prem, or cloud — with autoscaling between a head node and an elastic worker pool. |
+
+Each recipe assumes you've followed [Getting started](../getting-started.md)
+locally first. The local sweep proves your script and grid are sound;
+the recipe then lifts the same call onto cluster workers without
+changing the `sweep()` invocation itself — only the `backend=` argument
+changes.
+
+## Prerequisites that apply across all three
+
+- A working GMAT install reachable on **every** worker node, not just
+  the driver. The discovery is `gmat-run`'s job; misconfigured workers
+  surface as every run failing with the same import error.
+- A shared output directory at the same path on every worker. Per-run
+  Parquet files and the manifest live there; node-local scratch only
+  works if you stage results back yourself.
+- The matching cluster-orchestrator package installed in the same env
+  the workers run from (`dask-jobqueue`, `dask-kubernetes`, or `ray`).
+  None of these are `gmat-sweep` dependencies — pick whichever your
+  infrastructure uses and install it explicitly.
+
+## When none of these fits
+
+The three orchestrators above are the ones with one-shot recipes. For
+anything else — AWS Batch, GCP Batch, custom MPI launchers, in-house
+schedulers — write a custom `Pool` against the
+[`Pool`][gmat_sweep.backends.Pool] ABC. Its contract is small: accept
+[`RunSpec`][gmat_sweep.spec.RunSpec]s, route each through the per-task
+subprocess hop, and yield [`RunOutcome`][gmat_sweep.spec.RunOutcome]s as
+they complete. The three shipped pools are exactly that pattern, three
+different ways.

--- a/docs/recipes/kubernetes.md
+++ b/docs/recipes/kubernetes.md
@@ -1,0 +1,187 @@
+# Kubernetes pod-per-worker
+
+Wire [`DaskPool`][gmat_sweep.backends.DaskPool] into a Kubernetes
+cluster via [`dask-kubernetes`](https://kubernetes.dask.org/). Each
+Dask worker becomes one Pod, the sweep dispatches across them, and Pod
+lifecycle (creation, eviction, restart) is handled by the Dask
+Operator.
+
+The Operator path is the recommended setup — `dask-kubernetes` ships a
+`KubeCluster` constructor that talks to the operator's CRDs, so you
+don't hand-write Pod YAML for each cluster. A pure `kubectl apply`
+flow is possible (see "Manual YAML" at the bottom) but is more work
+and more error-prone.
+
+## Prerequisites
+
+- A reachable Kubernetes cluster — managed (GKE, EKS, AKS, …) or
+  self-hosted. `kubectl get nodes` should succeed from the machine
+  running the driver.
+- The [Dask Operator](https://kubernetes.dask.org/en/latest/operator_installation.html)
+  installed in the cluster (one-time `helm install` per cluster).
+- A container image containing GMAT and `gmat-sweep[dask]`. The
+  canonical image is `ghcr.io/astro-tools/gmat`; pin a tag matching the
+  GMAT release you want every worker to run. (Mismatched worker images
+  silently produce inconsistent sweeps — see "Image discipline" below.)
+- A `PersistentVolumeClaim` (or equivalent: EFS, GCS Fuse, Azure Files)
+  mounted at the same path in every worker Pod, holding the script and
+  the `out=` directory.
+- Python with `gmat-sweep[dask]` and `dask-kubernetes` installed in
+  the driver env. Neither is a `gmat-sweep` dependency.
+
+## Worked example
+
+### Operator-mode driver
+
+```python
+from dask.distributed import Client
+from dask_kubernetes.operator import KubeCluster, make_cluster_spec
+
+from gmat_sweep import sweep
+from gmat_sweep.backends import DaskPool
+
+spec = make_cluster_spec(
+    name="gmat-sweep",
+    image="ghcr.io/astro-tools/gmat:<your-tag>",
+    n_workers=8,
+    resources={"requests": {"cpu": "1", "memory": "4Gi"}},
+)
+spec["spec"]["worker"]["spec"]["volumes"] = [
+    {"name": "shared", "persistentVolumeClaim": {"claimName": "gmat-shared"}},
+]
+spec["spec"]["worker"]["spec"]["containers"][0]["volumeMounts"] = [
+    {"name": "shared", "mountPath": "/shared"},
+]
+spec["spec"]["scheduler"]["spec"]["volumes"] = spec["spec"]["worker"]["spec"]["volumes"]
+spec["spec"]["scheduler"]["spec"]["containers"][0]["volumeMounts"] = (
+    spec["spec"]["worker"]["spec"]["containers"][0]["volumeMounts"]
+)
+
+cluster = KubeCluster(custom_cluster_spec=spec)
+client = Client(cluster)
+
+with DaskPool(client=client) as pool:
+    df = sweep(
+        "/shared/missions/mission.script",
+        grid={"Sat.SMA": [7000.0, 7100.0, 7200.0, 7300.0]},
+        backend=pool,
+        out="/shared/sweeps/sma-scan",
+    )
+
+print(df.head())
+cluster.close()
+```
+
+`KubeCluster(custom_cluster_spec=spec)` creates a `DaskCluster` CRD; the
+operator reconciles it into a scheduler Pod and `n_workers` worker
+Pods. `cluster.close()` deletes the CRD and the operator garbage-collects
+the Pods.
+
+You can scale the cluster mid-sweep — `cluster.scale(16)` — but for a
+fixed-size sweep the constructor's `n_workers` is enough. For
+autoscaling, set `cluster.adapt(minimum=2, maximum=16)` after the
+`Client` is wired up.
+
+### Running the driver
+
+The driver itself can run anywhere with `kubectl` access — your laptop,
+a CI runner, or a small pod inside the same cluster. Running it
+in-cluster avoids the Dask Client → scheduler hop crossing the cluster
+boundary, which simplifies networking and is often noticeably faster.
+A minimal driver Pod looks like:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gmat-sweep-driver
+spec:
+  serviceAccountName: gmat-sweep-driver  # has Dask Operator API perms
+  restartPolicy: Never
+  containers:
+    - name: driver
+      image: ghcr.io/astro-tools/gmat:<your-tag>
+      command: ["python", "-u", "/shared/drivers/driver.py"]
+      volumeMounts:
+        - { name: shared, mountPath: /shared }
+  volumes:
+    - name: shared
+      persistentVolumeClaim:
+        claimName: gmat-shared
+```
+
+`kubectl apply -f driver.yaml` queues it. The driver Pod and the
+worker Pods all share the same `gmat-shared` PVC, so the script path
+and `out=` path resolve identically on every side.
+
+## Caveats
+
+### Image discipline — every Pod runs the same image
+
+Dask serialises the sweep's task callable on the driver and sends it
+to workers; the workers must `pickle`-load it under the same
+`gmat-sweep` and `gmat-run` versions or the call fails. **The driver
+image and the worker image must be the same image, the same tag.** The
+[`backend equivalence guarantee`](../backends.md#backend-equivalence-guarantee)
+pins this property in CI on a single backend, but it can't catch a
+worker pool that's silently running a different image.
+
+The simplest safe pattern: `make_cluster_spec(image="...")` with a
+fully-pinned tag, and the driver Pod manifest uses the same string.
+
+### Storage — shared volume at the same path
+
+Same constraint as the [Slurm recipe](slurm.md#shared-filesystem-is-non-negotiable),
+expressed Kubernetes-side: the `out=` directory must be on a
+`ReadWriteMany` (or appropriately mounted `ReadWriteOncePod` per node)
+PVC visible to every worker Pod and the driver. Storage classes that
+work in practice include EFS (AWS), Filestore (GCP), Azure Files,
+NFS-CSI on self-hosted clusters, and GCS Fuse via the GCS CSI driver.
+
+`emptyDir` and per-Pod `hostPath` mounts do **not** satisfy this — a
+sweep run on `emptyDir` writes per-run Parquet files to whichever Pod
+ran the run, and the aggregated DataFrame back at the driver will be
+empty.
+
+### Image pull policy
+
+For a sweep that scales out under sustained load, set
+`imagePullPolicy: IfNotPresent` on the worker container so re-spawned
+Pods reuse a cached image instead of re-pulling on every Pod start.
+The default `Always` is fine for development but adds 10–60 s to every
+new worker on most registries. The image is identified by a fully-pinned
+tag, so `IfNotPresent` is safe — there's no "latest" drift to worry
+about.
+
+### Pod eviction during a sweep
+
+Kubernetes can evict a worker Pod for any of the usual reasons —
+preemption, node draining, OOM, voluntary scale-down. The Dask
+scheduler reassigns in-flight tasks to a surviving worker and the
+sweep continues, but a task that was mid-flight at eviction time
+records as a failure in the manifest.
+
+Recovery is the standard `gmat-sweep` resume flow — the manifest
+persists across the eviction (it's on the shared PVC, not the evicted
+Pod's local disk) and `Sweep.from_manifest(...).resume()` re-runs the
+failed entries on whatever worker pool is healthy at resume time. See
+[Resume](../resume.md) for the full call.
+
+## Manual YAML — when the operator isn't an option
+
+Some clusters can't install operators — locked-down policy, no Helm,
+shared cluster with strict CRD review. In that case, the older
+`KubeCluster.from_yaml(pod_spec.yaml)` path still works against
+hand-written Pod templates, no operator required. The trade-off is that
+you maintain the full Pod spec (resources, volumes, security context,
+labels) yourself, and you lose autoscaling. Prefer the operator path
+unless your cluster forbids it.
+
+## When this isn't enough
+
+Multi-region failover, custom CSI drivers with side-effects on `out=`,
+or per-Pod side cars (logging, monitoring) that have to run alongside
+the worker — all of those exit the recipe and become custom
+`Pool` work against the [`Pool`][gmat_sweep.backends.Pool] ABC. The
+`DaskPool` source under `gmat_sweep/backends/dask.py` is a working
+template.

--- a/docs/recipes/ray-autoscaling.md
+++ b/docs/recipes/ray-autoscaling.md
@@ -1,0 +1,185 @@
+# Ray autoscaling
+
+Wire [`RayPool`][gmat_sweep.backends.RayPool] into a Ray cluster brought
+up with `ray up cluster.yaml`. The cluster has one head node and an
+autoscaling worker pool that grows under sweep load and shrinks when
+the queue drains. Each `gmat-sweep` run becomes one Ray task; the
+worker hosts that run them are managed by Ray's autoscaler.
+
+## Prerequisites
+
+- A cloud or on-prem provider Ray's autoscaler can drive — AWS, GCP,
+  Azure, vSphere, or a [custom node provider](https://docs.ray.io/en/latest/cluster/vms/references/ray-cluster-configuration.html).
+  Local clusters work too; `ray up` against a local provider is the
+  simplest way to test the recipe end-to-end.
+- A container image containing GMAT and `gmat-sweep[ray]` —
+  `ghcr.io/astro-tools/gmat`, with a tag matching the GMAT release the
+  sweep targets. The same image runs on the head node and every
+  worker; see "Worker-image discipline" below.
+- A shared filesystem (or object-store path) reachable from every node
+  at the same path, holding the script and the `out=` directory.
+- `gmat-sweep[ray]` and `ray[default]` installed in the driver env.
+  `ray` is **not** a `gmat-sweep` core dependency — install it
+  yourself.
+
+## Worked example
+
+### `cluster.yaml`
+
+```yaml
+cluster_name: gmat-sweep
+provider:
+  type: aws
+  region: us-east-1
+auth:
+  ssh_user: ubuntu
+
+available_node_types:
+  head:
+    resources: {}
+    node_config:
+      InstanceType: m6i.large
+      ImageId: ami-0123456789abcdef0
+  worker:
+    resources: {}
+    node_config:
+      InstanceType: m6i.xlarge
+      ImageId: ami-0123456789abcdef0
+    min_workers: 0
+    max_workers: 16
+
+head_node_type: head
+docker:
+  image: ghcr.io/astro-tools/gmat:<your-tag>
+  container_name: ray
+  pull_before_run: true
+
+file_mounts:
+  /shared: /local/path/to/shared
+
+initialization_commands: []
+setup_commands: []
+
+head_start_ray_commands:
+  - ray stop
+  - ulimit -n 65536; ray start --head --port=6379 --object-manager-port=8076 --autoscaling-config=~/ray_bootstrap_config.yaml --dashboard-host=0.0.0.0
+worker_start_ray_commands:
+  - ray stop
+  - ulimit -n 65536; ray start --address=$RAY_HEAD_IP:6379 --object-manager-port=8076
+```
+
+`ray up cluster.yaml` brings up the head node, installs Ray, and pulls
+the GMAT image. `min_workers: 0, max_workers: 16` lets the autoscaler
+hold zero idle workers and scale up to sixteen as tasks queue. Adjust
+the instance types and image to your provider; the GMAT image is the
+load-bearing piece.
+
+### Driver
+
+```python
+import ray
+
+from gmat_sweep import sweep
+from gmat_sweep.backends import RayPool
+
+ray.init(address="ray://<head-public-ip>:10001")
+
+with RayPool() as pool:
+    df = sweep(
+        "/shared/missions/mission.script",
+        grid={"Sat.SMA": [7000.0, 7100.0, 7200.0, 7300.0]},
+        backend=pool,
+        out="/shared/sweeps/sma-scan",
+    )
+
+print(df.head())
+```
+
+`ray.init(address="ray://...")` connects the driver — typically your
+laptop or a CI runner — to the cluster's Ray Client server (port
+`10001` by default). `RayPool()` then dispatches tasks to whichever
+workers Ray decides to keep around; the autoscaler grows the pool
+under load and reaps idle workers a few minutes after the sweep ends.
+
+Because `ray.init` was already called when `RayPool` is constructed,
+the pool's `close()` leaves the runtime alone (it only calls
+`ray.shutdown()` for runtimes it bootstrapped itself). Running the
+driver again — same script, same grid — reuses the same cluster.
+
+### Watching the sweep
+
+The Ray dashboard runs on port `8265` of the head node:
+`http://<head-public-ip>:8265`. The Tasks view shows in-flight
+`gmat-sweep` tasks; the Cluster view shows the autoscaler bringing
+worker nodes up and tearing them down. Pair this with a
+`watch -n 5 ls /shared/sweeps/sma-scan/` on the shared filesystem to
+watch per-run Parquet files appear.
+
+## Caveats
+
+### Worker-image discipline
+
+Ray serialises the task callable and ships it to workers; if the
+driver's `gmat-sweep` and the worker's `gmat-sweep` differ by even a
+patch version, deserialisation can succeed silently and produce
+inconsistent runs — the manifest's `backend` field doesn't catch this.
+
+Pin one image, one tag, in `cluster.yaml`'s `docker.image`, and use
+the **same** image to run the driver if the driver runs in-cluster.
+The
+[backend equivalence guarantee](../backends.md#backend-equivalence-guarantee)
+pins per-backend determinism on a single CI image; it can't pin a
+heterogeneous worker pool you assemble yourself.
+
+### Object-store sizing
+
+Ray pre-allocates an in-memory object store on every node — by default
+roughly 30% of system memory. Sweeps that produce large per-run
+outputs (large Parquet files, sweeps with many time steps) push more
+through the object store than a small-output sweep, and Ray will spill
+to disk when the in-memory store fills up. Spill is correct but slow;
+if you see the dashboard report "spilled X GB" during a sweep, raise
+`object_store_memory` in `cluster.yaml`'s worker node config:
+
+```yaml
+worker_start_ray_commands:
+  - ray stop
+  - ulimit -n 65536; ray start --address=$RAY_HEAD_IP:6379 --object-store-memory=8000000000
+```
+
+(Eight GB in this example.) The right number is workload-specific —
+profile a small sweep first, then size for the real one.
+
+### Subprocess hop inside each Ray task
+
+Each `gmat-sweep` task runs as a Ray actor task. Inside that task, the
+sweep still does its per-run subprocess hop — `_worker_entrypoint`
+spawns a child Python that bootstraps GMAT and exits. Ray's worker
+processes themselves are long-lived (the autoscaler manages them at
+node granularity, not per task), but the subprocess hop is per task,
+not per worker. This is by design — it's the same isolation contract
+that protects sweeps on every other backend.
+
+The `reuse_gmat_context=True` default still amortises bootstrap across
+the runs assigned to a single Ray worker process, so worker-level
+reuse is the fast path on Ray too.
+
+### `runtime_env` and Ray's `uv` auto-bootstrap
+
+Recent Ray versions auto-detect a `pyproject.toml`/`uv.lock` near the
+driver and try to install a matching env on every worker via
+`runtime_env`. For a cluster running a pre-baked GMAT image, that's
+unwanted — the image already has the right env, and the auto-bootstrap
+re-installs `gmat-sweep` on every worker every time the cluster scales.
+`RayPool` disables this hook automatically; if you construct your own
+`runtime_env`, set `env_vars={"RAY_RUNTIME_ENV_HOOK_DISABLE_UV_RUN": "1"}`
+to opt out.
+
+## When this isn't enough
+
+Custom routing (per-task placement constraints, GPU-affinity workers,
+multi-tenant priority queues) and any deviation from "one task per
+run, run on whichever worker is free" are out of scope for the
+`RayPool` recipe. Implement them in a custom `Pool` against the
+[`Pool`][gmat_sweep.backends.Pool] ABC; `gmat_sweep/backends/ray.py` is
+the working template.

--- a/docs/recipes/slurm.md
+++ b/docs/recipes/slurm.md
@@ -1,0 +1,134 @@
+# Slurm with `srun`
+
+Wire [`DaskPool`][gmat_sweep.backends.DaskPool] into a Slurm allocation
+via [`dask-jobqueue`](https://jobqueue.dask.org/)'s `SLURMCluster`. Each
+Dask worker becomes one Slurm task, the sweep dispatches across them, and
+the per-run subprocess isolation that `gmat-sweep` already does on a
+laptop carries over node-by-node unchanged.
+
+## Prerequisites
+
+- A Slurm cluster you can submit to (`sbatch`, `srun`, `squeue` on PATH).
+- A shared filesystem (NFS, Lustre, GPFS, …) mounted at the same path on
+  the login node and every compute node. The driver writes the manifest
+  there and every worker reads/writes the per-run output dir from there.
+- A working GMAT install reachable on every compute node — either the
+  same shared filesystem or a node-local install at the same path. GMAT
+  discovery is done by [`gmat-run`](https://github.com/astro-tools/gmat-run);
+  see its install guide for the search order. `gmat-sweep` does not
+  install GMAT.
+- Python with `gmat-sweep[dask]` and `dask-jobqueue` installed in an env
+  reachable from the worker nodes (a shared `venv`, `conda` env, or
+  `module load` line is the usual choice). `dask-jobqueue` is **not** a
+  `gmat-sweep` dependency — install it yourself.
+
+## Worked example
+
+### `driver.py`
+
+```python
+from dask.distributed import Client
+from dask_jobqueue import SLURMCluster
+
+from gmat_sweep import sweep
+from gmat_sweep.backends import DaskPool
+
+cluster = SLURMCluster(
+    cores=1,
+    processes=1,
+    memory="4 GB",
+    walltime="01:00:00",
+    job_extra_directives=["--ntasks=1", "--cpus-per-task=1"],
+    local_directory="/scratch/$USER/dask-worker-space",
+    log_directory="/scratch/$USER/dask-logs",
+)
+cluster.scale(jobs=8)
+client = Client(cluster)
+
+with DaskPool(client=client) as pool:
+    df = sweep(
+        "/shared/missions/mission.script",
+        grid={"Sat.SMA": [7000.0, 7100.0, 7200.0, 7300.0]},
+        backend=pool,
+        out="/shared/sweeps/sma-scan",
+    )
+
+print(df.head())
+```
+
+`SLURMCluster` submits one Slurm job per Dask worker; `cluster.scale(jobs=8)`
+asks for eight. The worker pool is elastic — Dask drops idle workers back
+to Slurm and re-requests them as new specs arrive — so the same driver
+also works for shorter or much longer sweeps without rewiring.
+
+### Submitting the driver
+
+The driver itself is a single Python process. Submit it as a one-task
+allocation that lives long enough to manage the worker pool:
+
+```bash
+#!/bin/bash
+#SBATCH --job-name=gmat-sweep-driver
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=2G
+#SBATCH --time=02:00:00
+#SBATCH --output=/shared/sweeps/sma-scan/driver.log
+
+srun python -u driver.py
+```
+
+`sbatch driver.sbatch` queues it; `squeue -u $USER` shows the driver job
+plus the eight worker jobs as Dask scales them up.
+
+## Caveats
+
+### Shared filesystem is non-negotiable
+
+Every worker reads the script, writes per-run Parquet outputs, and
+appends manifest entries through the same `out=` directory. That
+directory **must** be visible at the same path from the driver and from
+every compute node. NFS, Lustre, BeeGFS, and GPFS all work; node-local
+SSD scratch does not unless you stage the result back at the end.
+
+If `out=` resolves to a different location on different nodes, runs will
+appear to "succeed" but their Parquet files end up scattered across
+worker-local disks and the aggregated DataFrame will be empty or partial.
+
+### GMAT must be reachable from every worker
+
+`gmat-run` discovers a local GMAT install at import time. Each Dask
+worker is a fresh Python process on a compute node, so each worker has
+to find GMAT independently. Two patterns work:
+
+1. Shared-filesystem install — a single GMAT tree under `/shared/gmat/`
+   visible to every node. Set `GMAT_BIN_DIR` (or whatever discovery hook
+   `gmat-run` exposes) in the worker environment.
+2. Node-local install at the same canonical path on every node.
+
+Both are operationally fine; pick whichever your cluster admins prefer.
+The discovery itself is `gmat-run`'s problem, not `gmat-sweep`'s — but
+a misconfigured worker shows up as every run failing with the same
+import error, so it's worth checking in a `srun python -c "import
+gmat_run"` before launching the sweep.
+
+### Subprocess isolation still applies inside each worker
+
+Each Dask worker is one Python process. The sweep's per-run subprocess
+hop runs **inside** that worker — `_worker_entrypoint` spawns a child
+Python that bootstraps GMAT, runs the script, and exits. No special
+Slurm-side configuration is needed; the per-task fresh GMAT context
+that protects sweeps on a laptop protects them on Slurm in exactly the
+same way.
+
+The `reuse_gmat_context=True` default still amortises bootstrap across
+the runs assigned to a single worker, so worker-level reuse remains the
+fast path on Slurm too.
+
+## When this isn't enough
+
+The recipe above covers the common Slurm-via-`dask-jobqueue` setup. For
+exotic schedulers, MPI-style launches, or Slurm features that don't fit
+the `SLURMCluster` model, write a custom `Pool` against the
+[`Pool`][gmat_sweep.backends.Pool] ABC — its only requirement is that
+each task runs through the subprocess hop.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,11 @@ nav:
   - Getting started: getting-started.md
   - Parameter spec: parameter-spec.md
   - Backends: backends.md
+  - Recipes:
+      - recipes/index.md
+      - Slurm with srun: recipes/slurm.md
+      - Kubernetes pod-per-worker: recipes/kubernetes.md
+      - Ray autoscaling: recipes/ray-autoscaling.md
   - Monte Carlo: monte-carlo.md
   - Aggregation: aggregation.md
   - Resume: resume.md

--- a/tests/test_recipe_snippets.py
+++ b/tests/test_recipe_snippets.py
@@ -1,0 +1,61 @@
+"""Syntax check for the Python code blocks in docs/recipes/*.md.
+
+`py_compile` parses each ```python``` block without executing it, so missing
+runtime dependencies (`dask_jobqueue`, `dask_kubernetes`, `ray`) don't fail
+the test. The goal is to catch typos and stale API names in the recipe
+snippets — anything that would render but not parse.
+"""
+
+from __future__ import annotations
+
+import py_compile
+import re
+import tempfile
+from pathlib import Path
+
+import pytest
+
+RECIPES_DIR = Path(__file__).resolve().parent.parent / "docs" / "recipes"
+
+_FENCE = re.compile(r"^```python\s*$\n(.*?)^```\s*$", re.DOTALL | re.MULTILINE)
+
+
+def _python_blocks(md_path: Path) -> list[tuple[int, str]]:
+    """Return (1-based block index, source) for every ```python``` fence in the file."""
+    text = md_path.read_text()
+    return [(i + 1, m.group(1)) for i, m in enumerate(_FENCE.finditer(text))]
+
+
+def _all_blocks() -> list[tuple[Path, int, str]]:
+    out: list[tuple[Path, int, str]] = []
+    for md in sorted(RECIPES_DIR.glob("*.md")):
+        for idx, src in _python_blocks(md):
+            out.append((md, idx, src))
+    return out
+
+
+@pytest.mark.parametrize(
+    ("md_path", "block_idx", "source"),
+    _all_blocks(),
+    ids=lambda v: v.name if isinstance(v, Path) else str(v),
+)
+def test_recipe_python_block_compiles(md_path: Path, block_idx: int, source: str) -> None:
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as fh:
+        fh.write(source)
+        tmp_path = Path(fh.name)
+    try:
+        py_compile.compile(
+            str(tmp_path),
+            dfile=f"{md_path.name}#python-block-{block_idx}",
+            doraise=True,
+        )
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+def test_at_least_one_python_block_per_recipe() -> None:
+    """Index page is allowed to have no python; the three orchestrator pages must each have ≥1."""
+    required = {"slurm.md", "kubernetes.md", "ray-autoscaling.md"}
+    found = {md.name for md in RECIPES_DIR.glob("*.md") if _python_blocks(md)}
+    missing = required - found
+    assert not missing, f"recipe pages missing python snippets: {sorted(missing)}"


### PR DESCRIPTION
## Summary

- Three new docs pages under `docs/recipes/` — one per cluster orchestrator — each pairing the cluster-side configuration with the matching `sweep()` driver. Slurm anchors on `DaskPool` + `dask-jobqueue.SLURMCluster`; Kubernetes on `DaskPool` + the `dask-kubernetes` operator (with a brief manual-YAML escape hatch); Ray on `RayPool` + `ray up cluster.yaml` with autoscaling.
- New `docs/recipes/index.md` is the section landing page — a "Choosing a recipe" table plus the cross-cutting prerequisites (shared FS, GMAT install on every node, orchestrator package installed). `docs/backends.md`'s trailing Cluster-recipes stub now points at the new section instead of describing it inline.
- `mkdocs.yml` gains a Recipes subsection between Backends and Monte Carlo.
- New `tests/test_recipe_snippets.py` extracts every ` ```python ` block from `docs/recipes/*.md` and `py_compile`s each. `py_compile` parses without importing, so missing `dask-jobqueue` / `dask-kubernetes` / `ray` runtimes don't fail the test — it catches typos and stale API names, nothing more. Acceptance criterion #2 (end-to-end execution on real cluster infrastructure) was relaxed in the issue body before this PR; it remains a follow-up.

## Test plan

- [x] `uv run mkdocs build --strict` — clean.
- [x] `uv run ruff check` and `uv run ruff format --check` — clean.
- [x] `uv run pytest -m "not integration and not slow"` — 485 passed (including 4 new `test_recipe_snippets.py` cases).
- [ ] End-to-end execution against real Slurm, Kubernetes, Ray clusters (tracked as a follow-up; see issue #63 acceptance criterion #2).

Closes #63