### PR TITLE
ci: speed up backend-k8s with local registry + buildx GHA cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,6 +314,13 @@ jobs:
           config: tests/k8s/kind-config.yaml
       - name: Connect registry to kind network
         run: docker network connect kind kind-registry
+      - name: Point kind nodes at the local registry
+        run: |
+          for node in $(kind get nodes --name gmat-sweep); do
+            docker exec "$node" mkdir -p /etc/containerd/certs.d/localhost:5000
+            echo '[host."http://kind-registry:5000"]' \
+              | docker exec -i "$node" tee /etc/containerd/certs.d/localhost:5000/hosts.toml >/dev/null
+          done
       - uses: docker/setup-buildx-action@v3
       - name: Build and push sweep CI image
         uses: docker/build-push-action@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,7 +282,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
-      GMAT_SWEEP_K8S_IMAGE: gmat-sweep-k8s-ci:local
+      GMAT_SWEEP_K8S_IMAGE: localhost:5000/gmat-sweep-k8s-ci:local
       GMAT_SWEEP_K8S_PVC: gmat-sweep-ci
       GMAT_SWEEP_K8S_MOUNT_PATH: /sweep
       GMAT_SWEEP_K8S_DRIVER_MOUNT_PATH: /sweep
@@ -301,15 +301,29 @@ jobs:
           cache: true
       - name: Prepare shared /sweep directory
         run: sudo mkdir -p /sweep && sudo chmod 777 /sweep
+      - name: Start local registry
+        run: |
+          docker run -d --restart=always \
+            -p "127.0.0.1:5000:5000" \
+            --name kind-registry \
+            registry:2
       - name: Provision kind cluster
         uses: helm/kind-action@v1
         with:
           cluster_name: gmat-sweep
           config: tests/k8s/kind-config.yaml
-      - name: Build sweep CI image
-        run: docker build -t gmat-sweep-k8s-ci:local -f tests/k8s/Dockerfile .
-      - name: Load image into kind
-        run: kind load docker-image gmat-sweep-k8s-ci:local --name gmat-sweep
+      - name: Connect registry to kind network
+        run: docker network connect kind kind-registry
+      - uses: docker/setup-buildx-action@v3
+      - name: Build and push sweep CI image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: tests/k8s/Dockerfile
+          push: true
+          tags: localhost:5000/gmat-sweep-k8s-ci:local
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       - name: Apply PV + PVC
         run: kubectl apply -f tests/k8s/sweep-pvc.yaml
       - run: uv sync --all-groups --extra k8s

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,6 +322,8 @@ jobs:
               | docker exec -i "$node" tee /etc/containerd/certs.d/localhost:5000/hosts.toml >/dev/null
           done
       - uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: network=host
       - name: Build and push sweep CI image
         uses: docker/build-push-action@v6
         with:

--- a/tests/k8s/kind-config.yaml
+++ b/tests/k8s/kind-config.yaml
@@ -2,8 +2,8 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 containerdConfigPatches:
   - |-
-    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
-      endpoint = ["http://kind-registry:5000"]
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      config_path = "/etc/containerd/certs.d"
 nodes:
   - role: control-plane
     extraMounts:

--- a/tests/k8s/kind-config.yaml
+++ b/tests/k8s/kind-config.yaml
@@ -1,5 +1,9 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
+      endpoint = ["http://kind-registry:5000"]
 nodes:
   - role: control-plane
     extraMounts:


### PR DESCRIPTION
## Summary

The `backend k8s (kind)` job is the longest gate in CI at ~247s on `main` (run #25579133905). Per-step breakdown:

| Step | Time |
|---|---|
| Setup (checkout/python/uv/gmat) | 11s |
| Provision kind cluster | 39s |
| **Build sweep CI image** | **49s** |
| **Load image into kind** | **51s** |
| Apply PV + PVC | 0s |
| uv sync | 5s |
| pytest (equivalence + throughput) | 90s |
| Cleanup | 3s |

The two bolded steps (~100s combined) are the discretionary budget. This PR collapses them into a single buildx step backed by GHA layer cache, served to kind via a localhost registry mirror.

- **Local registry sidecar** (`registry:2` on `127.0.0.1:5000`) is started before the cluster and connected to the kind docker network as `kind-registry`.
- **`containerdConfigPatches`** in `kind-config.yaml` mirrors `localhost:5000` → `http://kind-registry:5000`. Pods reference `localhost:5000/gmat-sweep-k8s-ci:local`; kubelet resolves the pull through the sidecar over the kind network.
- **`docker/build-push-action@v6`** with `cache-from/cache-to: type=gha,mode=max` builds and pushes to the registry in one step. The GMAT base layer and `pip install -e .[k8s]` step are stable across PRs, so warm-cache builds drop to ~10s.
- **`kind load docker-image` is removed** — the slow tar/import path is gone.

Expected steady-state job time after this lands: ~155-165s (~35% reduction). To clear 2 minutes outright, follow-ups would be (a) splitting throughput out of the PR gate or (b) swapping kind for k3d.

## Test plan

- [ ] First run on this branch is a cache miss — confirm the build step still completes (~50s, similar to today) and the job succeeds end-to-end.
- [ ] Push a no-op change and confirm the second run hits the GHA cache (build step drops to ~10s).
- [ ] Confirm pods pull `localhost:5000/gmat-sweep-k8s-ci:local` successfully (no `ImagePullBackOff` events) and that equivalence + throughput suites pass.
- [ ] Verify total job time lands in the ~155-165s range on the warm-cache run.