### PR TITLE
Notebook _repr_html_ for Sweep, RunOutcome, ManifestEntry

### DIFF
--- a/src/gmat_sweep/_repr_html.py
+++ b/src/gmat_sweep/_repr_html.py
@@ -1,0 +1,99 @@
+"""Shared HTML-table builders for ``_repr_html_`` on Sweep, RunOutcome, ManifestEntry.
+
+Pure-Python rendering — no template engine, no extra dependency. Each
+helper returns a plain ``str`` of HTML. All values flow through
+:func:`html.escape` so the rendered table cannot break on a ``<`` in a
+file path, override value, or stderr line.
+"""
+
+from __future__ import annotations
+
+import html
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+__all__ = [
+    "build_kv_table",
+    "format_overrides_html",
+    "format_paths_html",
+    "short_sha",
+    "summarise_stderr_html",
+]
+
+# stderr is rendered as one ellipsised line so a multi-megabyte traceback
+# doesn't bloat the cell — full text is still on disk in the worker log.
+_STDERR_SUMMARY_WIDTH = 80
+
+
+def short_sha(sha: str) -> str:
+    """First 12 chars of a hex SHA, or the full string when shorter."""
+    return sha[:12]
+
+
+def summarise_stderr_html(stderr: str | None) -> str:
+    """First line of ``stderr`` truncated to fit the cell, HTML-escaped.
+
+    Returns ``"(no stderr)"`` for ``None`` or empty input. Unlike the
+    plain-text variant in :mod:`gmat_sweep.cli`, this version escapes the
+    output so a ``<`` in a traceback can't break the surrounding table.
+    """
+    if not stderr:
+        return "(no stderr)"
+    lines = stderr.splitlines()
+    first = lines[0] if lines else ""
+    if len(first) <= _STDERR_SUMMARY_WIDTH:
+        return html.escape(first)
+    return html.escape(first[: _STDERR_SUMMARY_WIDTH - 3]) + "..."
+
+
+def format_paths_html(paths: Mapping[str, Path]) -> str:
+    """Render a ``{name: path}`` mapping as a one-line `key → path` list, HTML-escaped.
+
+    Empty input renders as ``"(none)"``. Multiple entries are joined with
+    ``<br>`` so the cell stays one column wide but readable.
+    """
+    if not paths:
+        return "(none)"
+    parts = [
+        f"{html.escape(k)} &rarr; <code>{html.escape(str(v))}</code>" for k, v in paths.items()
+    ]
+    return "<br>".join(parts)
+
+
+def format_overrides_html(overrides: Mapping[str, Any]) -> str:
+    """Render an ``overrides`` mapping as a one-key-per-line block, HTML-escaped.
+
+    Empty input renders as ``"(none)"``. Values are passed through
+    :func:`repr` so numeric vs string vs ``None`` stay distinguishable
+    (matches the plain-text :func:`gmat_sweep.cli._format_run_detail`
+    layout).
+    """
+    if not overrides:
+        return "(none)"
+    parts = [
+        f"<code>{html.escape(k)}</code> = <code>{html.escape(repr(v))}</code>"
+        for k, v in sorted(overrides.items())
+    ]
+    return "<br>".join(parts)
+
+
+def build_kv_table(
+    title: str,
+    rows: list[tuple[str, str]],
+) -> str:
+    """Build a ``<table>`` of two-column key/value rows with ``title`` as the caption.
+
+    ``rows`` is an ordered list of ``(label, html_value)`` pairs. Labels
+    are HTML-escaped; values are inserted verbatim, so callers must
+    pre-escape any user-supplied content (the helpers above do).
+    """
+    body = "".join(
+        f'<tr><th style="text-align:left;padding-right:1em">{html.escape(label)}</th>'
+        f"<td>{value}</td></tr>"
+        for label, value in rows
+    )
+    return (
+        f'<table><caption style="text-align:left;font-weight:bold">'
+        f"{html.escape(title)}</caption>{body}</table>"
+    )

--- a/src/gmat_sweep/manifest.py
+++ b/src/gmat_sweep/manifest.py
@@ -132,6 +132,33 @@ class ManifestEntry:
             log_path=log_path,
         )
 
+    def _repr_html_(self) -> str:
+        import html as _html
+
+        from gmat_sweep._repr_html import (
+            build_kv_table,
+            format_overrides_html,
+            format_paths_html,
+            summarise_stderr_html,
+        )
+
+        if self.log_path is None:
+            log = "(none)"
+        else:
+            log = f"<code>{_html.escape(str(self.log_path))}</code>"
+        rows: list[tuple[str, str]] = [
+            ("run_id", str(self.run_id)),
+            ("status", self.status),
+            ("duration", f"{self.duration_s:.2f} s"),
+            ("started_at", self.started_at.isoformat()),
+            ("ended_at", self.ended_at.isoformat()),
+            ("log_path", log),
+            ("output_paths", format_paths_html(self.output_paths)),
+            ("overrides", format_overrides_html(self.overrides)),
+            ("stderr", summarise_stderr_html(self.stderr)),
+        ]
+        return build_kv_table(f"ManifestEntry run_id={self.run_id}", rows)
+
 
 @dataclass(slots=True)
 class Manifest:

--- a/src/gmat_sweep/spec.py
+++ b/src/gmat_sweep/spec.py
@@ -195,3 +195,21 @@ class RunOutcome:
             started_at=datetime.fromisoformat(data["started_at"]),
             ended_at=datetime.fromisoformat(data["ended_at"]),
         )
+
+    def _repr_html_(self) -> str:
+        from gmat_sweep._repr_html import (
+            build_kv_table,
+            format_paths_html,
+            summarise_stderr_html,
+        )
+
+        rows: list[tuple[str, str]] = [
+            ("run_id", str(self.run_id)),
+            ("status", self.status),
+            ("duration", f"{self.duration_s:.2f} s"),
+            ("started_at", self.started_at.isoformat()),
+            ("ended_at", self.ended_at.isoformat()),
+            ("output_paths", format_paths_html(self.output_paths)),
+            ("stderr", summarise_stderr_html(self.stderr)),
+        ]
+        return build_kv_table(f"RunOutcome run_id={self.run_id}", rows)

--- a/src/gmat_sweep/sweep.py
+++ b/src/gmat_sweep/sweep.py
@@ -349,6 +349,39 @@ class Sweep:
             self.to_manifest(), self._output_dir, names, tolerance=tolerance, spool=spool
         )
 
+    def _repr_html_(self) -> str:
+        import html as _html
+
+        from gmat_sweep._repr_html import build_kv_table, short_sha
+
+        kind = self._parameter_spec.get("_kind", "grid")
+        try:
+            sha = canonical_script_sha256(self._script_path)
+            sha_cell = f"<code>{short_sha(sha)}</code>"
+        except OSError:
+            sha_cell = "(script not readable)"
+
+        rows: list[tuple[str, str]] = [
+            ("script", f"<code>{_html.escape(str(self._script_path))}</code>"),
+            ("script_sha256", sha_cell),
+            ("run_count", str(len(self._runs))),
+            ("parameter_spec._kind", _html.escape(str(kind))),
+            ("backend", _html.escape(type(self._backend).__name__)),
+        ]
+        if self._sweep_seed is not None:
+            rows.append(("sweep_seed", str(self._sweep_seed)))
+
+        if self._manifest is None:
+            rows.append(("status", "<em>not yet executed</em>"))
+        else:
+            counts = {"ok": 0, "failed": 0, "skipped": 0}
+            for entry in self._manifest.entries:
+                counts[entry.status] += 1
+            tally = ", ".join(f"{counts[k]} {k}" for k in ("ok", "failed", "skipped"))
+            rows.append(("outcomes", _html.escape(tally)))
+
+        return build_kv_table("Sweep", rows)
+
     def _enforce_debug_pool_single_spec(self, runs: Sequence[RunSpec]) -> None:
         # DebugPool runs every spec on the driver process and dirties GMAT's
         # process-global singletons after the first load; re-isolation

--- a/tests/test_repr_html.py
+++ b/tests/test_repr_html.py
@@ -1,0 +1,280 @@
+"""Tests for the ``_repr_html_`` methods on Sweep, RunOutcome, ManifestEntry."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pytest
+
+from gmat_sweep.backends.joblib import LocalJoblibPool
+from gmat_sweep.manifest import ManifestEntry
+from gmat_sweep.spec import RunOutcome, RunSpec
+from gmat_sweep.sweep import Sweep
+from tests.conftest import FakeGmatRun, FakeResults
+
+
+def _utc(year: int, month: int, day: int, h: int = 0, m: int = 0, s: int = 0) -> datetime:
+    return datetime(year, month, day, h, m, s, tzinfo=timezone.utc)
+
+
+def _assert_well_formed_html(markup: str) -> None:
+    """Feed ``markup`` to :class:`html.parser.HTMLParser` and assert it doesn't raise.
+
+    HTMLParser is permissive (it accepts unclosed tags), but it raises on
+    structurally broken markup like an unterminated attribute. This is the
+    practical "valid HTML" check the issue calls for — a stricter XML
+    parse would reject perfectly fine HTML.
+    """
+
+    class _Parser(HTMLParser):
+        def error(self, message: str) -> None:  # pragma: no cover - parser API
+            raise AssertionError(f"HTMLParser error: {message}")
+
+    parser = _Parser()
+    parser.feed(markup)
+    parser.close()
+
+
+def _write_script(tmp_path: Path) -> Path:
+    path = tmp_path / "mission.script"
+    path.write_text("% GMAT script\nCreate Spacecraft Sat;\n", encoding="utf-8")
+    return path
+
+
+def _make_runs(script: Path, output_dir: Path, n: int) -> list[RunSpec]:
+    return [
+        RunSpec(
+            script_path=script,
+            overrides={"Sat.SMA": 7000.0 + i},
+            output_dir=output_dir / f"run-{i}",
+            run_id=i,
+            seed=None,
+            run_options={},
+        )
+        for i in range(n)
+    ]
+
+
+def _payload_run_hook() -> Any:
+    payload = pd.DataFrame({"time": pd.to_datetime(["2026-05-04T00:00:00"]), "x": [1.0]})
+
+    def _run(**_: Any) -> FakeResults:
+        return FakeResults(reports={"R": payload})
+
+    return _run
+
+
+# ---- Sweep ----------------------------------------------------------------
+
+
+def test_sweep_repr_html_pre_run(tmp_path: Path) -> None:
+    script = _write_script(tmp_path)
+    runs = _make_runs(script, tmp_path / "out", n=3)
+    with LocalJoblibPool(workers=1) as pool:
+        sweep = Sweep(
+            runs=runs,
+            backend=pool,
+            manifest_path=tmp_path / "out" / "manifest.jsonl",
+            output_dir=tmp_path / "out",
+            script_path=script,
+            parameter_spec={"_kind": "grid", "Sat.SMA": [7000.0, 7100.0, 7200.0]},
+            sweep_seed=42,
+            progress=False,
+        )
+
+        html = sweep._repr_html_()
+
+    _assert_well_formed_html(html)
+    assert html.startswith("<table")
+    assert html.endswith("</table>")
+    assert "run_count" in html and ">3<" in html
+    assert "grid" in html
+    assert "LocalJoblibPool" in html
+    assert "not yet executed" in html
+    assert "sweep_seed" in html and "42" in html
+
+
+def test_sweep_repr_html_post_run(tmp_path: Path, fake_gmat_run: FakeGmatRun) -> None:
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+    script = _write_script(tmp_path)
+    output_dir = tmp_path / "out"
+    runs = _make_runs(script, output_dir, n=2)
+    with LocalJoblibPool(workers=1) as pool:
+        sweep = Sweep(
+            runs=runs,
+            backend=pool,
+            manifest_path=output_dir / "manifest.jsonl",
+            output_dir=output_dir,
+            script_path=script,
+            parameter_spec={"_kind": "grid", "Sat.SMA": [7000.0, 7100.0]},
+            progress=False,
+        ).run()
+
+        html = sweep._repr_html_()
+
+    _assert_well_formed_html(html)
+    assert "outcomes" in html
+    assert "2 ok" in html
+    assert "0 failed" in html
+    assert "not yet executed" not in html
+
+
+def test_sweep_repr_html_handles_unreadable_script(tmp_path: Path) -> None:
+    # Pass a non-existent script path so canonical_script_sha256 raises.
+    # The repr should degrade gracefully rather than blow up the notebook cell.
+    script = tmp_path / "missing.script"
+    runs: list[RunSpec] = []
+    with LocalJoblibPool(workers=1) as pool:
+        sweep = Sweep(
+            runs=runs,
+            backend=pool,
+            manifest_path=tmp_path / "out" / "manifest.jsonl",
+            output_dir=tmp_path / "out",
+            script_path=script,
+            parameter_spec={"_kind": "grid"},
+            progress=False,
+        )
+        html = sweep._repr_html_()
+
+    _assert_well_formed_html(html)
+    assert "script not readable" in html
+
+
+# ---- RunOutcome -----------------------------------------------------------
+
+
+def test_run_outcome_repr_html_ok() -> None:
+    outcome = RunOutcome.ok(
+        run_id=7,
+        output_paths={"ReportFile1": Path("/o/run-7/r1.parquet")},
+        started_at=_utc(2026, 5, 4, 0, 0, 0),
+        ended_at=_utc(2026, 5, 4, 0, 0, 12),
+    )
+    html = outcome._repr_html_()
+    _assert_well_formed_html(html)
+    assert "run_id" in html and ">7<" in html
+    assert "ok" in html
+    assert "12.00 s" in html
+    assert "ReportFile1" in html
+    assert "r1.parquet" in html
+    assert "(no stderr)" in html
+
+
+def test_run_outcome_repr_html_failed_truncates_long_stderr() -> None:
+    long_first_line = "E" * 200
+    outcome = RunOutcome.failed(
+        run_id=3,
+        stderr=f"{long_first_line}\nsecond line not shown",
+        started_at=_utc(2026, 5, 4, 0, 0, 0),
+        ended_at=_utc(2026, 5, 4, 0, 0, 1),
+    )
+    html = outcome._repr_html_()
+    _assert_well_formed_html(html)
+    assert "failed" in html
+    assert "..." in html
+    assert "second line not shown" not in html
+    assert "(none)" in html  # output_paths is empty for failed runs
+
+
+def test_run_outcome_repr_html_escapes_html_in_stderr() -> None:
+    outcome = RunOutcome.failed(
+        run_id=1,
+        stderr="<script>alert('boom')</script>",
+        started_at=_utc(2026, 5, 4),
+        ended_at=_utc(2026, 5, 4, 0, 0, 1),
+    )
+    html = outcome._repr_html_()
+    _assert_well_formed_html(html)
+    # The literal '<script>' must not appear unescaped — anything that does
+    # would let a stderr line break out of the table cell.
+    assert "<script>" not in html
+    assert "&lt;script&gt;" in html
+
+
+# ---- ManifestEntry --------------------------------------------------------
+
+
+def _make_entry(
+    *,
+    run_id: int = 0,
+    status: str = "ok",
+    overrides: dict[str, Any] | None = None,
+    log: bool = True,
+    stderr: str | None = None,
+) -> ManifestEntry:
+    return ManifestEntry(
+        run_id=run_id,
+        overrides=overrides if overrides is not None else {"Sat.SMA": 7000.0 + run_id},
+        status=status,  # type: ignore[arg-type]
+        output_paths={"R1": Path(f"/o/run-{run_id}/r1.parquet")} if status == "ok" else {},
+        started_at=_utc(2026, 5, 4, 0, 0, 0),
+        ended_at=_utc(2026, 5, 4, 0, 0, 12),
+        duration_s=12.0,
+        stderr=stderr,
+        log_path=Path(f"/o/run-{run_id}/log.txt") if log else None,
+    )
+
+
+def test_manifest_entry_repr_html_ok() -> None:
+    entry = _make_entry(run_id=2)
+    html = entry._repr_html_()
+    _assert_well_formed_html(html)
+    assert "run_id" in html and ">2<" in html
+    assert "ok" in html
+    assert "12.00 s" in html
+    assert "Sat.SMA" in html
+    assert "log.txt" in html
+    assert "r1.parquet" in html
+    assert "(no stderr)" in html
+
+
+def test_manifest_entry_repr_html_failed_with_no_log() -> None:
+    entry = _make_entry(run_id=5, status="failed", log=False, stderr="boom")
+    html = entry._repr_html_()
+    _assert_well_formed_html(html)
+    assert "failed" in html
+    assert "boom" in html
+    # log_path is None → cell renders as "(none)"; output_paths is empty for
+    # failed runs, also "(none)". We just need the status row to include the
+    # word at least twice (log_path + output_paths cells).
+    assert html.count("(none)") >= 2
+
+
+def test_manifest_entry_repr_html_renders_many_overrides() -> None:
+    overrides = {f"Sat.Field{i}": float(i) for i in range(50)}
+    entry = _make_entry(run_id=1, overrides=overrides)
+    html = entry._repr_html_()
+    _assert_well_formed_html(html)
+    # No truncation cap — every key is present.
+    for i in range(50):
+        assert f"Sat.Field{i}" in html
+
+
+def test_manifest_entry_repr_html_empty_overrides() -> None:
+    entry = _make_entry(run_id=1, overrides={})
+    html = entry._repr_html_()
+    _assert_well_formed_html(html)
+    assert "(none)" in html
+
+
+def test_manifest_entry_repr_html_escapes_keys_and_values() -> None:
+    entry = _make_entry(
+        run_id=1,
+        overrides={"<dangerous>": "<x>"},
+    )
+    html = entry._repr_html_()
+    _assert_well_formed_html(html)
+    assert "<dangerous>" not in html
+    assert "&lt;dangerous&gt;" in html
+
+
+@pytest.mark.parametrize("status", ["ok", "failed", "skipped"])
+def test_manifest_entry_repr_html_includes_status(status: str) -> None:
+    entry = _make_entry(status=status, stderr=None if status == "ok" else "x")
+    html = entry._repr_html_()
+    _assert_well_formed_html(html)
+    assert status in html


### PR DESCRIPTION
## Summary

- `Sweep`, `RunOutcome`, and `ManifestEntry` now render as compact HTML key/value tables when they're the last expression in a Jupyter cell, instead of the default `<gmat_sweep.sweep.Sweep object at 0x…>` placeholder. `__repr__` is unchanged.
- `Sweep._repr_html_` shows the script path + short SHA-256, run count, `parameter_spec._kind`, backend class, and (after `run()`) the ok/failed/skipped tally. Pre-`run()` it notes the sweep is not yet executed.
- `RunOutcome._repr_html_` and `ManifestEntry._repr_html_` mirror the `gmat-sweep show --run N` shape: status, duration, started/ended, output paths, stderr summary; `ManifestEntry` also includes log path and overrides (no truncation cap — sweep dimensionality is bounded by the design, not the run count).
- Pure Python — no new dependencies. All user-supplied strings flow through `html.escape` so a `<` in a path or stderr line cannot break the surrounding cell.

## Test plan

- [x] `uv run pytest tests/test_repr_html.py` — 14 new tests cover pre/post-run `Sweep`, ok/failed `RunOutcome`, ok/failed/skipped `ManifestEntry`, empty + many overrides, HTML-escaping, and graceful degradation when the script is unreadable.
- [x] `uv run pytest` — full suite (611 passed, 1 skipped for missing optional `mpi4py`).
- [x] `uv run ruff check`.
- [x] `uv run ruff format --check`.
- [x] `uv run mypy`.

Closes #86