### PR TITLE
Add lazy_fused_reports: wide-frame multi-report reshape on a shared timeline

### DIFF
--- a/docs/aggregation.md
+++ b/docs/aggregation.md
@@ -91,14 +91,14 @@ When a sweep produces several `ReportFile` outputs and you want them
 side-by-side on a shared timeline,
 [`lazy_fused_reports`][gmat_sweep.lazy_fused_reports] (and
 `Sweep.to_fused_reports`) reshape them into one wide DataFrame with a
-column-level [`MultiIndex`][pandas.MultiIndex] keyed by
-`(report_name, column)`. The first name in `names` is the merge anchor;
-subsequent reports are joined onto it per `run_id`.
+column-level `pandas.MultiIndex` keyed by `(report_name, column)`. The
+first name in `names` is the merge anchor; subsequent reports are
+joined onto it per `run_id`.
 
 | `tolerance` | Merge per run | When it fits |
 |-------------|---------------|--------------|
 | `"exact"` (literal) | inner join on `time` | every report shares the same step setting and you only want rows present in all of them |
-| `pd.Timedelta(...)` | [`pd.merge_asof`][pandas.merge_asof] (`backward` direction, default) | reports use different cadences and a "nearest within window" match per anchor row is what you want |
+| `pd.Timedelta(...)` | `pd.merge_asof` (`backward` direction, default) | reports use different cadences and a "nearest within window" match per anchor row is what you want |
 
 ```python
 from pathlib import Path
@@ -142,9 +142,10 @@ report's individual state for that run, but the other reports' data is
 not merged in — anchor-failure shadows the rest of the row. Pick the
 report most likely to be present as the first entry of `names`.
 
-`tolerance` is required (no default). For `pd.merge_asof`, see the
-[pandas reference][pandas.merge_asof] for direction (`backward` is the
-default), allow_exact_matches, and accepted `tolerance` types.
+`tolerance` is required (no default). See the
+[`pandas.merge_asof` reference](https://pandas.pydata.org/docs/reference/api/pandas.merge_asof.html)
+for the `direction` (`backward` by default), `allow_exact_matches`, and
+accepted `tolerance` types.
 
 ## Memory: streaming vs. eager reads
 

--- a/docs/aggregation.md
+++ b/docs/aggregation.md
@@ -85,6 +85,67 @@ the same way you'd use a per-run row position; the actual visibility
 times are still in the data columns (`Start`, `Stop`, `Duration`, etc.,
 depending on the `ContactLocator.ReportFormat` setting).
 
+## Fusing multiple reports per run
+
+When a sweep produces several `ReportFile` outputs and you want them
+side-by-side on a shared timeline,
+[`lazy_fused_reports`][gmat_sweep.lazy_fused_reports] (and
+`Sweep.to_fused_reports`) reshape them into one wide DataFrame with a
+column-level [`MultiIndex`][pandas.MultiIndex] keyed by
+`(report_name, column)`. The first name in `names` is the merge anchor;
+subsequent reports are joined onto it per `run_id`.
+
+| `tolerance` | Merge per run | When it fits |
+|-------------|---------------|--------------|
+| `"exact"` (literal) | inner join on `time` | every report shares the same step setting and you only want rows present in all of them |
+| `pd.Timedelta(...)` | [`pd.merge_asof`][pandas.merge_asof] (`backward` direction, default) | reports use different cadences and a "nearest within window" match per anchor row is what you want |
+
+```python
+from pathlib import Path
+
+import pandas as pd
+from gmat_sweep import Manifest, lazy_fused_reports
+
+manifest = Manifest.load(Path("./sweep/manifest.jsonl"))
+
+# Two reports on the same step setting → exact inner join.
+exact = lazy_fused_reports(
+    manifest, Path("./sweep"), names=["StateReport", "BurnReport"], tolerance="exact",
+)
+
+# Reports on different cadences (e.g. 1 Hz state + 10 s maneuvers) → asof merge
+# with a per-row tolerance window.
+fused = lazy_fused_reports(
+    manifest,
+    Path("./sweep"),
+    names=["StateReport", "BurnReport"],
+    tolerance=pd.Timedelta(seconds=2),
+)
+
+# Anchor's columns under (StateReport, *), right-side under (BurnReport, *).
+fused[("StateReport", "Sat.X")]
+fused[("BurnReport", "Sat.Tank.Mass")]
+```
+
+### Column shape
+
+| Column | Meaning |
+|--------|---------|
+| `(report_name, column)` | data column from that report |
+| `(report_name, "__status")` | per-report status — preserves the [`lazy_multiindex`][gmat_sweep.lazy_multiindex] contract for each report independently (e.g. one report failed-for-this-run while others succeeded) |
+| `("__status", "")` | run-level status, mirrored from the manifest entry |
+
+A run whose anchor failed (`status != "ok"` for the first name in
+`names`, or its parquet was missing) lands as a single `time=NaT` row
+with all data NaN. The per-report `__status` columns still surface every
+report's individual state for that run, but the other reports' data is
+not merged in — anchor-failure shadows the rest of the row. Pick the
+report most likely to be present as the first entry of `names`.
+
+`tolerance` is required (no default). For `pd.merge_asof`, see the
+[pandas reference][pandas.merge_asof] for direction (`backward` is the
+default), allow_exact_matches, and accepted `tolerance` types.
+
 ## Memory: streaming vs. eager reads
 
 `lazy_multiindex` and `lazy_ephemerides` accept `spool: bool = True`.

--- a/docs/api.md
+++ b/docs/api.md
@@ -62,6 +62,8 @@ auto-generated from docstrings via
 
 ::: gmat_sweep.lazy_contacts
 
+::: gmat_sweep.lazy_fused_reports
+
 ## Exceptions
 
 ::: gmat_sweep.GmatSweepError

--- a/src/gmat_sweep/__init__.py
+++ b/src/gmat_sweep/__init__.py
@@ -3,7 +3,12 @@
 import logging
 from importlib.metadata import PackageNotFoundError, version
 
-from gmat_sweep.aggregate import lazy_contacts, lazy_ephemerides, lazy_multiindex
+from gmat_sweep.aggregate import (
+    lazy_contacts,
+    lazy_ephemerides,
+    lazy_fused_reports,
+    lazy_multiindex,
+)
 from gmat_sweep.api import latin_hypercube, monte_carlo, sweep
 from gmat_sweep.backends import LocalJoblibPool, Pool
 from gmat_sweep.errors import (
@@ -70,6 +75,7 @@ __all__ = [
     "latin_hypercube_samples",
     "lazy_contacts",
     "lazy_ephemerides",
+    "lazy_fused_reports",
     "lazy_multiindex",
     "monte_carlo",
     "sweep",

--- a/src/gmat_sweep/aggregate.py
+++ b/src/gmat_sweep/aggregate.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
 
     from gmat_sweep.manifest import Manifest, ManifestEntry
 
-__all__ = ["lazy_contacts", "lazy_ephemerides", "lazy_multiindex"]
+__all__ = ["lazy_contacts", "lazy_ephemerides", "lazy_fused_reports", "lazy_multiindex"]
 
 
 _RUN_ID_COL = "run_id"
@@ -347,4 +347,221 @@ def _empty_frame(*, secondary_index: str, index_names: tuple[str, str]) -> pd.Da
             [pd.Series([], dtype="int64"), secondary_series],
             names=list(index_names),
         ),
+    )
+
+
+def lazy_fused_reports(
+    manifest: Manifest,
+    output_dir: Path,
+    names: Sequence[str],
+    *,
+    tolerance: str | pd.Timedelta,
+    spool: bool = True,
+) -> pd.DataFrame:
+    """Fuse N ``ReportFile`` outputs per run into one wide ``(run_id, time)``-indexed DataFrame.
+
+    Each report is read via :func:`lazy_multiindex` and the per-run slices
+    are stitched together into a single frame whose columns form a
+    two-level :class:`pandas.MultiIndex` keyed by ``(report_name, column)``.
+    The first name in ``names`` is the merge anchor: subsequent reports
+    are joined to it per ``run_id`` via :func:`pandas.merge_asof` (with
+    the user-supplied ``tolerance``), or via an inner join on ``time``
+    when ``tolerance="exact"`` — appropriate when every report shares a
+    step setting.
+
+    Parameters
+    ----------
+    manifest
+        The sweep manifest.
+    output_dir
+        Sweep output root, used to anchor relative paths in the manifest.
+    names
+        The ``ReportFile`` resource names to fuse, in merge order. The
+        first name is the anchor (left side of every merge); later names
+        are joined onto it. Must contain at least two unique names — for a
+        single report use :func:`lazy_multiindex` with ``name=...``.
+    tolerance
+        Required. Either the literal string ``"exact"`` (collapses to an
+        inner join on ``time`` per run, appropriate when reports share a
+        step setting) or any value :func:`pandas.merge_asof` accepts as a
+        ``tolerance`` argument — typically a :class:`pandas.Timedelta`.
+    spool
+        Forwarded to each underlying :func:`lazy_multiindex` call.
+        ``True`` (default) streams per-run Parquet a batch at a time;
+        ``False`` reads each fragment in one shot.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Row index: ``(run_id, time)`` :class:`MultiIndex`. Column index:
+        a two-level :class:`MultiIndex` ``("report", "field")``. For each
+        report, data columns appear at ``(report_name, column)`` and the
+        per-report status (preserving the per-report contract from
+        :func:`lazy_multiindex`) at ``(report_name, "__status")``. A
+        run-level status sits at ``("__status", "")``.
+
+    Notes
+    -----
+    The anchor selection is asymmetric. A run whose anchor failed
+    (``__status != "ok"``) — or whose anchor parquet was missing — lands
+    as a single ``time=NaT`` row with all data ``NaN`` and the per-report
+    ``__status`` of every report preserved. The other reports' data for
+    that run is not surfaced. Pick the report most likely to be present
+    as the first entry of ``names``.
+
+    Raises
+    ------
+    SweepConfigError
+        ``names`` has fewer than two entries, contains duplicates, or any
+        entry does not match a ``ReportFile`` resource in the sweep
+        (raised by the underlying :func:`lazy_multiindex` call).
+    """
+    if len(names) < 2:
+        raise SweepConfigError(
+            f"lazy_fused_reports requires at least 2 report names; got {len(names)}. "
+            "Use lazy_multiindex(name=...) for a single report."
+        )
+    if len(set(names)) != len(names):
+        raise SweepConfigError(
+            f"lazy_fused_reports requires unique report names; got duplicates in {list(names)}"
+        )
+
+    asof_tolerance: pd.Timedelta | None
+    if isinstance(tolerance, str):
+        if tolerance != "exact":
+            raise SweepConfigError(
+                f"tolerance must be the literal string 'exact' or a pd.Timedelta; got {tolerance!r}"
+            )
+        asof_tolerance = None
+    else:
+        asof_tolerance = tolerance
+
+    per_report: list[pd.DataFrame] = [
+        lazy_multiindex(manifest, output_dir, name=name, spool=spool) for name in names
+    ]
+
+    # Internal flat labels avoid string-prefix collisions with arbitrary
+    # GMAT column names. The flat → (report, field) mapping is applied
+    # once at the very end to build the column MultiIndex.
+    flat_to_tuple: dict[str, tuple[str, str]] = {}
+    rename_per_report: list[dict[str, str]] = []
+    for ridx, (name, df) in enumerate(zip(names, per_report, strict=True)):
+        rename: dict[str, str] = {}
+        for cidx, col in enumerate(df.columns):
+            flat = f"_s{ridx}" if col == _STATUS_COL else f"_d{ridx}_{cidx}"
+            rename[col] = flat
+            flat_to_tuple[flat] = (name, col)
+        rename_per_report.append(rename)
+
+    flat_per_report: list[pd.DataFrame] = [
+        df.reset_index().rename(columns=rename_per_report[i]) for i, df in enumerate(per_report)
+    ]
+
+    run_status: dict[int, str] = {e.run_id: e.status for e in manifest.entries}
+    run_ids: list[int] = [e.run_id for e in manifest.entries]
+
+    parts: list[pd.DataFrame] = []
+    for run_id in run_ids:
+        per_run = [
+            df[df[_RUN_ID_COL] == run_id].drop(columns=[_RUN_ID_COL]) for df in flat_per_report
+        ]
+        anchor = per_run[0]
+        anchor_has_data = not anchor.empty and bool(anchor[_TIME_COL].notna().any())
+        if anchor_has_data:
+            fused = _merge_run_fused(
+                per_run, tolerance=asof_tolerance, rename_per_report=rename_per_report
+            )
+        else:
+            fused = _anchor_failed_row_fused(
+                per_run,
+                rename_per_report=rename_per_report,
+                run_level_status=run_status[run_id],
+            )
+        fused[_RUN_ID_COL] = run_id
+        fused[_STATUS_COL] = run_status[run_id]
+        parts.append(fused)
+
+    if not parts:
+        return _empty_fused_frame(flat_to_tuple)
+
+    result = pd.concat(parts, axis=0, ignore_index=True, sort=False)
+    result[_TIME_COL] = pd.to_datetime(result[_TIME_COL]).astype("datetime64[ns]")
+    result = result.set_index([_RUN_ID_COL, _TIME_COL]).sort_index()
+
+    new_cols: list[tuple[str, str]] = [
+        (_STATUS_COL, "") if col == _STATUS_COL else flat_to_tuple[col] for col in result.columns
+    ]
+    result.columns = pd.MultiIndex.from_tuples(new_cols, names=["report", "field"])
+    return cast(pd.DataFrame, result)
+
+
+def _merge_run_fused(
+    per_run: Sequence[pd.DataFrame],
+    *,
+    tolerance: pd.Timedelta | None,
+    rename_per_report: Sequence[dict[str, str]],
+) -> pd.DataFrame:
+    # Anchor has ok-data here; later reports join onto it. ``tolerance=None``
+    # is the "exact" sentinel from lazy_fused_reports — collapses the merge
+    # to an inner join on time. Reports with only a NaN-marker row for this
+    # run contribute one row's worth of NaN data + their NaN-marker per-report
+    # status.
+    anchor = cast(
+        pd.DataFrame,
+        per_run[0].dropna(subset=[_TIME_COL]).sort_values(_TIME_COL).reset_index(drop=True),
+    )
+
+    for i in range(1, len(per_run)):
+        right = per_run[i]
+        right_has_data = not right.empty and bool(right[_TIME_COL].notna().any())
+        if right_has_data:
+            right_ok = cast(
+                pd.DataFrame,
+                right.dropna(subset=[_TIME_COL]).sort_values(_TIME_COL).reset_index(drop=True),
+            )
+            if tolerance is None:
+                anchor = anchor.merge(right_ok, on=_TIME_COL, how="inner")
+            else:
+                anchor = pd.merge_asof(anchor, right_ok, on=_TIME_COL, tolerance=tolerance)
+        else:
+            for orig_col, flat in rename_per_report[i].items():
+                if orig_col == _STATUS_COL:
+                    anchor[flat] = right[flat].iloc[0] if not right.empty else pd.NA
+                else:
+                    anchor[flat] = np.nan
+    return anchor
+
+
+def _anchor_failed_row_fused(
+    per_run: Sequence[pd.DataFrame],
+    *,
+    rename_per_report: Sequence[dict[str, str]],
+    run_level_status: str,
+) -> pd.DataFrame:
+    # Anchor has no ok-data for this run; emit one NaT-time row carrying
+    # every report's per-report status. Data columns are NaN regardless of
+    # whether non-anchor reports happened to have data — the asymmetry is
+    # documented on lazy_fused_reports.
+    row: dict[str, Any] = {_TIME_COL: pd.NaT}
+    for i, df in enumerate(per_run):
+        for orig_col, flat in rename_per_report[i].items():
+            if orig_col == _STATUS_COL:
+                if not df.empty:
+                    row[flat] = df[flat].iloc[0]
+                else:
+                    row[flat] = run_level_status
+            else:
+                row[flat] = np.nan
+    return pd.DataFrame([row])
+
+
+def _empty_fused_frame(flat_to_tuple: dict[str, tuple[str, str]]) -> pd.DataFrame:
+    cols = [*flat_to_tuple.values(), (_STATUS_COL, "")]
+    return pd.DataFrame(
+        {col: pd.Series([], dtype="object") for col in cols},
+        index=pd.MultiIndex.from_arrays(
+            [pd.Series([], dtype="int64"), pd.Series([], dtype="datetime64[ns]")],
+            names=[_RUN_ID_COL, _TIME_COL],
+        ),
+        columns=pd.MultiIndex.from_tuples(cols, names=["report", "field"]),
     )

--- a/src/gmat_sweep/sweep.py
+++ b/src/gmat_sweep/sweep.py
@@ -23,7 +23,12 @@ from typing import TYPE_CHECKING, Any
 
 from tqdm.auto import tqdm
 
-from gmat_sweep.aggregate import lazy_contacts, lazy_ephemerides, lazy_multiindex
+from gmat_sweep.aggregate import (
+    lazy_contacts,
+    lazy_ephemerides,
+    lazy_fused_reports,
+    lazy_multiindex,
+)
 from gmat_sweep.errors import BackendError, SweepConfigError
 from gmat_sweep.manifest import Manifest, ManifestEntry, canonical_script_sha256
 
@@ -326,6 +331,23 @@ class Sweep:
         See :func:`gmat_sweep.aggregate.lazy_contacts` for the contract.
         """
         return lazy_contacts(self.to_manifest(), self._output_dir, name=name)
+
+    def to_fused_reports(
+        self,
+        names: Sequence[str],
+        *,
+        tolerance: str | pd.Timedelta,
+        spool: bool = True,
+    ) -> pd.DataFrame:
+        """Fuse N ``ReportFile`` outputs per run into one wide MultiIndex-column DataFrame.
+
+        See :func:`gmat_sweep.aggregate.lazy_fused_reports` for the
+        contract — this is a thin convenience that binds the sweep's own
+        manifest and output directory.
+        """
+        return lazy_fused_reports(
+            self.to_manifest(), self._output_dir, names, tolerance=tolerance, spool=spool
+        )
 
     def _enforce_debug_pool_single_spec(self, runs: Sequence[RunSpec]) -> None:
         # DebugPool runs every spec on the driver process and dirties GMAT's

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -8,7 +8,12 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from gmat_sweep.aggregate import lazy_contacts, lazy_ephemerides, lazy_multiindex
+from gmat_sweep.aggregate import (
+    lazy_contacts,
+    lazy_ephemerides,
+    lazy_fused_reports,
+    lazy_multiindex,
+)
 from gmat_sweep.errors import SweepConfigError
 from gmat_sweep.manifest import Manifest, ManifestEntry
 
@@ -392,6 +397,215 @@ def test_lazy_contacts_failed_run_materialises_as_nan_row_with_na_interval(
     assert (failed_rows["__status"] == "failed").all()
     # Failed-row interval_id is pd.NA in the nullable Int64 level.
     assert bool(pd.isna(failed_rows.index[0]))
+
+
+def _write_timed_parquet(
+    output_dir: Path,
+    run_id: int,
+    basename: str,
+    timestamps: list[str],
+    *,
+    value_offset: int = 0,
+) -> Path:
+    """Helper: write a per-run report parquet with caller-controlled timestamps."""
+    path = output_dir / f"run-{run_id}" / f"{basename}.parquet"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df = pd.DataFrame(
+        {
+            "time": pd.to_datetime(timestamps),
+            "x": [value_offset + i for i in range(len(timestamps))],
+        }
+    )
+    df.to_parquet(path)
+    return path
+
+
+def _ok_two_reports_entry(
+    run_id: int,
+    path_a: Path,
+    path_b: Path,
+) -> ManifestEntry:
+    return _ok_entry(run_id, path_a, key="report__A", extra_paths={"report__B": path_b})
+
+
+# ---- fused multi-report aggregation --------------------------------------
+
+
+def test_lazy_fused_reports_exact_tolerance_inner_join(tmp_path: Path) -> None:
+    times = [f"2026-05-04T00:00:0{i}" for i in range(3)]
+    entries: list[ManifestEntry] = []
+    for run_id in range(2):
+        pa = _write_timed_parquet(tmp_path, run_id, "report__A", times, value_offset=run_id * 100)
+        pb = _write_timed_parquet(tmp_path, run_id, "report__B", times, value_offset=run_id * 200)
+        entries.append(_ok_two_reports_entry(run_id, pa, pb))
+
+    df = lazy_fused_reports(_make_manifest(entries), tmp_path, ["A", "B"], tolerance="exact")
+
+    assert df.index.names == ["run_id", "time"]
+    assert isinstance(df.columns, pd.MultiIndex)
+    assert df.columns.names == ["report", "field"]
+    assert {("A", "x"), ("B", "x"), ("A", "__status"), ("B", "__status"), ("__status", "")} <= set(
+        df.columns
+    )
+    assert len(df) == 2 * 3
+    assert (df[("A", "__status")] == "ok").all()
+    assert (df[("B", "__status")] == "ok").all()
+    assert (df[("__status", "")] == "ok").all()
+
+
+def test_lazy_fused_reports_numeric_tolerance_matches_within_window(tmp_path: Path) -> None:
+    # Anchor (A) at 1-Hz over :00..:04. B at every 10s starting :00. With
+    # tolerance=2s and merge_asof's default backward direction, only A times
+    # within 2s after the most recent B time get a B match. A=:00..:02 match
+    # B=:00; A=:03..:04 are >2s past B=:00 and B=:10 is in the future, so they
+    # land NaN on the B side.
+    a_times = [f"2026-05-04T00:00:0{i}" for i in range(5)]
+    b_times = ["2026-05-04T00:00:00", "2026-05-04T00:00:10"]
+    pa = _write_timed_parquet(tmp_path, 0, "report__A", a_times)
+    pb = _write_timed_parquet(tmp_path, 0, "report__B", b_times, value_offset=99)
+    entry = _ok_two_reports_entry(0, pa, pb)
+
+    df = lazy_fused_reports(
+        _make_manifest([entry]), tmp_path, ["A", "B"], tolerance=pd.Timedelta(seconds=2)
+    )
+
+    assert len(df) == 5
+    # First three anchor rows hit B=:00 (value_offset=99 so x=99 there).
+    matched = df[("B", "x")].notna()
+    assert matched.tolist() == [True, True, True, False, False]
+    assert (df.loc[matched, ("B", "x")] == 99).all()
+
+
+def test_lazy_fused_reports_no_overlap_within_tolerance(tmp_path: Path) -> None:
+    # A times: :00, :01, :02. B time: :30. tolerance=1s → no rows match B.
+    a_times = [f"2026-05-04T00:00:0{i}" for i in range(3)]
+    b_times = ["2026-05-04T00:00:30"]
+    pa = _write_timed_parquet(tmp_path, 0, "report__A", a_times)
+    pb = _write_timed_parquet(tmp_path, 0, "report__B", b_times, value_offset=42)
+    entry = _ok_two_reports_entry(0, pa, pb)
+
+    df = lazy_fused_reports(
+        _make_manifest([entry]), tmp_path, ["A", "B"], tolerance=pd.Timedelta(seconds=1)
+    )
+
+    assert len(df) == 3
+    assert df[("A", "x")].notna().all()
+    assert df[("B", "x")].isna().all()
+
+
+def test_lazy_fused_reports_anchor_failed_lands_as_one_nat_row(tmp_path: Path) -> None:
+    # Run 0 has both A and B; run 1 is ok but only produced B (anchor missing).
+    times = ["2026-05-04T00:00:00", "2026-05-04T00:00:01"]
+    pa0 = _write_timed_parquet(tmp_path, 0, "report__A", times)
+    pb0 = _write_timed_parquet(tmp_path, 0, "report__B", times, value_offset=10)
+    pb1 = _write_timed_parquet(tmp_path, 1, "report__B", times, value_offset=100)
+    entries = [
+        _ok_two_reports_entry(0, pa0, pb0),
+        ManifestEntry(
+            run_id=1,
+            overrides={},
+            status="ok",
+            output_paths={"report__B": pb1},
+            started_at=_utc(2026, 5, 4),
+            ended_at=_utc(2026, 5, 4, 0, 0, 1),
+            duration_s=1.0,
+            stderr=None,
+            log_path=None,
+        ),
+    ]
+
+    df = lazy_fused_reports(_make_manifest(entries), tmp_path, ["A", "B"], tolerance="exact")
+
+    run_1 = df.xs(1, level="run_id")
+    assert len(run_1) == 1
+    assert bool(pd.isna(run_1.index[0]))
+    assert run_1[("A", "x")].isna().all()
+    assert run_1[("B", "x")].isna().all()
+    # Per-report status mirrors lazy_multiindex's per-report contract:
+    # both A and B report "ok" because the run itself was ok.
+    assert (run_1[("A", "__status")] == "ok").all()
+    assert (run_1[("B", "__status")] == "ok").all()
+    assert (run_1[("__status", "")] == "ok").all()
+
+
+def test_lazy_fused_reports_failed_run_per_report_status_propagates(tmp_path: Path) -> None:
+    times = ["2026-05-04T00:00:00", "2026-05-04T00:00:01"]
+    pa = _write_timed_parquet(tmp_path, 0, "report__A", times)
+    pb = _write_timed_parquet(tmp_path, 0, "report__B", times, value_offset=10)
+    entries = [
+        _ok_two_reports_entry(0, pa, pb),
+        _nonok_entry(1, "failed"),
+    ]
+
+    df = lazy_fused_reports(_make_manifest(entries), tmp_path, ["A", "B"], tolerance="exact")
+
+    run_1 = df.xs(1, level="run_id")
+    assert len(run_1) == 1
+    assert (run_1[("A", "__status")] == "failed").all()
+    assert (run_1[("B", "__status")] == "failed").all()
+    assert (run_1[("__status", "")] == "failed").all()
+
+
+def test_lazy_fused_reports_right_report_failed_anchor_ok(tmp_path: Path) -> None:
+    # Run 0: both reports ok. Run 1: A ok, B missing (manifest entry has no B key).
+    times = ["2026-05-04T00:00:00", "2026-05-04T00:00:01"]
+    pa0 = _write_timed_parquet(tmp_path, 0, "report__A", times)
+    pb0 = _write_timed_parquet(tmp_path, 0, "report__B", times, value_offset=10)
+    pa1 = _write_timed_parquet(tmp_path, 1, "report__A", times, value_offset=100)
+    entries = [
+        _ok_two_reports_entry(0, pa0, pb0),
+        _ok_entry(1, pa1, key="report__A"),
+    ]
+
+    df = lazy_fused_reports(_make_manifest(entries), tmp_path, ["A", "B"], tolerance="exact")
+
+    # Run 1: anchor has data → 2 rows. B's data NaN because B was missing.
+    run_1 = df.xs(1, level="run_id")
+    assert len(run_1) == 2
+    assert run_1[("A", "x")].notna().all()
+    assert run_1[("B", "x")].isna().all()
+    # B's per-report status is "ok" — the run was ok, just no B output.
+    assert (run_1[("B", "__status")] == "ok").all()
+
+
+def test_lazy_fused_reports_three_reports_chain_merge(tmp_path: Path) -> None:
+    times = [f"2026-05-04T00:00:0{i}" for i in range(2)]
+    pa = _write_timed_parquet(tmp_path, 0, "report__A", times, value_offset=0)
+    pb = _write_timed_parquet(tmp_path, 0, "report__B", times, value_offset=10)
+    pc = _write_timed_parquet(tmp_path, 0, "report__C", times, value_offset=20)
+    entry = _ok_entry(
+        0,
+        pa,
+        key="report__A",
+        extra_paths={"report__B": pb, "report__C": pc},
+    )
+
+    df = lazy_fused_reports(_make_manifest([entry]), tmp_path, ["A", "B", "C"], tolerance="exact")
+
+    assert len(df) == 2
+    assert {("A", "x"), ("B", "x"), ("C", "x")} <= set(df.columns)
+    assert df[("A", "x")].tolist() == [0, 1]
+    assert df[("B", "x")].tolist() == [10, 11]
+    assert df[("C", "x")].tolist() == [20, 21]
+
+
+def test_lazy_fused_reports_empty_manifest(tmp_path: Path) -> None:
+    df = lazy_fused_reports(_make_manifest([]), tmp_path, ["A", "B"], tolerance="exact")
+
+    assert df.empty
+    assert df.index.names == ["run_id", "time"]
+    assert isinstance(df.columns, pd.MultiIndex)
+    assert ("__status", "") in df.columns
+
+
+def test_lazy_fused_reports_single_name_raises(tmp_path: Path) -> None:
+    with pytest.raises(SweepConfigError, match=r"at least 2 report names"):
+        lazy_fused_reports(_make_manifest([]), tmp_path, ["A"], tolerance="exact")
+
+
+def test_lazy_fused_reports_duplicate_names_raises(tmp_path: Path) -> None:
+    with pytest.raises(SweepConfigError, match=r"unique report names"):
+        lazy_fused_reports(_make_manifest([]), tmp_path, ["A", "A"], tolerance="exact")
 
 
 def test_lazy_contacts_three_kinds_aggregate_independently(tmp_path: Path) -> None:

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -274,6 +274,45 @@ def test_sweep_to_dataframe_marks_failed_run(tmp_path: Path, fake_gmat_run: Fake
     assert failed_rows.index.get_level_values("run_id").tolist() == [1]
 
 
+def test_sweep_to_fused_reports_returns_multiindex_column_frame(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    script = _write_script(tmp_path)
+    output_dir = tmp_path / "out"
+    runs = _make_runs(script, output_dir, n=2)
+
+    times = pd.to_datetime([f"2026-05-04T00:00:0{i}" for i in range(2)])
+
+    def _run(**_: Any) -> FakeResults:
+        return FakeResults(
+            reports={
+                "A": pd.DataFrame({"time": times, "x": [1.0, 2.0]}),
+                "B": pd.DataFrame({"time": times, "y": [10.0, 20.0]}),
+            }
+        )
+
+    fake_gmat_run.install_loader(run_hook=_run)
+
+    with LocalJoblibPool(workers=1) as pool:
+        sweep = Sweep(
+            runs=runs,
+            backend=pool,
+            manifest_path=output_dir / "manifest.jsonl",
+            output_dir=output_dir,
+            script_path=script,
+            parameter_spec={},
+            progress=False,
+        ).run()
+
+    df = sweep.to_fused_reports(["A", "B"], tolerance="exact")
+
+    assert df.index.names == ["run_id", "time"]
+    assert isinstance(df.columns, pd.MultiIndex)
+    assert {("A", "x"), ("B", "y"), ("__status", "")} <= set(df.columns)
+    assert len(df) == 2 * 2
+    assert (df[("__status", "")] == "ok").all()
+
+
 def test_sweep_to_manifest_requires_run_first(tmp_path: Path, fake_gmat_run: FakeGmatRun) -> None:
     script = _write_script(tmp_path)
     output_dir = tmp_path / "out"


### PR DESCRIPTION
## Summary
- New `lazy_fused_reports(manifest, output_dir, names, *, tolerance, spool=True)` and `Sweep.to_fused_reports` fuse N `ReportFile` outputs per run into one DataFrame with column-level `MultiIndex` keyed by `(report_name, column)`.
- Per-run merge anchors on the first name; subsequent reports join via `pd.merge_asof` with a user-supplied `tolerance`, or via inner join on `time` when `tolerance="exact"` (sentinel for the same-step-setting case).
- Per-report `__status` slots at `(name, "__status")` preserve the per-report NaN-vs-data contract; a row-level `("__status", "")` mirrors the manifest's run-level status. Anchor failure shadows the run as a single `time=NaT` row — documented on the helper.

## Test plan
- [x] `uv run pytest` — 597 pass, 1 pre-existing mpi4py skip
- [x] `uv run ruff check` and `uv run ruff format --check` clean
- [x] `uv run mypy` (strict) clean
- [x] `uv run coverage report --include='src/gmat_sweep/aggregate.py' --fail-under=95` — 98%
- [x] `uv run coverage report --fail-under=85` — 98%
- [ ] CI re-runs the same on Ubuntu / Windows / macOS

Closes #44