### PR TITLE
Cut v0.3.0: cluster backends release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,121 @@ All notable changes to gmat-sweep are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] — 2026-05-07
+
+The cluster-backends release: `DaskPool` and `RayPool` join the
+`Pool` ABC behind opt-in extras, the CLI gains a `--backend` flag
+and a rich `show --detail` / `show --run` mode, three cluster-recipe
+pages and two example notebooks document the multi-host story
+end-to-end, and a 1000-run benchmark sweep with a per-backend
+throughput floor lands in CI. Trove classifier moves from
+`Development Status :: 3 - Alpha` to `4 - Beta`.
+
+### Added
+
+- `DaskPool` (`gmat-sweep[dask]`) — distributed pool over
+  `dask.distributed`. Spawns a `LocalCluster` by default; `client=`
+  accepts an existing `distributed.Client` so a sweep plugs into an
+  already-running cluster (Slurm, Kubernetes, a long-lived dev
+  scheduler). Imported lazily — a minimal install never imports
+  `distributed` (#57).
+- `RayPool` (`gmat-sweep[ray]`) — distributed pool over Ray. Calls
+  `ray.init` for you by default; `address=` connects to a pre-existing
+  cluster (`"auto"`, `"ray://host:port"`, or a raw GCS address).
+  Owns the runtime only when its own `__init__` initialised it; an
+  externally-initialised runtime is left alone on `close()` (#58).
+- `backend=` keyword on [`sweep`][gmat_sweep.sweep],
+  [`monte_carlo`][gmat_sweep.monte_carlo], and
+  [`latin_hypercube`][gmat_sweep.latin_hypercube]. Replaces the
+  former `workers=` shorthand: pass any constructed `Pool` to
+  control execution. The `backend=None` default still constructs
+  a fresh `LocalJoblibPool` over every available core (#56).
+- `reuse_gmat_context: bool = True` keyword on every `Pool`
+  constructor. `True` (the default) lets a worker process import
+  `gmat_run` once and reuse the bootstrap across many tasks —
+  paid once per worker. `False` spawns a fresh Python interpreter
+  per task via `python -m gmat_sweep._run_subprocess`. Same flag,
+  same semantics on `LocalJoblibPool`, `DaskPool`, and `RayPool` (#78).
+- Manifest header carries a new `backend` field — the pool's
+  `__class__.__name__` (e.g. `"LocalJoblibPool"`, `"DaskPool"`,
+  `"RayPool"`). Additive within `schema_version=1`: manifests
+  written before this field landed load with `backend == "unknown"`.
+- `_run_subprocess` module — `python -m gmat_sweep._run_subprocess
+  <spec.json> <outcome.json>` runs one `RunSpec` in the calling
+  interpreter and writes the resulting `RunOutcome` back. Internal
+  surface; the subprocess hop the `reuse_gmat_context=False` path
+  uses on every backend (#55).
+- CLI `--backend {local,dask,ray}` flag and repeatable
+  `--backend-arg KEY=VALUE` escape hatch on every sweep-running
+  subcommand (`run`, `monte-carlo`, `latin-hypercube`, `explicit`)
+  and on `resume`. `--workers N` maps onto each backend in the
+  natural way (`workers` / `n_workers` / `num_cpus`). Missing
+  extras exit with code `4` and a `pip install gmat-sweep[…]`
+  message on stderr (#59).
+- `gmat-sweep show --detail` — per-run table sorted with `failed`
+  first, then `skipped`, then `ok`, plus the existing one-line
+  summary trailer. `gmat-sweep show --run N` prints `run_id=N`'s
+  full record: header fields, override dict, full unsuppressed
+  `stderr`. `--filter STATUS` narrows the table to a single
+  bucket. `--detail` and `--run` are mutually exclusive (#60).
+- New documentation pages: [`docs/backends.md`](docs/backends.md)
+  (the three pools, the `reuse_gmat_context` contract, and the
+  backend-equivalence guarantee), three cluster-recipe pages —
+  [`recipes/slurm.md`](docs/recipes/slurm.md),
+  [`recipes/kubernetes.md`](docs/recipes/kubernetes.md),
+  [`recipes/ray-autoscaling.md`](docs/recipes/ray-autoscaling.md) —
+  and [`docs/benchmarks.md`](docs/benchmarks.md) (1000-run
+  reference sweep numbers per backend with reproduce commands)
+  (#63, #61).
+- New runnable example notebooks rendered into the docs site:
+  `06_dask_cluster_recipe.ipynb` (100-run grid through a
+  `distributed.LocalCluster` with `DaskPool`) and
+  `07_ray_autoscaling_recipe.ipynb` (100-run Monte Carlo through
+  `RayPool` against a local `ray.init()`) (#64).
+- Backend-equivalence validation suite — `tests/test_backend_equivalence.py`
+  runs a 16-run grid sweep, a 32-run Monte Carlo sweep, and a 16-run
+  Latin hypercube sweep on each of `LocalJoblibPool` / `DaskPool` /
+  `RayPool` and asserts pairwise bit-equality on the aggregated
+  DataFrame and the manifest's reproducibility-bearing fields. Cross-
+  process determinism on `DaskPool` is pinned in the same suite.
+  Gated as `integration and slow`; runs on a dedicated CI cell on
+  every PR (#62).
+- Per-backend throughput regression — `tests/test_backend_throughput.py`
+  runs a 50-run benchmark on each of the three backends and asserts
+  measured throughput meets the floor in
+  `tests/data/throughput_floor.json`. The 1000-run docs numbers and
+  the 50-run CI gate share a single sweep-fixture definition
+  (`tests/data/benchmark_sweep.py`) so the two cannot drift (#61).
+- `RAY_ENABLE_UV_RUN_RUNTIME_ENV=0` set at backend-package import
+  time (`gmat_sweep.backends.__init__`). Disables Ray's auto-`uv`
+  `runtime_env` hook before any `import ray`, which would otherwise
+  rebuild the worker venv from the project's *base* dependencies
+  under `uv run` and fail worker startup with `ModuleNotFoundError:
+  No module named 'ray'`. `setdefault` respects an explicit user
+  opt-in (#76).
+
+### Changed
+
+- The `workers=N` keyword on [`sweep`][gmat_sweep.sweep],
+  [`monte_carlo`][gmat_sweep.monte_carlo], and
+  [`latin_hypercube`][gmat_sweep.latin_hypercube] is replaced by
+  `backend=`. **Breaking:** a v0.2 caller passing `workers=8` must
+  now pass `backend=LocalJoblibPool(workers=8)`. The migration is
+  one line at every call site (#56).
+- `DaskPool` and `RayPool` default to `reuse_gmat_context=True` —
+  a worker process imports `gmat_run` once and reuses the bootstrap
+  across many tasks. Safe only when every spec dispatched through
+  the pool loads the same script (the common case). Callers that
+  compose a single Dask or Ray pool across calls that load different
+  scripts must pass `reuse_gmat_context=False` (#78).
+- Coverage gate held at ≥ 85 % (the v0.2 number); the four per-file
+  95 % gates on `grids.py`, `distributions.py`, `manifest.py`, and
+  `aggregate.py` are unchanged. A bump toward the v1.0 ≥ 90 %
+  charter target is deferred to a follow-up so the cut PR stayed
+  focused on release mechanics.
+
+[0.3.0]: https://github.com/astro-tools/gmat-sweep/releases/tag/v0.3.0
+
 ## [0.2.0] — 2026-05-05
 
 The stochastic-sweep release: `monte_carlo()` and `latin_hypercube()`

--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ The four entry points cover the common shapes:
 - **Not** an optimiser. Gradient-, Bayesian-, and population-based optimisation
   (CasADi, pagmo2, scikit-optimize) is a different problem; `gmat-sweep` may serve as the
   parallel evaluator inside one, but it ships no optimiser of its own.
-- **Not** a distributed cluster runner yet. The default `LocalJoblibPool` saturates one
-  machine; `DaskPool` and `RayPool` for multi-machine sweeps are scoped for v0.3.
+- **Not** a workflow engine. `gmat-sweep` runs homogeneous parametric sweeps of
+  one mission; Snakemake / Nextflow / Hamilton manage DAGs of heterogeneous tasks.
+  A workflow engine can schedule a `gmat-sweep` step; the converse is not interesting.
 
 ## Requirements
 
@@ -125,6 +126,27 @@ whose lifetime is tied to the returned DataFrame. Pass `out=Path(...)` to keep t
 that's also what enables [resuming a killed sweep](https://astro-tools.github.io/gmat-sweep/resume/)
 via `Sweep.from_manifest(...).resume()` or `gmat-sweep resume <manifest>`.
 
+For multi-host sweeps, swap the local pool for `DaskPool` or `RayPool` — same
+`sweep()` / `monte_carlo()` / `latin_hypercube()` call shape, different `backend=`:
+
+```python
+from gmat_sweep import sweep
+from gmat_sweep.backends import DaskPool
+
+with DaskPool(n_workers=8) as pool:
+    df = sweep(
+        "mission.script",
+        grid={"Sat.SMA": [7000, 7100, 7200]},
+        backend=pool,
+    )
+```
+
+`DaskPool` and `RayPool` ship behind `pip install gmat-sweep[dask]` /
+`gmat-sweep[ray]`. See the [backends page](https://astro-tools.github.io/gmat-sweep/backends/)
+for the full set of pool patterns and the
+[cluster recipes](https://astro-tools.github.io/gmat-sweep/recipes/) for
+Slurm / Kubernetes / Ray autoscaling wiring.
+
 A `gmat-sweep` console script is also installed for shell-script and CI use:
 
 ```bash
@@ -190,8 +212,8 @@ Runnable example notebooks:
 
 | Release | Scope |
 |---|---|
-| **v0.2** *(current)* | `monte_carlo()` and `latin_hypercube()` plus explicit-row `samples=DataFrame` sweeps. Programmatic resume via `Sweep.from_manifest(...).resume()`. Ephemeris and contact aggregation across runs. CLI gains `monte-carlo`, `latin-hypercube`, `explicit`, and `resume` subcommands. Manifest frozen as a stable v1 schema with a documented compatibility policy. macOS added to CI. Coverage gate raised to 85%. |
-| **v0.3** *(next)* | `DaskPool` (extra `[dask]`) and `RayPool` (extra `[ray]`) for multi-machine sweeps. Cluster-recipe pages for Slurm `srun`, Kubernetes pod-per-worker, and Ray autoscaling. Benchmark page comparing backends on a 1000-run reference sweep. Throughput regression tests. `gmat-sweep show` gains a rich detail mode for inspecting per-run timing and stderr. |
+| **v0.3** *(current)* | `DaskPool` (extra `[dask]`) and `RayPool` (extra `[ray]`) join `LocalJoblibPool` behind a single `Pool` ABC. CLI `--backend {local,dask,ray}` flag and rich `gmat-sweep show --detail` / `--run` modes. Three cluster-recipe pages (Slurm with `srun`, Kubernetes pod-per-worker, Ray autoscaling). Benchmark page comparing backends on a 1000-run reference sweep, with a per-backend throughput floor enforced in CI. Manifest header gains a `backend` field; `reuse_gmat_context` exposes the bootstrap-amortisation choice on every pool. |
+| **v0.4** *(next)* | Notebook-friendly `__repr_html__` for `Sweep` / `RunOutcome`. Optional plotting helpers (`sweep_corner`, `sweep_heatmap`) behind a `[plot]` extra pulling matplotlib. A docs cookbook page on integrating sweep outputs into downstream consumers. Smoke-canary cell against the canonical `ghcr.io/astro-tools/gmat` image. |
 
 Past releases live in [`CHANGELOG.md`](CHANGELOG.md).
 

--- a/docs/examples/03_killed_sweep_recovery.ipynb
+++ b/docs/examples/03_killed_sweep_recovery.ipynb
@@ -500,19 +500,7 @@
    "cell_type": "markdown",
    "id": "a2b7e1a9ff96",
    "metadata": {},
-   "source": [
-    "## Why the resumed DataFrame is identical to a never-killed sweep\n",
-    "\n",
-    "- The manifest is **append-only with `fsync` after every entry**, so the original five `ok` rows are still on disk byte-for-byte and their Parquet files are reused as-is.\n",
-    "- `Sweep.from_manifest` re-derives the run iterable from the manifest's `parameter_spec` — a grid sweep rebuilds the same cartesian product; a Monte Carlo or Latin hypercube rebuilds bit-equal draws because the expanders are deterministic in `(perturb, n, seed)`.\n",
-    "- The canonical script-hash check refuses to mix outputs from two different scripts; the [`allow_script_drift`](https://astro-tools.github.io/gmat-sweep/resume/#script-drift) escape hatch is available when the change is known to be benign.\n",
-    "\n",
-    "## Where to next\n",
-    "\n",
-    "- **Resume reference.** [Resume](https://astro-tools.github.io/gmat-sweep/resume/) documents the last-wins entry semantics, the script-drift gate, and the limitations (single-machine, no `gmat-sweep resume` CLI yet).\n",
-    "- **Manifest schema.** [Manifest schema](https://astro-tools.github.io/gmat-sweep/manifest-schema/) documents every field the JSON Lines records carry, including the canonical script-hash convention the resume gate relies on.\n",
-    "- **CLI reference.** The [`gmat-sweep run` and `gmat-sweep show`](https://astro-tools.github.io/gmat-sweep/parameter-spec/) flags."
-   ]
+   "source": "## Why the resumed DataFrame is identical to a never-killed sweep\n\n- The manifest is **append-only with `fsync` after every entry**, so the original five `ok` rows are still on disk byte-for-byte and their Parquet files are reused as-is.\n- `Sweep.from_manifest` re-derives the run iterable from the manifest's `parameter_spec` — a grid sweep rebuilds the same cartesian product; a Monte Carlo or Latin hypercube rebuilds bit-equal draws because the expanders are deterministic in `(perturb, n, seed)`.\n- The canonical script-hash check refuses to mix outputs from two different scripts; the [`allow_script_drift`](https://astro-tools.github.io/gmat-sweep/resume/#script-drift) escape hatch is available when the change is known to be benign.\n\n## Where to next\n\n- **Resume reference.** [Resume](https://astro-tools.github.io/gmat-sweep/resume/) documents the last-wins entry semantics, the script-drift gate, and the single-machine limitation. The same flow is also available from the shell as [`gmat-sweep resume`](https://astro-tools.github.io/gmat-sweep/cli/#resume).\n- **Manifest schema.** [Manifest schema](https://astro-tools.github.io/gmat-sweep/manifest-schema/) documents every field the JSON Lines records carry, including the canonical script-hash convention the resume gate relies on.\n- **CLI reference.** The [`gmat-sweep run` and `gmat-sweep show`](https://astro-tools.github.io/gmat-sweep/parameter-spec/) flags."
   }
  ],
  "metadata": {

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -17,25 +17,36 @@ Python process. Two reasons stack:
    crash deep inside the engine.
 
 The [`Pool`][gmat_sweep.Pool] ABC enforces this at class-definition time
-via its `subprocess_isolated` class attribute. Any `Pool` subclass that
-tries to set it to anything other than `True` is rejected when its module
-is imported, before a sweep can start. Each worker subprocess imports
-`gmat_run` once on its first run and reuses that import for the rest of the
-runs that worker handles.
+via its `subprocess_isolated` class attribute: every `Pool` subclass must
+implement both bootstrap-amortisation modes correctly, and any subclass
+that tries to opt out is rejected when its module is imported, before a
+sweep can start.
 
-Backends that reuse worker processes honour the contract via
-`python -m gmat_sweep._run_subprocess` — an internal CLI module that
-runs one [`RunSpec`][gmat_sweep.RunSpec] in a freshly-spawned interpreter
-and emits the resulting [`RunOutcome`][gmat_sweep.RunOutcome] as JSON.
-Each task body in such a backend invokes the entrypoint via
-`subprocess.run`, so even when the surrounding worker process is
-long-lived, the GMAT run itself gets a fresh interpreter. The entrypoint
-is internal infrastructure; callers go through a `Pool`.
+The two modes are exposed via the `reuse_gmat_context` keyword on every
+pool constructor:
 
-The trade-off is the bootstrap cost amortising over batches — for a sweep
-of N runs with W workers, you pay roughly W bootstraps total, not 1 and not
-N. For a small sweep that's overhead worth knowing about; for a meaningfully
-large sweep it is a rounding error.
+- **`reuse_gmat_context=True` — the default.** A worker process imports
+  `gmat_run` once and reuses the loaded state across many tasks. Bootstrap
+  cost is paid once per worker, then amortised. Safe **only when every
+  task dispatched through the pool loads the same script** — GMAT relies
+  on process-global singletons that cannot be reused across runs that
+  load different scripts. This is the right choice for the common case
+  (one mission, many parameter combinations) and is what every notebook
+  and recipe in the docs assumes.
+- **`reuse_gmat_context=False` — the isolation path.** Every task spawns
+  a fresh Python interpreter that bootstraps `gmatpy` from scratch via
+  `python -m gmat_sweep._run_subprocess` (an internal CLI module that
+  runs one [`RunSpec`][gmat_sweep.RunSpec] and emits the resulting
+  [`RunOutcome`][gmat_sweep.RunOutcome] as JSON). Slower per task but
+  supports arbitrary heterogeneous scripts on a single pool. Reach for
+  it when you compose one Dask or Ray pool across calls that load
+  different `.script` files.
+
+The contract is uniform across `LocalJoblibPool`, `DaskPool`, and
+`RayPool`. Under the default, a sweep of N runs with W workers pays
+roughly W bootstraps total, not 1 and not N — for a small sweep that's
+overhead worth knowing about; for a meaningfully large sweep it is a
+rounding error.
 
 ## Why does `gmat-sweep` depend on `gmat-run`?
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -88,6 +88,14 @@ gmat-sweep run --grid Sat.SMA=7000:7200:3 --out ./sweep mission.script
 
 - [Parameter spec](parameter-spec.md) — what overrides are valid and how
   the cartesian product is laid out.
+- [Backends](backends.md) — `LocalJoblibPool`, `DaskPool`, `RayPool`, and
+  the `reuse_gmat_context` knob that picks how the GMAT bootstrap is
+  amortised across runs.
+- [Cluster recipes](recipes/index.md) — Slurm, Kubernetes, and Ray
+  autoscaling wiring once the local sweep proves out and you need to
+  fan it across multiple machines.
+- [Benchmarks](benchmarks.md) — backend timing and throughput on a
+  1000-run reference sweep.
 - [Manifest schema](manifest-schema.md) — what's in `manifest.jsonl` and
   how to load it back.
 - [API reference](api.md) — every public symbol, auto-generated.

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,6 +54,9 @@ order-independence contracts.
   vision snippet.
 - **[Parameter spec](parameter-spec.md)** — how grids, dotted-path overrides,
   and the CLI's mini-grammar work.
+- **[Backends](backends.md)** — the three pool implementations
+  (`LocalJoblibPool`, `DaskPool`, `RayPool`), the `reuse_gmat_context`
+  contract, and the backend-equivalence guarantee.
 - **[Monte Carlo](monte-carlo.md)** — stochastic dispersion sweeps with
   named distributions and a determinism contract.
 - **[CLI reference](cli.md)** — the `gmat-sweep` console script: every
@@ -61,6 +64,11 @@ order-independence contracts.
 - **[Manifest schema](manifest-schema.md)** — the JSON Lines manifest each
   sweep writes alongside its outputs.
 - **[Supported versions](supported-versions.md)** — GMAT × Python × OS matrix.
+- **[Benchmarks](benchmarks.md)** — wall-clock and throughput numbers for the
+  three backends on a 1000-run reference sweep.
+- **[Cluster recipes](recipes/index.md)** — Slurm with `srun`, Kubernetes
+  pod-per-worker, and Ray autoscaling — wiring `DaskPool` and `RayPool`
+  into shared infrastructure.
 - **[FAQ](faq.md)** — subprocess isolation, the `gmat-run` dependency, and
   where to get GMAT.
 - **[API reference](api.md)** — auto-generated from docstrings.

--- a/docs/parameter-spec.md
+++ b/docs/parameter-spec.md
@@ -367,7 +367,11 @@ core. Pass an explicit pool via `backend=` to:
 - **Use a different execution backend** — any [`Pool`][gmat_sweep.Pool]
   subclass works, including third-party ones. The pool's class name is
   recorded on the manifest header so a later loader can tell which
-  backend produced the sweep.
+  backend produced the sweep. For multi-host sweeps, [`DaskPool`][gmat_sweep.backends.DaskPool]
+  (`pip install gmat-sweep[dask]`) and [`RayPool`][gmat_sweep.backends.RayPool]
+  (`pip install gmat-sweep[ray]`) ship in the box; see [Backends](backends.md)
+  for the full set of pool patterns and the [cluster recipes](recipes/index.md)
+  for Slurm / Kubernetes / Ray autoscaling wiring.
 
 When you supply `backend=`, you own the pool's lifecycle —
 [`sweep()`][gmat_sweep.sweep] will not call

--- a/docs/recipes/ray-autoscaling.md
+++ b/docs/recipes/ray-autoscaling.md
@@ -171,9 +171,11 @@ driver and try to install a matching env on every worker via
 `runtime_env`. For a cluster running a pre-baked GMAT image, that's
 unwanted — the image already has the right env, and the auto-bootstrap
 re-installs `gmat-sweep` on every worker every time the cluster scales.
-`RayPool` disables this hook automatically; if you construct your own
-`runtime_env`, set `env_vars={"RAY_RUNTIME_ENV_HOOK_DISABLE_UV_RUN": "1"}`
-to opt out.
+`RayPool` disables this hook automatically by setting
+`RAY_ENABLE_UV_RUN_RUNTIME_ENV=0` at backend-package import time;
+if you bypass `RayPool` and call `ray.init` yourself, set the same
+env var (`os.environ["RAY_ENABLE_UV_RUN_RUNTIME_ENV"] = "0"` before
+`import ray`) to opt out.
 
 ## When this isn't enough
 

--- a/docs/resume.md
+++ b/docs/resume.md
@@ -129,6 +129,3 @@ are not rerun.
 - **Single-machine.** `script_path` and per-run `output_dir` are
   recorded as absolute paths in the manifest, so a manifest written on
   one machine cannot be resumed on another.
-- **Python-only entry point today.** A `gmat-sweep resume` CLI
-  subcommand is planned; the Python API above is the supported way in
-  the meantime.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,11 +37,6 @@ nav:
   - Getting started: getting-started.md
   - Parameter spec: parameter-spec.md
   - Backends: backends.md
-  - Recipes:
-      - recipes/index.md
-      - Slurm with srun: recipes/slurm.md
-      - Kubernetes pod-per-worker: recipes/kubernetes.md
-      - Ray autoscaling: recipes/ray-autoscaling.md
   - Monte Carlo: monte-carlo.md
   - Aggregation: aggregation.md
   - Resume: resume.md
@@ -58,6 +53,11 @@ nav:
       - Latin hypercube vs Monte Carlo: examples/05_latin_hypercube.ipynb
       - Dask cluster recipe: examples/06_dask_cluster_recipe.ipynb
       - Ray autoscaling recipe: examples/07_ray_autoscaling_recipe.ipynb
+  - Recipes:
+      - recipes/index.md
+      - Slurm with srun: recipes/slurm.md
+      - Kubernetes pod-per-worker: recipes/kubernetes.md
+      - Ray autoscaling: recipes/ray-autoscaling.md
   - FAQ: faq.md
   - API reference: api.md
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gmat-sweep"
-version = "0.2.0"
+version = "0.3.0"
 description = "Run parameter sweeps and Monte Carlo dispersions over GMAT missions in parallel from Python."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -21,7 +21,7 @@ keywords = [
   "parallel",
 ]
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 4 - Beta",
   "Intended Audience :: Science/Research",
   "License :: OSI Approved :: MIT License",
   "Operating System :: POSIX :: Linux",

--- a/tests/test_backend_equivalence.py
+++ b/tests/test_backend_equivalence.py
@@ -42,11 +42,13 @@ must produce bit-equal DataFrames — this is the v0.2 contract pinned for
 restated here for every backend so a Dask or Ray regression that
 introduced scheduling-dependent draws would fail this gate.
 
-The Dask path additionally pins **cross-process** determinism: a fresh
-driver-process Python interpreter that re-runs the same Monte Carlo sweep
-must produce a bit-equal DataFrame. Ray's actor lifecycle makes the same
-fixture expensive to set up, so cross-process is Dask-only per the
-issue's scope note.
+The Dask and Ray paths additionally pin **cross-process** determinism: a
+fresh driver-process Python interpreter that re-runs the same Monte Carlo
+sweep must produce a bit-equal DataFrame. Both backends carry their own
+worker-startup machinery (Dask spawns a `LocalCluster` and `Client`; Ray
+auto-bootstraps a runtime via ``ray.init``), and either could in
+principle introduce process-affected RNG state — the cross-process gate
+is the catch.
 
 Wall-clock budget
 -----------------
@@ -319,7 +321,7 @@ def test_monte_carlo_same_backend_repeatable(backend_name: Backend, tmp_path: Pa
     pd.testing.assert_frame_equal(result_a.df, result_b.df, check_exact=True)
 
 
-# ---- cross-process determinism (Dask path only) --------------------------
+# ---- cross-process determinism (Dask and Ray) ----------------------------
 
 
 # A fresh driver-process Python that runs the same Monte Carlo sweep through
@@ -417,6 +419,95 @@ def test_monte_carlo_dask_cross_process_determinism(tmp_path: Path) -> None:
     # would mean the spec-generation RNG itself drifted across processes,
     # which is a stricter signal than "the resulting numbers happened to
     # match".
+    cross_process_manifest = _load_manifest(cross_process_out)
+    in_process_overrides = {e.run_id: e.overrides for e in in_process.manifest.entries}
+    cross_process_overrides = {e.run_id: e.overrides for e in cross_process_manifest.entries}
+    assert in_process_overrides == cross_process_overrides
+
+
+# A Ray analogue of ``_CROSS_PROCESS_SCRIPT``. Same body, just RayPool. Kept
+# inline (rather than parametrised) so a future regression points at the
+# Ray-specific test without scrolling through a generic helper.
+_CROSS_PROCESS_SCRIPT_RAY = """
+from pathlib import Path
+
+import gmat_sweep
+from gmat_sweep.backends.ray import RayPool
+
+inj_script = Path({inj_script!r})
+out = Path({out!r})
+n = {n!r}
+seed = {seed!r}
+workers = {workers!r}
+perturb = {{
+    "CoastTime.Value": ("normal", 600.0, 30.0),
+    "Inj.Element1": ("normal", 1.0, 0.005),
+    "Inj.Element2": ("normal", 0.0, 0.005),
+    "Inj.Element3": ("normal", 0.0, 0.005),
+}}
+
+pool = RayPool(num_cpus=workers)
+try:
+    df = gmat_sweep.monte_carlo(
+        inj_script,
+        n=n,
+        perturb=perturb,
+        seed=seed,
+        backend=pool,
+        out=out,
+        progress=False,
+    )
+finally:
+    pool.close()
+
+df.reset_index().to_parquet(out / "result.parquet")
+"""
+
+
+def test_monte_carlo_ray_cross_process_determinism(tmp_path: Path) -> None:
+    """Driver-process restart between Ray MC sweeps must yield bit-equal DataFrames.
+
+    Ray analogue of :func:`test_monte_carlo_dask_cross_process_determinism`.
+    Catches the same regression class — process-affected RNG state, a
+    worker-startup hook that perturbs draws — on Ray's actor lifecycle.
+    Ray's auto-`uv` `runtime_env` rebuild (the bug fixed in #76) is
+    exactly the kind of cross-process trap this gate exists to surface,
+    so the contract belongs on both backends, not just Dask.
+    """
+    in_process_out = tmp_path / "in-process"
+    pool = build_pool("ray", workers=_WORKERS)
+    try:
+        in_process = _run_monte_carlo(pool, in_process_out)
+    finally:
+        pool.close()
+    _assert_sweep_actually_succeeded(in_process, "in-process Ray MC sweep")
+
+    cross_process_out = tmp_path / "cross-process"
+    code = _CROSS_PROCESS_SCRIPT_RAY.format(
+        inj_script=str(_INJ_SCRIPT),
+        out=str(cross_process_out),
+        n=_MC_N,
+        seed=_SEED,
+        workers=_WORKERS,
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 0, (
+        f"cross-process Ray sweep failed (rc={completed.returncode}): "
+        f"stdout={completed.stdout!r} stderr={completed.stderr!r}"
+    )
+
+    cross_process_df = cast(
+        pd.DataFrame,
+        pd.read_parquet(cross_process_out / "result.parquet").set_index(["run_id", "time"]),
+    )
+
+    pd.testing.assert_frame_equal(in_process.df, cross_process_df, check_exact=True)
+
     cross_process_manifest = _load_manifest(cross_process_out)
     in_process_overrides = {e.run_id: e.overrides for e in in_process.manifest.entries}
     cross_process_overrides = {e.run_id: e.overrides for e in cross_process_manifest.entries}

--- a/tests/test_backends_init.py
+++ b/tests/test_backends_init.py
@@ -1,0 +1,110 @@
+"""Tests for the gmat_sweep.backends package's lazy __getattr__ and import-time env setup.
+
+The package's ``__init__`` does two things worth pinning at unit level:
+
+1. A lazy ``__getattr__`` that imports :class:`DaskPool` and :class:`RayPool`
+   only when the user asks for them. With the matching extra installed, the
+   attribute access returns the class. Without it, the access raises
+   :class:`AttributeError` whose message names the extra so a missing-extras
+   error includes a copy-paste install command.
+
+2. ``RAY_ENABLE_UV_RUN_RUNTIME_ENV=0`` is set via ``os.environ.setdefault`` at
+   import time so a driver started under ``uv run`` does not silently rebuild
+   each Ray worker's venv from the project's *base* dependencies (see #76).
+   ``setdefault`` is the load-bearing detail — a user who explicitly sets the
+   env var to ``"1"`` (re-enabling Ray's auto-`uv` hook) must have their
+   choice preserved.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+import gmat_sweep.backends as backends_pkg
+
+
+def test_unknown_attribute_raises_attribute_error() -> None:
+    """``gmat_sweep.backends.<unknown>`` raises ``AttributeError`` with the
+    standard ``module ... has no attribute ...`` message."""
+    with pytest.raises(AttributeError) as ei:
+        backends_pkg.NoSuchPool  # noqa: B018 - intentional attribute access  # type: ignore[attr-defined]
+    assert "gmat_sweep.backends" in str(ei.value)
+    assert "NoSuchPool" in str(ei.value)
+
+
+def test_dask_pool_attribute_error_when_distributed_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If ``distributed`` cannot be imported, ``gmat_sweep.backends.DaskPool``
+    raises :class:`AttributeError` whose message names the ``[dask]`` extra."""
+    # ``setitem(... None)`` makes ``importlib.import_module("distributed")``
+    # raise ``ImportError`` — same trick the dask backend's lazy-import test
+    # uses (see tests/test_backends_dask.py).
+    monkeypatch.setitem(sys.modules, "distributed", None)
+    with pytest.raises(AttributeError) as ei:
+        backends_pkg.DaskPool  # noqa: B018 - intentional attribute access
+    msg = str(ei.value)
+    assert "DaskPool" in msg
+    assert "[dask]" in msg
+    assert "pip install gmat-sweep[dask]" in msg
+
+
+def test_ray_pool_attribute_error_when_ray_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If ``ray`` cannot be imported, ``gmat_sweep.backends.RayPool`` raises
+    :class:`AttributeError` whose message names the ``[ray]`` extra."""
+    monkeypatch.setitem(sys.modules, "ray", None)
+    with pytest.raises(AttributeError) as ei:
+        backends_pkg.RayPool  # noqa: B018 - intentional attribute access
+    msg = str(ei.value)
+    assert "RayPool" in msg
+    assert "[ray]" in msg
+    assert "pip install gmat-sweep[ray]" in msg
+
+
+def test_dask_pool_attribute_returns_class_when_extra_installed() -> None:
+    """The happy path: with ``distributed`` importable, the attribute access
+    returns the :class:`DaskPool` class itself."""
+    pytest.importorskip("distributed")
+    from gmat_sweep.backends.dask import DaskPool as direct_cls
+
+    assert backends_pkg.DaskPool is direct_cls
+
+
+def test_ray_pool_attribute_returns_class_when_extra_installed() -> None:
+    """The happy path: with ``ray`` importable, the attribute access returns
+    the :class:`RayPool` class itself."""
+    pytest.importorskip("ray")
+    from gmat_sweep.backends.ray import RayPool as direct_cls
+
+    assert backends_pkg.RayPool is direct_cls
+
+
+def test_ray_runtime_env_var_set_to_zero_when_unset_at_import(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With ``RAY_ENABLE_UV_RUN_RUNTIME_ENV`` unset, importing
+    :mod:`gmat_sweep.backends` sets it to ``"0"``."""
+    monkeypatch.delenv("RAY_ENABLE_UV_RUN_RUNTIME_ENV", raising=False)
+    importlib.reload(backends_pkg)
+    import os
+
+    assert os.environ.get("RAY_ENABLE_UV_RUN_RUNTIME_ENV") == "0"
+
+
+def test_ray_runtime_env_var_preserves_explicit_user_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the user has set ``RAY_ENABLE_UV_RUN_RUNTIME_ENV=1`` explicitly,
+    importing :mod:`gmat_sweep.backends` does not overwrite it. ``setdefault``
+    is the load-bearing detail — flipping to unconditional ``__setitem__``
+    would silently undo a deliberate opt-in."""
+    monkeypatch.setenv("RAY_ENABLE_UV_RUN_RUNTIME_ENV", "1")
+    importlib.reload(backends_pkg)
+    import os
+
+    assert os.environ.get("RAY_ENABLE_UV_RUN_RUNTIME_ENV") == "1"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -306,6 +306,37 @@ def test_show_on_missing_file_exits_manifest_code(
     assert "not found" in capsys.readouterr().err
 
 
+def test_show_on_zero_entry_manifest_prints_zero_ok_summary(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A freshly-saved manifest header with no entries appended yet is the
+    edge case ``_format_summary`` falls back on. The output must remain
+    parseable — callers that grep for ``"<N> runs"`` or pipe the line into
+    a downstream tool expect a stable shape regardless of bucket counts.
+    """
+    manifest = Manifest(
+        script_sha256="a" * 64,
+        gmat_sweep_version="0.3.0",
+        gmat_run_version="0.4.0",
+        gmat_install_version="R2026a",
+        python_version="3.12.3",
+        os_platform="Linux-6.6.0",
+        sweep_seed=None,
+        parameter_spec={"_kind": "grid", "Sat.SMA": [7000.0]},
+        run_count=1,
+        entries=[],
+    )
+    path = tmp_path / "manifest.jsonl"
+    manifest.save(path)
+
+    rc = cli.main(["show", str(path)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "0 runs" in out
+    assert "0 ok" in out
+    assert str(tmp_path) in out
+
+
 # ---- show --detail / --run / --filter -----------------------------------
 
 
@@ -1520,3 +1551,50 @@ def test_resume_subcommand_accepts_backend_flag(
     )
     assert rc == 0
     assert fake.calls == [{"n_workers": 1}]
+
+
+def test_resume_subcommand_forwards_backend_arg_kwargs(
+    tmp_path: Path,
+    fake_gmat_run: FakeGmatRun,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``resume`` routes through ``_build_pool`` like every other sweep-running
+    subcommand — ``--backend-arg KEY=VALUE`` must reach the pool constructor."""
+    fake = _make_recording_pool_class()
+    monkeypatch.setattr(cli, "DaskPool", fake)
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+
+    rc = cli.main(
+        [
+            "run",
+            "--grid",
+            "Sat.SMA=7000:8000:2",
+            "--workers",
+            "1",
+            "--out",
+            str(out),
+            str(script),
+        ]
+    )
+    assert rc == 0
+    fake.calls.clear()
+
+    rc = cli.main(
+        [
+            "resume",
+            str(out / "manifest.jsonl"),
+            "--script",
+            str(script),
+            "--workers",
+            "1",
+            "--backend",
+            "dask",
+            "--backend-arg",
+            "threads_per_worker=2",
+        ]
+    )
+    assert rc == 0
+    assert fake.calls == [{"n_workers": 1, "threads_per_worker": 2}]

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -138,6 +138,63 @@ def test_sweep_manifest_header_carries_script_hash_seed_and_spec(
     assert reloaded.gmat_sweep_version == gmat_sweep.__version__
 
 
+class _NamedSpecificPool(Pool):
+    """A no-IO Pool subclass with a distinct class name.
+
+    Used by the manifest-backend-field test to confirm
+    :meth:`Sweep._build_manifest` records ``pool.__class__.__name__`` rather
+    than e.g. a hard-coded ``"LocalJoblibPool"`` literal or the abstract
+    ``"Pool"``.
+    """
+
+    def submit(self, spec: RunSpec) -> Future[RunOutcome]:
+        future: Future[RunOutcome] = Future()
+        future.spec = spec  # type: ignore[attr-defined]
+        return future
+
+    def as_completed(self, futures: Iterable[Future[RunOutcome]]) -> Iterator[RunOutcome]:
+        now = datetime.now(timezone.utc)
+        for f in futures:
+            spec: RunSpec = f.spec  # type: ignore[attr-defined]
+            outcome = RunOutcome.ok(
+                run_id=spec.run_id,
+                output_paths={},
+                started_at=now,
+                ended_at=now,
+            )
+            f.set_result(outcome)
+            yield outcome
+
+    def close(self) -> None:
+        pass
+
+
+def test_sweep_manifest_records_pool_class_name_as_backend(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    """:meth:`Sweep._build_manifest` records the pool's ``__class__.__name__``
+    as the manifest's ``backend`` field. The contract every cross-backend
+    consumer (the equivalence suite, the CLI's ``show`` output) relies on.
+    """
+    script = _write_script(tmp_path)
+    output_dir = tmp_path / "out"
+    runs = _make_runs(script, output_dir, n=2)
+
+    pool = _NamedSpecificPool()
+    Sweep(
+        runs=runs,
+        backend=pool,
+        manifest_path=output_dir / "manifest.jsonl",
+        output_dir=output_dir,
+        script_path=script,
+        parameter_spec={"Sat.SMA": [7000.0, 7001.0]},
+        progress=False,
+    ).run()
+
+    reloaded = Manifest.load(output_dir / "manifest.jsonl")
+    assert reloaded.backend == "_NamedSpecificPool"
+
+
 def test_sweep_manifest_parent_directory_is_created(
     tmp_path: Path, fake_gmat_run: FakeGmatRun
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1239,7 +1239,7 @@ wheels = [
 
 [[package]]
 name = "gmat-sweep"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "gmat-run" },


### PR DESCRIPTION
## Summary

- Bump version to 0.3.0 and Trove classifier to `Development Status :: 4 - Beta`. Aggregate every v0.3 PR (#55–#64, plus #76 and #78) into a `[0.3.0]` CHANGELOG section. Refresh the README roadmap (drop v0.2 row, promote v0.3 to current, add v0.4 next), add a `backend=DaskPool(...)` callout to the Quick start, and replace the stale "Not a distributed cluster runner yet" non-goal with a workflow-engine non-goal that survives multiple releases.
- Pre-cut audit fixes across six existing docs pages that hadn't picked up the cluster-backends story (or carried stale wording from earlier cuts): `docs/index.md` and `docs/getting-started.md` now link to Backends / Recipes / Benchmarks; `docs/parameter-spec.md` cross-links to backends.md for the cluster pools; `docs/faq.md`'s subprocess-isolation section reflects the post-#79 `reuse_gmat_context` semantics; `docs/resume.md` and notebook 03's final cell drop the "no `gmat-sweep resume` CLI yet" wording (the CLI shipped in v0.2); `docs/recipes/ray-autoscaling.md` fixes the wrong opt-out env var (`RAY_RUNTIME_ENV_HOOK_DISABLE_UV_RUN=1` → `RAY_ENABLE_UV_RUN_RUNTIME_ENV=0`).
- Move `Recipes:` in the mkdocs nav from between `Backends` and `Monte Carlo` to between `Examples` and `FAQ` — recipes are how-tos a reader reaches for after the worked notebooks, not a prerequisite for the conceptual tour.
- Six audit-list unit tests for v0.3 features that pass integration but lacked unit coverage: `tests/test_backends_init.py` pins the lazy `__getattr__` install-hint contract (DaskPool / RayPool extras-missing → AttributeError with `pip install gmat-sweep[…]` message) and the `RAY_ENABLE_UV_RUN_RUNTIME_ENV=0` `setdefault` semantics (both the unset path and the explicit-user-opt-in preservation); `tests/test_sweep.py` asserts `Sweep._build_manifest` records `pool.__class__.__name__` as the manifest's backend field; `tests/test_cli.py` extends `resume`'s backend coverage with a `--backend-arg` case and adds a zero-entry-manifest `show` test; `tests/test_backend_equivalence.py` adds a Ray cross-process-determinism analogue of the existing Dask gate.

## Test plan

- [x] `uv run ruff check` clean
- [x] `uv run ruff format --check` clean
- [x] `uv run mypy` clean (54 source files)
- [x] `uv run pytest -m "not integration"` — 495 passing locally
- [x] `uv run mkdocs build --strict` — clean
- [x] CI green on the 18-cell main matrix
- [ ] Backend-equivalence (#62) and throughput-regression (#61) jobs green
- [ ] After merge: tag `v0.3.0`, watch `release.yml` (PyPI) and `docs.yml` (Pages deploy)
- [ ] After publish: `pip install gmat-sweep==0.3.0` smoke-installs cleanly on Linux / Windows / macOS × Python 3.10 / 3.11 / 3.12
- [ ] Branch protection on `main`: add `backend-throughput` and `backend-equivalence` to required-status-checks (separate `gh api` call; not part of this PR)
- [ ] Discussions announcement in `astro-tools/.github` — drafted manually post-tag

## Out of scope

- New features outside the v0.3 milestone — those land in v0.4.
- `MANIFEST_SCHEMA_VERSION` bump to 2 — the v0.3 `backend` field is additive within `schema_version=1`.
- Coverage gate raise toward the v1.0 ≥ 90% target — deferred to a follow-up so the cut PR stays focused on release mechanics.

Closes #65