### PR TITLE
DebugPool: in-process backend for breakpoint-driven debugging

### DIFF
--- a/docs/backends.md
+++ b/docs/backends.md
@@ -227,6 +227,56 @@ existing behaviour where `--workers` is forwarded to a backend's
 canonical kwarg name (`n_workers` for Dask, `num_cpus` for Ray) and
 otherwise has no effect.
 
+## `DebugPool` — in-process, single-run, debugger-friendly
+
+`DebugPool` is the off-spec backend. Every spec runs on the driver process
+— no subprocess, no parallelism — so a `breakpoint()` placed in user code,
+override application, or `gmat_run` itself drops directly into the driver's
+debugger and IDE step-through Just Works. **Production sweeps must not use
+it**: GMAT's process-global singletons get dirtied by the run, so the pool
+accepts exactly one spec and refuses any sweep that submits more.
+
+The isolation violation is the feature, but it is gated behind two
+opt-ins: `DebugPool(allow_unisolated_pool=True)` to construct, and
+`Sweep(..., allow_unisolated_pool=True)` to dispatch through. Either flag
+missing raises `BackendError`. The high-level `sweep()` / `monte_carlo()`
+/ `latin_hypercube()` entry points do not surface the flag — drive
+`DebugPool` through the `Sweep` class directly.
+
+```python
+from pathlib import Path
+
+from gmat_sweep import RunSpec, Sweep
+from gmat_sweep.backends.debug import DebugPool
+
+out = Path("./debug-run")
+out.mkdir(exist_ok=True)
+spec = RunSpec(
+    script_path=Path("mission.script"),
+    overrides={"Sat.SMA": 7100.0},
+    output_dir=out / "run_0",
+    run_id=0,
+    seed=None,
+    run_options={},
+)
+
+with DebugPool(allow_unisolated_pool=True) as pool:
+    Sweep(
+        runs=[spec],
+        backend=pool,
+        manifest_path=out / "manifest.jsonl",
+        output_dir=out,
+        script_path=spec.script_path,
+        parameter_spec={"_kind": "explicit", "columns": ["Sat.SMA"], "rows": [[7100.0]]},
+        allow_unisolated_pool=True,
+    ).run()
+```
+
+Drop a `breakpoint()` anywhere downstream of `Sweep.run()` — for example
+inside the `.script`-driven mission, or in a `gmat_run` plugin — and the
+driver's debugger catches it. Switch back to `LocalJoblibPool` (or any
+other isolated pool) the moment you want N > 1 runs.
+
 ## Failed runs
 
 A single failed run never aborts the sweep, regardless of backend. The

--- a/src/gmat_sweep/backends/__init__.py
+++ b/src/gmat_sweep/backends/__init__.py
@@ -42,6 +42,7 @@ from gmat_sweep.backends.joblib import LocalJoblibPool
 
 if TYPE_CHECKING:
     from gmat_sweep.backends.dask import DaskPool
+    from gmat_sweep.backends.debug import DebugPool
     from gmat_sweep.backends.kubernetes import KubernetesJobPool
     from gmat_sweep.backends.mpi import MPIPool
     from gmat_sweep.backends.process_pool import ProcessPoolExecutorPool
@@ -49,6 +50,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "DaskPool",
+    "DebugPool",
     "KubernetesJobPool",
     "LocalJoblibPool",
     "MPIPool",
@@ -75,6 +77,13 @@ def __getattr__(name: str) -> Any:
         from gmat_sweep.backends.process_pool import ProcessPoolExecutorPool
 
         return ProcessPoolExecutorPool
+    if name == "DebugPool":
+        # Stdlib only — in-process single-run debug backend. Lazy so a
+        # plain ``from gmat_sweep.backends import LocalJoblibPool`` doesn't
+        # carry the debug module's name into the importing namespace.
+        from gmat_sweep.backends.debug import DebugPool
+
+        return DebugPool
     entry = _OPTIONAL_BACKENDS.get(name)
     if entry is None:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/gmat_sweep/backends/base.py
+++ b/src/gmat_sweep/backends/base.py
@@ -38,7 +38,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable, Iterator
 from concurrent.futures import Future
 from types import TracebackType
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Literal
 
 from gmat_sweep.errors import BackendError
 from gmat_sweep.spec import RunOutcome, RunSpec
@@ -57,6 +57,13 @@ class Pool(ABC):
     the error fires when the bad backend's module is imported, not at sweep
     time.
 
+    The single recognised opt-out is the literal string ``"debug"``, used by
+    :class:`gmat_sweep.backends.debug.DebugPool` to declare in-process,
+    single-run dispatch for ``breakpoint()``-driven debugging. Sweeps refuse
+    to dispatch through any pool whose ``subprocess_isolated`` is not
+    :data:`True` unless the caller acknowledges the violation via
+    ``Sweep(..., allow_unisolated_pool=True)``.
+
     Subclasses accept ``reuse_gmat_context: bool = True`` as a keyword-only
     parameter on ``__init__`` and store it; concrete dispatch in
     :meth:`as_completed` reads ``self._reuse_gmat_context`` to choose between
@@ -66,15 +73,16 @@ class Pool(ABC):
     path).
     """
 
-    subprocess_isolated: ClassVar[bool] = True
+    subprocess_isolated: ClassVar[bool | Literal["debug"]] = True
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
-        if cls.subprocess_isolated is not True:
+        if cls.subprocess_isolated is not True and cls.subprocess_isolated != "debug":
             raise BackendError(
                 f"{cls.__name__}.subprocess_isolated is "
                 f"{cls.subprocess_isolated!r}; Pool subclasses must implement "
-                "both reuse and isolation modes (set to True or omit)."
+                "both reuse and isolation modes (set to True or omit), or "
+                'declare in-process debug dispatch via the "debug" sentinel.'
             )
 
     @abstractmethod

--- a/src/gmat_sweep/backends/debug.py
+++ b/src/gmat_sweep/backends/debug.py
@@ -1,0 +1,116 @@
+"""DebugPool: in-process, single-run backend for breakpoint-driven debugging.
+
+The pool runs one :class:`gmat_sweep.spec.RunSpec` on the driver process —
+no subprocess, no parallelism — so a ``breakpoint()`` placed in user code,
+override-application logic, or :mod:`gmat_run` itself drops directly into
+the driver's debugger and IDE step-through Just Works. This explicitly
+violates the subprocess-isolation contract every other pool implements;
+that violation is the feature.
+
+Two consequences follow from the in-process design:
+
+- **Single-run only.** GMAT relies on process-global singletons that
+  cannot be reused across loads of different scripts, and re-isolating
+  in-process between specs is not implemented. :meth:`Sweep.run` raises
+  :class:`gmat_sweep.errors.BackendError` if more than one spec is
+  submitted to a :class:`DebugPool`. Use :class:`LocalJoblibPool` /
+  :class:`ProcessPoolExecutorPool` for any sweep with N > 1.
+- **Two opt-ins.** Constructing the pool requires
+  ``allow_unisolated_pool=True``; passing it through to a sweep also
+  requires ``Sweep(..., allow_unisolated_pool=True)``. Both raise
+  :class:`gmat_sweep.errors.BackendError` if the flag is missing, so the
+  isolation violation never happens silently.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from concurrent.futures import Future
+from typing import ClassVar, Literal
+
+from gmat_sweep.backends.base import Pool
+from gmat_sweep.errors import BackendError
+from gmat_sweep.spec import RunOutcome, RunSpec
+from gmat_sweep.worker import run_one
+
+__all__ = ["DebugPool"]
+
+
+class DebugPool(Pool):
+    """In-process, single-run pool for ``breakpoint()``-driven debugging.
+
+    Dispatches each spec by calling :func:`gmat_sweep.worker.run_one`
+    synchronously on the driver process. No worker pool is constructed, no
+    subprocess is spawned, and nothing is parallelised — the point is for
+    the driver's debugger to be the worker's debugger. The trade-off is
+    that the GMAT singletons in the driver process get dirtied by the
+    run; reusing the same Python interpreter for a second run is not
+    supported, and :class:`gmat_sweep.sweep.Sweep` enforces the limit.
+
+    Parameters
+    ----------
+    allow_unisolated_pool:
+        Required opt-in. Defaults to :data:`False`, which raises
+        :class:`gmat_sweep.errors.BackendError` from ``__init__`` so the
+        violation cannot happen accidentally. Pass :data:`True` to
+        construct the pool — and remember to pass the matching flag to
+        :class:`gmat_sweep.sweep.Sweep` as well.
+
+    Examples
+    --------
+    >>> from gmat_sweep import Sweep
+    >>> from gmat_sweep.backends.debug import DebugPool
+    >>> pool = DebugPool(allow_unisolated_pool=True)  # doctest: +SKIP
+    >>> sweep = Sweep(  # doctest: +SKIP
+    ...     runs=[only_spec],
+    ...     backend=pool,
+    ...     manifest_path=out / "manifest.jsonl",
+    ...     output_dir=out,
+    ...     script_path=mission,
+    ...     parameter_spec={"_kind": "explicit", ...},
+    ...     allow_unisolated_pool=True,
+    ... )
+    >>> with pool:  # doctest: +SKIP
+    ...     sweep.run()
+    """
+
+    subprocess_isolated: ClassVar[Literal["debug"]] = "debug"
+
+    def __init__(self, *, allow_unisolated_pool: bool = False) -> None:
+        if not allow_unisolated_pool:
+            raise BackendError(
+                "DebugPool violates the subprocess-isolation contract — every "
+                "spec runs on the driver process so breakpoint() drops in. "
+                "Pass allow_unisolated_pool=True to acknowledge."
+            )
+        self._pending: dict[Future[RunOutcome], RunSpec] = {}
+        self._closed = False
+
+    def submit(self, spec: RunSpec) -> Future[RunOutcome]:
+        if self._closed:
+            raise BackendError("DebugPool is closed; cannot submit new specs")
+        future: Future[RunOutcome] = Future()
+        self._pending[future] = spec
+        return future
+
+    def as_completed(self, futures: Iterable[Future[RunOutcome]]) -> Iterator[RunOutcome]:
+        if self._closed:
+            raise BackendError("DebugPool is closed; cannot drain futures")
+
+        for f in list(futures):
+            spec = self._pending.pop(f, None)
+            if spec is None:
+                raise BackendError(
+                    "Future was not submitted to this pool, or has already been drained"
+                )
+            outcome = run_one(spec)
+            f.set_result(outcome)
+            yield outcome
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        for f in self._pending:
+            f.cancel()
+        self._pending.clear()

--- a/src/gmat_sweep/sweep.py
+++ b/src/gmat_sweep/sweep.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Any
 from tqdm.auto import tqdm
 
 from gmat_sweep.aggregate import lazy_contacts, lazy_ephemerides, lazy_multiindex
-from gmat_sweep.errors import SweepConfigError
+from gmat_sweep.errors import BackendError, SweepConfigError
 from gmat_sweep.manifest import Manifest, ManifestEntry, canonical_script_sha256
 
 if TYPE_CHECKING:
@@ -72,6 +72,15 @@ class Sweep:
     progress:
         ``True`` (default) wraps the drain loop in a :mod:`tqdm` bar.
         Set to ``False`` for non-interactive use (tests, CI logs).
+    allow_unisolated_pool:
+        Acknowledgement flag for backends whose ``subprocess_isolated`` is
+        not :data:`True` (today: only
+        :class:`gmat_sweep.backends.debug.DebugPool` with the ``"debug"``
+        sentinel). Defaults to :data:`False`, in which case constructing a
+        :class:`Sweep` over an unisolated backend raises
+        :class:`gmat_sweep.errors.BackendError`. Pass :data:`True` together
+        with the matching flag on the pool to opt in to in-process,
+        single-run debug dispatch.
     """
 
     def __init__(
@@ -85,7 +94,15 @@ class Sweep:
         parameter_spec: Mapping[str, Any],
         sweep_seed: int | None = None,
         progress: bool = True,
+        allow_unisolated_pool: bool = False,
     ) -> None:
+        if backend.subprocess_isolated is not True and not allow_unisolated_pool:
+            raise BackendError(
+                f"backend {type(backend).__name__} declares "
+                f"subprocess_isolated={backend.subprocess_isolated!r} (not True); "
+                "pass allow_unisolated_pool=True to acknowledge in-process or "
+                "otherwise unisolated dispatch."
+            )
         self._runs: list[RunSpec] = list(runs)
         self._backend = backend
         self._manifest_path = Path(manifest_path)
@@ -112,6 +129,7 @@ class Sweep:
         :exc:`KeyboardInterrupt` is not caught; it propagates so the caller's
         ``with``-managed pool exits and cancels still-pending futures.
         """
+        self._enforce_debug_pool_single_spec(self._runs)
         manifest = self._build_manifest()
         manifest.save(self._manifest_path)
         self._manifest = manifest
@@ -251,6 +269,7 @@ class Sweep:
         )
         specs_by_run_id: dict[int, RunSpec] = {s.run_id: s for s in self._runs}
         runs_to_submit: list[RunSpec] = [specs_by_run_id[rid] for rid in sorted(to_retry)]
+        self._enforce_debug_pool_single_spec(runs_to_submit)
 
         futures: list[Future[RunOutcome]] = [self._backend.submit(s) for s in runs_to_submit]
 
@@ -307,6 +326,18 @@ class Sweep:
         See :func:`gmat_sweep.aggregate.lazy_contacts` for the contract.
         """
         return lazy_contacts(self.to_manifest(), self._output_dir, name=name)
+
+    def _enforce_debug_pool_single_spec(self, runs: Sequence[RunSpec]) -> None:
+        # DebugPool runs every spec on the driver process and dirties GMAT's
+        # process-global singletons after the first load; re-isolation
+        # in-process is not implemented, so the pool refuses anything other
+        # than exactly one spec. Other unisolated pools (none today) would
+        # need their own enforcement once they appear.
+        if self._backend.subprocess_isolated == "debug" and len(runs) != 1:
+            raise BackendError(
+                f"DebugPool dispatches a single spec in-process; got {len(runs)}. "
+                "Use LocalJoblibPool or ProcessPoolExecutorPool for multi-spec sweeps."
+            )
 
     def _build_manifest(self) -> Manifest:
         # Local import: gmat_sweep.__init__ sets __version__ as part of module

--- a/tests/test_backends_base.py
+++ b/tests/test_backends_base.py
@@ -93,6 +93,42 @@ def test_subclass_setting_subprocess_isolated_none_raises() -> None:
                 pass
 
 
+def test_subclass_setting_subprocess_isolated_to_debug_string_is_accepted() -> None:
+    # The "debug" sentinel is the one recognised opt-out — DebugPool uses it
+    # to declare in-process single-run dispatch.
+    class _Debug(Pool):
+        subprocess_isolated: ClassVar[str] = "debug"  # type: ignore[assignment]
+
+        def submit(self, spec: RunSpec) -> Future[RunOutcome]:
+            return Future()
+
+        def as_completed(self, futures: Iterable[Future[RunOutcome]]) -> Iterator[RunOutcome]:
+            return iter([])
+
+        def close(self) -> None:
+            pass
+
+    assert _Debug.subprocess_isolated == "debug"
+
+
+def test_subclass_setting_subprocess_isolated_to_unknown_string_raises() -> None:
+    # Only the literal "debug" string is accepted; any other string still
+    # raises so the contract has exactly one named opt-out.
+    with pytest.raises(BackendError):
+
+        class _Bad(Pool):
+            subprocess_isolated: ClassVar[str] = "fast"  # type: ignore[assignment]
+
+            def submit(self, spec: RunSpec) -> Future[RunOutcome]:
+                return Future()
+
+            def as_completed(self, futures: Iterable[Future[RunOutcome]]) -> Iterator[RunOutcome]:
+                return iter([])
+
+            def close(self) -> None:
+                pass
+
+
 def test_pool_works_as_context_manager() -> None:
     pool = _MinimalPool()
     with pool as p:

--- a/tests/test_backends_debug.py
+++ b/tests/test_backends_debug.py
@@ -1,0 +1,219 @@
+"""Tests for gmat_sweep.backends.debug.DebugPool — in-process, single-run dispatch."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gmat_sweep.backends.base import Pool
+from gmat_sweep.backends.debug import DebugPool
+from gmat_sweep.errors import BackendError
+from gmat_sweep.spec import RunSpec
+from gmat_sweep.sweep import Sweep
+from tests.conftest import FakeGmatRun, FakeResults
+
+
+def _make_spec(*, output_dir: Path, run_id: int = 0) -> RunSpec:
+    return RunSpec(
+        script_path=Path("/missions/m.script"),
+        overrides={},
+        output_dir=output_dir,
+        run_id=run_id,
+        seed=None,
+        run_options={},
+    )
+
+
+def _write_script(tmp_path: Path) -> Path:
+    path = tmp_path / "mission.script"
+    path.write_text("% GMAT script\nCreate Spacecraft Sat;\n", encoding="utf-8")
+    return path
+
+
+def _make_runs(script: Path, output_dir: Path, n: int) -> list[RunSpec]:
+    return [
+        RunSpec(
+            script_path=script,
+            overrides={},
+            output_dir=output_dir / f"run-{i}",
+            run_id=i,
+            seed=None,
+            run_options={},
+        )
+        for i in range(n)
+    ]
+
+
+def test_debugpool_is_pool_subclass_with_debug_sentinel() -> None:
+    assert issubclass(DebugPool, Pool)
+    assert DebugPool.subprocess_isolated == "debug"
+
+
+def test_debugpool_construction_requires_explicit_optin() -> None:
+    with pytest.raises(BackendError) as ei:
+        DebugPool()
+    assert "allow_unisolated_pool" in str(ei.value)
+
+
+def test_debugpool_constructs_when_optin_passed() -> None:
+    pool = DebugPool(allow_unisolated_pool=True)
+    pool.close()
+
+
+def test_debugpool_runs_specs_in_driver_process(tmp_path: Path, fake_gmat_run: FakeGmatRun) -> None:
+    # Runs in-process iff the worker observes the driver's pid.
+    observed_pids: list[int] = []
+
+    def _record_pid(**_: Any) -> FakeResults:
+        observed_pids.append(os.getpid())
+        return FakeResults()
+
+    fake_gmat_run.install_loader(run_hook=_record_pid)
+
+    pool = DebugPool(allow_unisolated_pool=True)
+    spec = _make_spec(output_dir=tmp_path / "run_0")
+    f = pool.submit(spec)
+    outcomes = list(pool.as_completed([f]))
+
+    assert len(outcomes) == 1
+    assert outcomes[0].status == "ok"
+    assert f.done()
+    assert f.result() is outcomes[0]
+    assert observed_pids == [os.getpid()]
+
+
+def test_debugpool_user_breakpoint_drops_into_driver_debugger(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The reason DebugPool exists: a breakpoint() reached during the run
+    # must hit the driver's sys.breakpointhook. Patch the hook to a recorder
+    # and have the fake mission's run() call breakpoint() while the pool is
+    # active; assert the recorder fired in this process.
+    breakpoint_hits: list[int] = []
+
+    def _record_breakpoint(*_args: Any, **_kwargs: Any) -> None:
+        breakpoint_hits.append(os.getpid())
+
+    monkeypatch.setattr(sys, "breakpointhook", _record_breakpoint)
+
+    def _trigger_breakpoint(**_: Any) -> FakeResults:
+        breakpoint()
+        return FakeResults()
+
+    fake_gmat_run.install_loader(run_hook=_trigger_breakpoint)
+
+    pool = DebugPool(allow_unisolated_pool=True)
+    f = pool.submit(_make_spec(output_dir=tmp_path / "run_0"))
+    list(pool.as_completed([f]))
+
+    assert breakpoint_hits == [os.getpid()]
+
+
+def test_debugpool_close_is_idempotent() -> None:
+    pool = DebugPool(allow_unisolated_pool=True)
+    pool.close()
+    pool.close()
+
+
+def test_debugpool_submit_after_close_raises(tmp_path: Path) -> None:
+    pool = DebugPool(allow_unisolated_pool=True)
+    pool.close()
+    with pytest.raises(BackendError):
+        pool.submit(_make_spec(output_dir=tmp_path / "run_0"))
+
+
+def test_debugpool_as_completed_rejects_unknown_future(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    pool = DebugPool(allow_unisolated_pool=True)
+    f = pool.submit(_make_spec(output_dir=tmp_path / "run_0"))
+    list(pool.as_completed([f]))  # Drained — no longer pending.
+
+    with pytest.raises(BackendError):
+        list(pool.as_completed([f]))
+
+
+def test_debugpool_lazy_export_from_backends_package() -> None:
+    # The pool is registered on the backends package so
+    # `from gmat_sweep.backends import DebugPool` works without forcing an
+    # eager import on plain `from gmat_sweep.backends import LocalJoblibPool`.
+    from gmat_sweep import backends
+
+    assert backends.DebugPool is DebugPool
+
+
+# ---- Sweep-level gates ----------------------------------------------------
+
+
+def test_sweep_rejects_debugpool_without_acknowledgement(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    script = _write_script(tmp_path)
+    runs = _make_runs(script, tmp_path / "out", n=1)
+    pool = DebugPool(allow_unisolated_pool=True)
+    try:
+        with pytest.raises(BackendError) as ei:
+            Sweep(
+                runs=runs,
+                backend=pool,
+                manifest_path=tmp_path / "out" / "manifest.jsonl",
+                output_dir=tmp_path / "out",
+                script_path=script,
+                parameter_spec={"_kind": "explicit", "columns": [], "rows": [[]]},
+                progress=False,
+            )
+        assert "allow_unisolated_pool" in str(ei.value)
+    finally:
+        pool.close()
+
+
+def test_sweep_runs_one_spec_through_debugpool(tmp_path: Path, fake_gmat_run: FakeGmatRun) -> None:
+    script = _write_script(tmp_path)
+    output_dir = tmp_path / "out"
+    runs = _make_runs(script, output_dir, n=1)
+
+    with DebugPool(allow_unisolated_pool=True) as pool:
+        sweep = Sweep(
+            runs=runs,
+            backend=pool,
+            manifest_path=output_dir / "manifest.jsonl",
+            output_dir=output_dir,
+            script_path=script,
+            parameter_spec={"_kind": "explicit", "columns": [], "rows": [[]]},
+            progress=False,
+            allow_unisolated_pool=True,
+        )
+        sweep.run()
+
+    manifest = sweep.to_manifest()
+    assert manifest.run_count == 1
+    assert len(manifest.entries) == 1
+    assert manifest.entries[0].run_id == 0
+
+
+def test_sweep_run_rejects_multi_spec_through_debugpool(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    script = _write_script(tmp_path)
+    output_dir = tmp_path / "out"
+    runs = _make_runs(script, output_dir, n=2)
+
+    with DebugPool(allow_unisolated_pool=True) as pool:
+        sweep = Sweep(
+            runs=runs,
+            backend=pool,
+            manifest_path=output_dir / "manifest.jsonl",
+            output_dir=output_dir,
+            script_path=script,
+            parameter_spec={"_kind": "explicit", "columns": [], "rows": [[], []]},
+            progress=False,
+            allow_unisolated_pool=True,
+        )
+        with pytest.raises(BackendError) as ei:
+            sweep.run()
+        assert "DebugPool" in str(ei.value)
+        assert "2" in str(ei.value)


### PR DESCRIPTION
## Summary
- Add `gmat_sweep.backends.debug.DebugPool`: in-process, single-run dispatch so `breakpoint()` reached during a run drops into the driver's debugger.
- Extend `Pool.__init_subclass__` to accept the literal `\"debug\"` sentinel for `subprocess_isolated`; every other non-`True` value still raises `BackendError` at class-definition time.
- Gate the isolation violation behind two opt-ins — `DebugPool(allow_unisolated_pool=True)` and `Sweep(..., allow_unisolated_pool=True)`. Either flag missing raises. `Sweep.run`/`Sweep.resume` also raise on multi-spec submission to a `DebugPool` (GMAT singletons can't be re-isolated in-process).
- Document in `docs/backends.md`, exposed lazily from `gmat_sweep.backends`; not re-exported from top-level `gmat_sweep`.

## Test plan
- [x] `uv run pytest` (586 passed, 1 skipped — mpi4py unrelated)
- [x] `uv run ruff check`
- [x] `uv run ruff format --check`
- [x] `uv run mypy`
- [x] New `tests/test_backends_debug.py` covers: opt-in enforcement on the pool, opt-in enforcement on `Sweep`, in-process dispatch (driver pid match), `breakpoint()` reaches `sys.breakpointhook`, multi-spec rejection, lazy export, close/submit-after-close idempotency.
- [x] Extended `tests/test_backends_base.py` with `\"debug\"`-sentinel acceptance and unknown-string rejection.

Closes #69