### PR TITLE
Sweep.archive: provenance bundle for Zenodo / JOSS deposits

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -417,6 +417,100 @@ input summary, derived plots) before handing the bundle off. The
 verifier a way to check that the script in the bundle is the script
 the manifest was actually written against.
 
+## Pattern 4 — Archival deposit (Zenodo / JOSS)
+
+Pattern 3 builds a hand-rolled wrapper around the on-disk bundle. When
+the consumer is an *archival* deposit — a Zenodo record, JOSS
+supplementary material, or an internal handoff that needs to survive
+filesystem churn — `gmat-sweep` ships a packager that produces a single
+self-describing `.zip` directly:
+[`Sweep.archive`][gmat_sweep.Sweep.archive] and the matching
+`gmat-sweep archive` CLI subcommand.
+
+The bundle layout is:
+
+```
+bundle.zip
+├── README.md            generated reproduce recipe + manifest summary
+├── script/<name>        copy of the .script the manifest references
+├── manifest.jsonl       paths rewritten to be bundle-relative
+├── MANIFEST.hash        sha256sum-c compatible (every other member)
+└── runs/run-<id>/...    per-run Parquet outputs (and worker.log if requested)
+```
+
+Two things are worth calling out about this layout, because they're what
+make the bundle re-runnable on a fresh machine:
+
+1. **Manifest paths are rewritten on the way in.** The on-disk manifest
+   stores absolute `output_paths` pointing at the sweep's per-run
+   directories. The bundled manifest carries `runs/run-<id>/<basename>`
+   relative paths instead, which the aggregator resolves against the
+   unzip directory without further plumbing.
+2. **The bundle is byte-deterministic.** Two archives of the same
+   manifest are identical at the byte level — fixed `ZipInfo` timestamps,
+   sorted entries, stable hashes. Re-uploading to Zenodo from a
+   different machine produces the same record.
+
+### From a finished sweep
+
+```python
+from pathlib import Path
+
+from gmat_sweep import Sweep
+from gmat_sweep.backends import LocalJoblibPool
+
+with LocalJoblibPool() as pool:
+    sweep = Sweep.from_manifest(
+        Path("./out/manifest.jsonl"),
+        Path("./mission.script"),
+        backend=pool,
+    )
+bundle = sweep.archive(Path("./sma-scan-2026q2.zip"))
+```
+
+`Sweep.archive` returns the resolved path to the `.zip`. By default it
+drops every per-run `worker.log` (and sets the manifest's `log_path`
+field to `null`) so the archive stays small. Pass `include_logs=True`
+when you want them — useful for failure-analysis deposits where the
+worker traces are part of the record.
+
+### From the CLI
+
+```bash
+gmat-sweep archive ./out/manifest.jsonl \
+    --script ./mission.script \
+    --out ./sma-scan-2026q2.zip
+```
+
+Exits 2 if the script's canonical SHA-256 disagrees with the manifest's
+recorded hash; pass `--allow-script-drift` to proceed anyway (the
+bundle still records the manifest's original hash, so a downstream
+verifier can spot the drift).
+
+### Reproducing the sweep from a bundle
+
+The generated `README.md` documents this for whoever downloads the
+deposit, but the steps boil down to:
+
+```bash
+unzip sma-scan-2026q2.zip -d sma-scan-2026q2/
+cd sma-scan-2026q2/
+
+# Verify integrity:
+sha256sum -c MANIFEST.hash
+
+# One-line summary:
+gmat-sweep show manifest.jsonl
+
+# Re-run only the runs that failed or are missing on disk:
+gmat-sweep resume manifest.jsonl --script script/mission.script
+```
+
+For an all-`ok` bundle, `gmat-sweep resume` is a no-op on the run side —
+nothing failed, nothing's missing — and the aggregator reads the
+existing per-run Parquets. The resulting DataFrame is bit-equal to the
+one the original sweep produced.
+
 ## Where to from here
 
 - The full set of fields and shapes the manifest carries is documented

--- a/src/gmat_sweep/archive.py
+++ b/src/gmat_sweep/archive.py
@@ -1,0 +1,322 @@
+"""Provenance bundle: pack a finished sweep into a self-describing ``.zip``.
+
+The single internal entry point is :func:`_archive_sweep`. :meth:`Sweep.archive`
+calls it with state from the in-memory sweep; the ``gmat-sweep archive`` CLI
+calls it with state loaded from a manifest on disk. Both paths produce the
+same byte-equal bundle, which is the contract the round-trip test asserts.
+
+Bundle layout
+-------------
+::
+
+    bundle.zip
+    |-- README.md            generated reproduce recipe + manifest summary
+    |-- script/<name>        copy of the .script the manifest references
+    |-- manifest.jsonl       rewritten so output_paths/log_path are bundle-relative
+    |-- MANIFEST.hash        sha256sum-format file covering every other member
+    `-- runs/run-<id>/...    per-run Parquet files (and worker.log if requested)
+
+The bundled manifest's ``output_paths`` and ``log_path`` are rewritten to
+``runs/run-<id>/<basename>`` form so :func:`gmat_sweep.aggregate.lazy_multiindex`
+resolves them against the unzip directory without further ceremony.
+``include_logs=False`` (the default) drops every per-run ``worker.log`` from
+both the bundle and the manifest's ``log_path`` field.
+
+Determinism
+-----------
+Members are written in a fixed order with a frozen ``date_time`` and ``0o644``
+external attrs so two archives of the same manifest compare byte-equal. This
+makes the CLI ↔ API equivalence test possible and keeps Zenodo re-uploads
+idempotent.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import zipfile
+from collections.abc import Iterable
+from dataclasses import replace
+from pathlib import Path
+
+from gmat_sweep.errors import SweepConfigError
+from gmat_sweep.manifest import Manifest, ManifestEntry, canonical_script_sha256
+
+__all__ = ["_archive_sweep"]
+
+
+_README_NAME = "README.md"
+_MANIFEST_NAME = "manifest.jsonl"
+_HASH_NAME = "MANIFEST.hash"
+_SCRIPT_DIR = "script"
+_RUNS_DIR = "runs"
+_WORKER_LOG_NAME = "worker.log"
+
+# Fixed timestamp for every ZipInfo so byte-equal archives are reproducible.
+# Any constant in zip's 1980-2107 range works; this one is the project epoch.
+_FROZEN_TIMESTAMP = (2026, 1, 1, 0, 0, 0)
+_UNIX_FILE_MODE = 0o644 << 16
+
+
+def _archive_sweep(
+    *,
+    manifest: Manifest,
+    output_dir: Path,
+    script_path: Path,
+    out: Path,
+    include_logs: bool,
+    sweep_version: str,
+    allow_script_drift: bool = False,
+) -> Path:
+    """Pack a finished sweep into ``out`` as a ``.zip`` and return the resolved path.
+
+    ``manifest`` is the source of truth for which runs to include and what
+    their per-run Parquet paths are. ``output_dir`` is the sweep root those
+    paths resolve against; ``script_path`` is the ``.script`` whose canonical
+    hash must match ``manifest.script_sha256`` (unless ``allow_script_drift``
+    is set, mirroring :meth:`Sweep.from_manifest`). ``sweep_version`` is
+    written into the generated README so the deposit records the packager
+    version separately from ``manifest.gmat_sweep_version``.
+    """
+    out = Path(out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    current_sha = canonical_script_sha256(script_path)
+    if current_sha != manifest.script_sha256 and not allow_script_drift:
+        raise SweepConfigError(
+            f"script hash mismatch for {script_path}: "
+            f"manifest={manifest.script_sha256}, current={current_sha}"
+        )
+
+    script_member = f"{_SCRIPT_DIR}/{script_path.name}"
+    rewritten = _rewrite_entries_to_relative(manifest.entries, output_dir, include_logs)
+    bundled_manifest = _clone_manifest_with_entries(manifest, rewritten)
+
+    members: list[tuple[str, bytes]] = []
+    members.append((script_member, script_path.read_bytes()))
+    members.append((_MANIFEST_NAME, _serialise_manifest(bundled_manifest)))
+    members.extend(_collect_run_members(manifest.entries, output_dir, include_logs))
+    # README references the bundled manifest's contents, so build it after the
+    # rewrite. Hash file references every other member, so build it last.
+    readme_bytes = _render_readme(
+        bundled_manifest, script_member, sweep_version, include_logs=include_logs
+    ).encode("utf-8")
+    members.append((_README_NAME, readme_bytes))
+    members.append((_HASH_NAME, _render_hash_file(members)))
+
+    members.sort(key=lambda m: m[0])
+
+    with zipfile.ZipFile(out, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=6) as zf:
+        for name, data in members:
+            info = zipfile.ZipInfo(filename=name, date_time=_FROZEN_TIMESTAMP)
+            info.external_attr = _UNIX_FILE_MODE
+            info.compress_type = zipfile.ZIP_DEFLATED
+            zf.writestr(info, data)
+
+    return out
+
+
+def _rewrite_entries_to_relative(
+    entries: Iterable[ManifestEntry],
+    output_dir: Path,
+    include_logs: bool,
+) -> list[ManifestEntry]:
+    """Rewrite each entry's ``output_paths`` and ``log_path`` to bundle-relative form.
+
+    Per-run Parquets land at ``runs/run-<id>/<basename>``; the worker log
+    lands at the same prefix but is dropped (entry ``log_path`` set to
+    ``None``) when ``include_logs`` is ``False``.
+    """
+    rewritten: list[ManifestEntry] = []
+    for entry in entries:
+        run_dir = f"{_RUNS_DIR}/run-{entry.run_id}"
+        new_paths: dict[str, Path] = {}
+        for key, raw in entry.output_paths.items():
+            new_paths[key] = Path(f"{run_dir}/{Path(raw).name}")
+        if include_logs and entry.log_path is not None:
+            new_log: Path | None = Path(f"{run_dir}/{_WORKER_LOG_NAME}")
+        else:
+            new_log = None
+        rewritten.append(replace(entry, output_paths=new_paths, log_path=new_log))
+    return rewritten
+
+
+def _clone_manifest_with_entries(manifest: Manifest, entries: list[ManifestEntry]) -> Manifest:
+    """Return a Manifest carrying the rewritten entries and the original header."""
+    return Manifest(
+        script_sha256=manifest.script_sha256,
+        gmat_sweep_version=manifest.gmat_sweep_version,
+        gmat_run_version=manifest.gmat_run_version,
+        gmat_install_version=manifest.gmat_install_version,
+        python_version=manifest.python_version,
+        os_platform=manifest.os_platform,
+        sweep_seed=manifest.sweep_seed,
+        parameter_spec=dict(manifest.parameter_spec),
+        run_count=manifest.run_count,
+        backend=manifest.backend,
+        schema_version=manifest.schema_version,
+        entries=entries,
+    )
+
+
+def _serialise_manifest(manifest: Manifest) -> bytes:
+    """Serialise a manifest header + entries as one trailing-newline-terminated JSONL blob."""
+    lines = [json.dumps(manifest._header_dict(), sort_keys=True)]
+    lines.extend(json.dumps(e.to_dict(), sort_keys=True) for e in manifest.entries)
+    return ("\n".join(lines) + "\n").encode("utf-8")
+
+
+def _collect_run_members(
+    entries: Iterable[ManifestEntry],
+    output_dir: Path,
+    include_logs: bool,
+) -> list[tuple[str, bytes]]:
+    """Read every per-run Parquet (and optional worker log) referenced by ``entries``."""
+    members: list[tuple[str, bytes]] = []
+    for entry in entries:
+        if entry.status != "ok":
+            # Failed/skipped runs have no Parquets to bundle. Their stderr and
+            # overrides survive in the manifest, which is enough for resume.
+            if include_logs and entry.log_path is not None:
+                log_path = entry.log_path
+                if not log_path.is_absolute():
+                    log_path = output_dir / log_path
+                if log_path.is_file():
+                    members.append(
+                        (
+                            f"{_RUNS_DIR}/run-{entry.run_id}/{_WORKER_LOG_NAME}",
+                            log_path.read_bytes(),
+                        )
+                    )
+            continue
+        for _key, raw in entry.output_paths.items():
+            src = raw if raw.is_absolute() else output_dir / raw
+            if not src.is_file():
+                raise SweepConfigError(
+                    f"manifest entry for run_id={entry.run_id} references missing "
+                    f"output file: {src}"
+                )
+            members.append((f"{_RUNS_DIR}/run-{entry.run_id}/{src.name}", src.read_bytes()))
+        if include_logs and entry.log_path is not None:
+            log_path = entry.log_path
+            if not log_path.is_absolute():
+                log_path = output_dir / log_path
+            if log_path.is_file():
+                members.append(
+                    (
+                        f"{_RUNS_DIR}/run-{entry.run_id}/{_WORKER_LOG_NAME}",
+                        log_path.read_bytes(),
+                    )
+                )
+    return members
+
+
+def _render_hash_file(members: list[tuple[str, bytes]]) -> bytes:
+    """Render a ``sha256sum`` -compatible file covering every member except itself.
+
+    Format: ``<hex-digest>  <relative-path>\\n`` per line, sorted by path. The
+    file itself is excluded so a downstream ``sha256sum -c MANIFEST.hash``
+    from the unzip directory verifies cleanly.
+    """
+    lines = [
+        f"{hashlib.sha256(data).hexdigest()}  {name}"
+        for name, data in members
+        if name != _HASH_NAME
+    ]
+    lines.sort()
+    return ("\n".join(lines) + "\n").encode("utf-8")
+
+
+def _render_readme(
+    manifest: Manifest,
+    script_member: str,
+    sweep_version: str,
+    *,
+    include_logs: bool,
+) -> str:
+    """Generate the bundle's README — reproduce recipe, summary, version stamp."""
+    counts = {"ok": 0, "failed": 0, "skipped": 0}
+    duration_s = 0.0
+    for entry in manifest.entries:
+        counts[entry.status] += 1
+        duration_s += entry.duration_s
+    breakdown = ", ".join(f"{counts[k]} {k}" for k in ("ok", "failed", "skipped") if counts[k])
+    if not breakdown:
+        breakdown = "0 runs"
+
+    log_note = (
+        "Per-run worker logs are bundled under each `runs/run-<id>/worker.log`."
+        if include_logs
+        else "Per-run worker logs were excluded; pass `--include-logs` "
+        "(or `include_logs=True`) at archive time to bundle them."
+    )
+
+    lines = [
+        f"# Sweep archive — {len(manifest.entries)} runs",
+        "",
+        "This bundle was produced by `gmat-sweep archive`. It contains every input "
+        "and output needed to re-aggregate or resume the sweep on a new machine.",
+        "",
+        "## Summary",
+        "",
+        f"- **Runs:** {len(manifest.entries)} ({breakdown})",
+        f"- **Total runtime:** {duration_s:.2f} s",
+        f"- **Script SHA-256:** `{manifest.script_sha256}`",
+        f"- **gmat-sweep (sweep):** {manifest.gmat_sweep_version}",
+        f"- **gmat-sweep (archive):** {sweep_version}",
+        f"- **gmat-run:** {manifest.gmat_run_version}",
+        f"- **GMAT install:** {manifest.gmat_install_version}",
+        f"- **Python:** {manifest.python_version}",
+        f"- **OS at sweep time:** {manifest.os_platform}",
+        f"- **Backend:** {manifest.backend}",
+        "",
+        "## Layout",
+        "",
+        "```",
+        "bundle/",
+        "|-- README.md           (this file)",
+        f"|-- {script_member}",
+        "|-- manifest.jsonl      (paths rewritten to be bundle-relative)",
+        "|-- MANIFEST.hash       (sha256sum -c compatible)",
+        "`-- runs/run-<id>/...   (per-run Parquet outputs)",
+        "```",
+        "",
+        log_note,
+        "",
+        "## Reproducing the sweep",
+        "",
+        "Unzip the bundle, then from the unzip directory:",
+        "",
+        "```bash",
+        "# One-line summary of the manifest:",
+        "gmat-sweep show manifest.jsonl",
+        "",
+        "# Re-run only the failed and missing runs:",
+        f"gmat-sweep resume manifest.jsonl --script {script_member}",
+        "```",
+        "",
+        "Or from Python:",
+        "",
+        "```python",
+        "from pathlib import Path",
+        "from gmat_sweep import Sweep",
+        "from gmat_sweep.backends import LocalJoblibPool",
+        "",
+        "with LocalJoblibPool() as pool:",
+        "    sweep = Sweep.from_manifest(",
+        '        Path("manifest.jsonl"),',
+        f'        Path("{script_member}"),',
+        "        backend=pool,",
+        "    ).resume()",
+        "    df = sweep.to_dataframe()",
+        "```",
+        "",
+        "## Verifying integrity",
+        "",
+        "From the unzip directory:",
+        "",
+        "```bash",
+        "sha256sum -c MANIFEST.hash",
+        "```",
+    ]
+    return "\n".join(lines) + "\n"

--- a/src/gmat_sweep/archive.py
+++ b/src/gmat_sweep/archive.py
@@ -160,10 +160,31 @@ def _clone_manifest_with_entries(manifest: Manifest, entries: list[ManifestEntry
 
 
 def _serialise_manifest(manifest: Manifest) -> bytes:
-    """Serialise a manifest header + entries as one trailing-newline-terminated JSONL blob."""
+    """Serialise a manifest header + entries as one trailing-newline-terminated JSONL blob.
+
+    Path values in entries go through :meth:`Path.as_posix` so the bundled
+    manifest carries forward-slash paths on every host — :class:`Path` on
+    Windows is a :class:`WindowsPath` whose ``str`` uses backslashes, which
+    would otherwise leak ``runs\\run-0\\foo`` into a deposit.
+    """
     lines = [json.dumps(manifest._header_dict(), sort_keys=True)]
-    lines.extend(json.dumps(e.to_dict(), sort_keys=True) for e in manifest.entries)
+    lines.extend(json.dumps(_entry_to_posix_dict(e), sort_keys=True) for e in manifest.entries)
     return ("\n".join(lines) + "\n").encode("utf-8")
+
+
+def _entry_to_posix_dict(entry: ManifestEntry) -> dict[str, object]:
+    """Mirror :meth:`ManifestEntry.to_dict` but force POSIX-style path strings."""
+    return {
+        "run_id": entry.run_id,
+        "overrides": dict(entry.overrides),
+        "status": entry.status,
+        "output_paths": {k: Path(v).as_posix() for k, v in entry.output_paths.items()},
+        "started_at": entry.started_at.isoformat(),
+        "ended_at": entry.ended_at.isoformat(),
+        "duration_s": entry.duration_s,
+        "stderr": entry.stderr,
+        "log_path": None if entry.log_path is None else Path(entry.log_path).as_posix(),
+    }
 
 
 def _collect_run_members(

--- a/src/gmat_sweep/cli.py
+++ b/src/gmat_sweep/cli.py
@@ -483,6 +483,35 @@ def _cmd_explicit(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
+def _cmd_archive(args: argparse.Namespace) -> int:
+    manifest_path = Path(args.manifest)
+    if not manifest_path.is_file():
+        print(f"gmat-sweep: manifest not found: {manifest_path}", file=sys.stderr)
+        return EXIT_MANIFEST
+    script = Path(args.script)
+    if not script.is_file():
+        print(f"gmat-sweep: script not found: {script}", file=sys.stderr)
+        return EXIT_CONFIG
+
+    from gmat_sweep import __version__ as sweep_version
+    from gmat_sweep.archive import _archive_sweep
+
+    manifest = Manifest.load(manifest_path)
+    out = Path(args.out)
+    bundle = _archive_sweep(
+        manifest=manifest,
+        output_dir=manifest_path.parent,
+        script_path=script,
+        out=out,
+        include_logs=args.include_logs,
+        sweep_version=sweep_version,
+        allow_script_drift=args.allow_script_drift,
+    )
+    print(_format_summary(manifest, manifest_path.parent))
+    print(f"archive: {bundle}")
+    return EXIT_OK
+
+
 def _cmd_resume(args: argparse.Namespace) -> int:
     manifest_path = Path(args.manifest)
     if not manifest_path.is_file():
@@ -816,6 +845,57 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     _add_backend_flag(resume)
     resume.set_defaults(func=_cmd_resume)
+
+    archive = subparsers.add_parser(
+        "archive",
+        help="Pack a finished sweep into a portable .zip for archival deposit.",
+        description=(
+            "Bundle a sweep's script, manifest, and per-run Parquet outputs into "
+            "a single .zip suitable for Zenodo / JOSS deposit or internal handoff. "
+            "Output paths in the bundled manifest are rewritten to be bundle-"
+            "relative; a sha256sum-compatible MANIFEST.hash and a generated "
+            "README.md describing how to resume the sweep are also included."
+        ),
+    )
+    archive.add_argument(
+        "manifest",
+        metavar="MANIFEST",
+        help="Path to a manifest.jsonl produced by a prior sweep.",
+    )
+    archive.add_argument(
+        "--script",
+        required=True,
+        metavar="PATH",
+        help=(
+            "Path to the same GMAT .script the sweep loaded. Its canonical "
+            "SHA-256 must equal the manifest's script_sha256 unless "
+            "--allow-script-drift is set."
+        ),
+    )
+    archive.add_argument(
+        "--out",
+        required=True,
+        metavar="PATH",
+        help="Destination .zip path. Parent directories are created on demand.",
+    )
+    archive.add_argument(
+        "--include-logs",
+        action="store_true",
+        help=(
+            "Bundle per-run worker.log files alongside the Parquet outputs. "
+            "Default is to drop them so the archive stays small; the manifest's "
+            "log_path field is set to null in that case."
+        ),
+    )
+    archive.add_argument(
+        "--allow-script-drift",
+        action="store_true",
+        help=(
+            "Proceed even if the script's canonical hash differs from the "
+            "manifest's. The bundle still records the manifest's original hash."
+        ),
+    )
+    archive.set_defaults(func=_cmd_archive)
 
     return parser
 

--- a/src/gmat_sweep/sweep.py
+++ b/src/gmat_sweep/sweep.py
@@ -308,6 +308,47 @@ class Sweep:
             raise RuntimeError("Sweep.to_manifest requires Sweep.run() to have been called")
         return self._manifest
 
+    def archive(
+        self,
+        out: str | Path,
+        *,
+        include_logs: bool = False,
+    ) -> Path:
+        """Pack the sweep — script, manifest, per-run Parquets — into a ``.zip``.
+
+        The bundle is suitable for archival deposit (Zenodo, JOSS supplementary
+        material) or internal handoff. Layout, path-rewrite rules, and the
+        accompanying ``MANIFEST.hash`` are documented in
+        :mod:`gmat_sweep.archive`.
+
+        Parameters
+        ----------
+        out:
+            Destination ``.zip`` path. Parent directories are created on demand.
+        include_logs:
+            When ``True``, every per-run ``worker.log`` is bundled and the
+            manifest's ``log_path`` field continues to point at it (rewritten
+            to bundle-relative form). The default ``False`` drops the logs and
+            sets ``log_path`` to ``None`` in the bundled manifest, keeping the
+            archive small.
+
+        Returns
+        -------
+        Path
+            The resolved path to the produced ``.zip``.
+        """
+        from gmat_sweep import __version__ as sweep_version
+        from gmat_sweep.archive import _archive_sweep
+
+        return _archive_sweep(
+            manifest=self.to_manifest(),
+            output_dir=self._output_dir,
+            script_path=self._script_path,
+            out=Path(out),
+            include_logs=include_logs,
+            sweep_version=sweep_version,
+        )
+
     def to_dataframe(self, name: str | None = None) -> pd.DataFrame:
         """Aggregate the sweep's ``ReportFile`` outputs into one DataFrame.
 

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,0 +1,329 @@
+"""Sweep.archive end-to-end: layout, hash file, log toggle, and resume round-trip."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import zipfile
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pandas as pd
+import pytest
+
+from gmat_sweep.api import sweep
+from gmat_sweep.backends.joblib import LocalJoblibPool
+from gmat_sweep.errors import SweepConfigError
+from gmat_sweep.manifest import Manifest
+from gmat_sweep.sweep import Sweep
+from tests.conftest import FakeGmatRun, FakeMission, FakeResults
+
+
+def _write_script(tmp_path: Path) -> Path:
+    path = tmp_path / "mission.script"
+    path.write_text("% GMAT mission\nCreate Spacecraft Sat;\n", encoding="utf-8")
+    return path
+
+
+def _install_sma_echoing_loader(fake_gmat_run: FakeGmatRun) -> None:
+    """Load each run's Sat.SMA into the report ``x`` column so frames carry per-run signal."""
+
+    def _load(path: Any, **_: Any) -> FakeMission:
+        mission = FakeMission(script_path=Path(path))
+
+        def _run(**_kwargs: Any) -> FakeResults:
+            sma = next(v for k, v in mission.overrides_log if k == "Sat.SMA")
+            payload = pd.DataFrame(
+                {"time": pd.to_datetime(["2026-05-04T00:00:00"]), "x": [float(sma)]}
+            )
+            return FakeResults(reports={"R": payload})
+
+        mission.run_hook = _run
+        fake_gmat_run.last_mission = mission
+        return mission
+
+    fake_gmat_run.module.Mission = SimpleNamespace(load=_load)  # type: ignore[attr-defined]
+
+
+def _run_grid(*, script: Path, out: Path, n: int = 16, fake_gmat_run: FakeGmatRun) -> Sweep:
+    _install_sma_echoing_loader(fake_gmat_run)
+    grid_values = [7000.0 + i for i in range(n)]
+    with LocalJoblibPool(workers=1) as pool:
+        sweep_obj = Sweep(
+            runs=__import__(
+                "gmat_sweep.grids", fromlist=["expand_grid_to_run_specs"]
+            ).expand_grid_to_run_specs({"Sat.SMA": grid_values}, script, out),
+            backend=pool,
+            manifest_path=out / "manifest.jsonl",
+            output_dir=out,
+            script_path=script,
+            parameter_spec={"_kind": "grid", "Sat.SMA": grid_values},
+            progress=False,
+        ).run()
+    return sweep_obj
+
+
+def _list_zip(path: Path) -> list[str]:
+    with zipfile.ZipFile(path) as zf:
+        return sorted(zf.namelist())
+
+
+# ---- Layout & manifest rewrite -------------------------------------------
+
+
+def test_archive_emits_expected_layout(tmp_path: Path, fake_gmat_run: FakeGmatRun) -> None:
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+    sweep_obj = _run_grid(script=script, out=out, n=4, fake_gmat_run=fake_gmat_run)
+
+    bundle = sweep_obj.archive(tmp_path / "bundle.zip")
+    assert bundle == tmp_path / "bundle.zip"
+
+    names = _list_zip(bundle)
+    assert "README.md" in names
+    assert "manifest.jsonl" in names
+    assert "MANIFEST.hash" in names
+    assert "script/mission.script" in names
+    for run_id in range(4):
+        assert f"runs/run-{run_id}/report__R.parquet" in names
+    # No worker logs by default.
+    assert not any(name.endswith("/worker.log") for name in names)
+
+
+def test_bundled_manifest_has_relative_paths_and_no_logs_by_default(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+    sweep_obj = _run_grid(script=script, out=out, n=3, fake_gmat_run=fake_gmat_run)
+
+    bundle = sweep_obj.archive(tmp_path / "bundle.zip")
+    with zipfile.ZipFile(bundle) as zf:
+        raw = zf.read("manifest.jsonl").decode("utf-8")
+
+    lines = [json.loads(line) for line in raw.splitlines()]
+    header, *entries = lines
+    assert header["script_sha256"] == sweep_obj.to_manifest().script_sha256
+
+    for entry in entries:
+        for path in entry["output_paths"].values():
+            assert not Path(path).is_absolute()
+            assert path.startswith(f"runs/run-{entry['run_id']}/")
+        assert entry["log_path"] is None
+
+
+def test_archive_include_logs_bundles_logs_and_keeps_log_path(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+    sweep_obj = _run_grid(script=script, out=out, n=2, fake_gmat_run=fake_gmat_run)
+
+    bundle = sweep_obj.archive(tmp_path / "with-logs.zip", include_logs=True)
+    names = _list_zip(bundle)
+    assert "runs/run-0/worker.log" in names
+    assert "runs/run-1/worker.log" in names
+
+    with zipfile.ZipFile(bundle) as zf:
+        raw = zf.read("manifest.jsonl").decode("utf-8")
+    entries = [json.loads(line) for line in raw.splitlines()[1:]]
+    assert entries[0]["log_path"] == f"runs/run-{entries[0]['run_id']}/worker.log"
+
+
+# ---- MANIFEST.hash format ------------------------------------------------
+
+
+def test_manifest_hash_file_matches_sha256sum_format(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+    sweep_obj = _run_grid(script=script, out=out, n=2, fake_gmat_run=fake_gmat_run)
+
+    bundle = sweep_obj.archive(tmp_path / "bundle.zip")
+    with zipfile.ZipFile(bundle) as zf:
+        hash_lines = zf.read("MANIFEST.hash").decode("utf-8").splitlines()
+        recorded = {}
+        for line in hash_lines:
+            digest, _, name = line.partition("  ")
+            recorded[name] = digest
+            assert len(digest) == 64
+
+        # Every member except MANIFEST.hash is covered, and digests match.
+        for name in zf.namelist():
+            if name == "MANIFEST.hash":
+                assert name not in recorded
+                continue
+            assert recorded[name] == hashlib.sha256(zf.read(name)).hexdigest()
+
+
+# ---- Determinism: API and CLI produce byte-equal bundles ------------------
+
+
+def test_two_archives_of_same_sweep_are_byte_equal(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+    sweep_obj = _run_grid(script=script, out=out, n=4, fake_gmat_run=fake_gmat_run)
+
+    a = sweep_obj.archive(tmp_path / "a.zip")
+    b = sweep_obj.archive(tmp_path / "b.zip")
+    assert a.read_bytes() == b.read_bytes()
+
+
+# ---- DoD: 16-run grid round-trips bit-equal across archive + resume -------
+
+
+def test_16_run_grid_archive_and_resume_yields_bit_equal_dataframe(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    """The headline acceptance test from the issue: a 16-run grid sweep,
+    archived and then unzipped, resumes to a DataFrame bit-equal to the
+    original aggregated frame."""
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+    sweep_obj = _run_grid(script=script, out=out, n=16, fake_gmat_run=fake_gmat_run)
+    original = sweep_obj.to_dataframe()
+
+    bundle = sweep_obj.archive(tmp_path / "bundle.zip")
+
+    extracted = tmp_path / "extracted"
+    with zipfile.ZipFile(bundle) as zf:
+        zf.extractall(extracted)
+
+    with LocalJoblibPool(workers=1) as pool:
+        resumed = (
+            Sweep.from_manifest(
+                extracted / "manifest.jsonl",
+                extracted / "script" / "mission.script",
+                backend=pool,
+                progress=False,
+            )
+            .resume()
+            .to_dataframe()
+        )
+
+    pd.testing.assert_frame_equal(resumed, original)
+
+
+# ---- Failure / skip path: no Parquet, manifest entry preserved ------------
+
+
+def test_failed_runs_are_packed_without_parquet_with_stderr_intact(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+
+    failing = {7002.0}
+
+    def _setitem(_key: str, value: Any) -> None:
+        if value in failing:
+            raise ValueError("rejected by GMAT")
+
+    def _load(path: Any, **_: Any) -> FakeMission:
+        def _run(**_kwargs: Any) -> FakeResults:
+            return FakeResults(
+                reports={
+                    "R": pd.DataFrame({"time": pd.to_datetime(["2026-05-04T00:00:00"]), "x": [1.0]})
+                }
+            )
+
+        mission = FakeMission(script_path=Path(path), setitem_hook=_setitem, run_hook=_run)
+        fake_gmat_run.last_mission = mission
+        return mission
+
+    fake_gmat_run.module.Mission = SimpleNamespace(load=_load)  # type: ignore[attr-defined]
+
+    sweep(
+        script,
+        grid={"Sat.SMA": [7000.0, 7001.0, 7002.0, 7003.0]},
+        backend=LocalJoblibPool(workers=1),
+        out=out,
+        progress=False,
+    )
+
+    pre = Manifest.load(out / "manifest.jsonl")
+    failed = pre.find_failed()
+    assert len(failed) == 1
+    failed_run_id = failed[0]
+
+    with LocalJoblibPool(workers=1) as pool:
+        loaded_sweep = Sweep.from_manifest(
+            out / "manifest.jsonl", script, backend=pool, progress=False
+        )
+    bundle = loaded_sweep.archive(tmp_path / "bundle.zip")
+
+    names = _list_zip(bundle)
+    assert not any(f"runs/run-{failed_run_id}/report__" in name for name in names)
+
+    with zipfile.ZipFile(bundle) as zf:
+        entries = [
+            json.loads(line) for line in zf.read("manifest.jsonl").decode("utf-8").splitlines()[1:]
+        ]
+    failed_entry = next(e for e in entries if e["run_id"] == failed_run_id)
+    assert failed_entry["status"] == "failed"
+    assert "rejected by GMAT" in failed_entry["stderr"]
+
+
+# ---- Drift handling -------------------------------------------------------
+
+
+def test_archive_refuses_when_script_hash_drifts(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+    sweep_obj = _run_grid(script=script, out=out, n=2, fake_gmat_run=fake_gmat_run)
+
+    script.write_text("% mutated\nCreate Spacecraft Sat;\n", encoding="utf-8")
+
+    with pytest.raises(SweepConfigError, match="script hash mismatch"):
+        sweep_obj.archive(tmp_path / "bundle.zip")
+
+
+def test_archive_before_run_raises_runtime_error(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    script = _write_script(tmp_path)
+    _install_sma_echoing_loader(fake_gmat_run)
+    from gmat_sweep.grids import expand_grid_to_run_specs
+
+    out = tmp_path / "out"
+    out.mkdir()
+    runs = expand_grid_to_run_specs({"Sat.SMA": [7000.0, 7001.0]}, script, out)
+
+    with LocalJoblibPool(workers=1) as pool:
+        sweep_obj = Sweep(
+            runs=runs,
+            backend=pool,
+            manifest_path=out / "manifest.jsonl",
+            output_dir=out,
+            script_path=script,
+            parameter_spec={"_kind": "grid", "Sat.SMA": [7000.0, 7001.0]},
+            progress=False,
+        )
+        with pytest.raises(RuntimeError, match=r"Sweep\.run"):
+            sweep_obj.archive(tmp_path / "bundle.zip")
+
+
+# ---- Generated README -----------------------------------------------------
+
+
+def test_generated_readme_includes_summary_and_resume_recipe(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+    sweep_obj = _run_grid(script=script, out=out, n=3, fake_gmat_run=fake_gmat_run)
+
+    bundle = sweep_obj.archive(tmp_path / "bundle.zip")
+    with zipfile.ZipFile(bundle) as zf:
+        readme = zf.read("README.md").decode("utf-8")
+
+    assert "3 ok" in readme
+    assert "Script SHA-256" in readme
+    assert "gmat-sweep resume manifest.jsonl --script script/mission.script" in readme
+    assert "sha256sum -c MANIFEST.hash" in readme

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1188,6 +1188,208 @@ def test_resume_help_lists_allow_script_drift(capsys: pytest.CaptureFixture[str]
     assert "--script" in out
 
 
+# ---- archive subcommand -------------------------------------------------
+
+
+def test_archive_writes_zip_and_matches_api(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The CLI archive output must be byte-equal to the Sweep.archive output —
+    proves the CLI is a thin wrapper and that bundles are deterministic."""
+    import zipfile
+
+    from gmat_sweep.sweep import Sweep
+
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+    rc = cli.main(
+        [
+            "run",
+            "--grid",
+            "Sat.SMA=7000:8000:3",
+            "--workers",
+            "1",
+            "--out",
+            str(out),
+            str(script),
+        ]
+    )
+    assert rc == 0
+    capsys.readouterr()
+
+    cli_bundle = tmp_path / "cli.zip"
+    rc = cli.main(
+        [
+            "archive",
+            str(out / "manifest.jsonl"),
+            "--script",
+            str(script),
+            "--out",
+            str(cli_bundle),
+        ]
+    )
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "3 runs" in captured.out
+    assert str(cli_bundle) in captured.out
+    assert cli_bundle.is_file()
+
+    with zipfile.ZipFile(cli_bundle) as zf:
+        names = sorted(zf.namelist())
+    assert "manifest.jsonl" in names
+    assert "MANIFEST.hash" in names
+    assert "script/mission.script" in names
+
+    # API and CLI produce byte-equal bundles for the same manifest.
+    with LocalJoblibPool(workers=1) as pool:
+        api_sweep = Sweep.from_manifest(
+            out / "manifest.jsonl", script, backend=pool, progress=False
+        )
+    api_bundle = api_sweep.archive(tmp_path / "api.zip")
+    assert cli_bundle.read_bytes() == api_bundle.read_bytes()
+
+
+def test_archive_include_logs_bundles_logs(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import zipfile
+
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+    cli.main(
+        [
+            "run",
+            "--grid",
+            "Sat.SMA=7000,7100",
+            "--workers",
+            "1",
+            "--out",
+            str(out),
+            str(script),
+        ]
+    )
+    capsys.readouterr()
+
+    bundle = tmp_path / "with-logs.zip"
+    rc = cli.main(
+        [
+            "archive",
+            str(out / "manifest.jsonl"),
+            "--script",
+            str(script),
+            "--out",
+            str(bundle),
+            "--include-logs",
+        ]
+    )
+    assert rc == 0
+    with zipfile.ZipFile(bundle) as zf:
+        names = zf.namelist()
+    assert any(name.endswith("/worker.log") for name in names)
+
+
+def test_archive_on_missing_manifest_exits_manifest_code(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    script = _write_script(tmp_path)
+    rc = cli.main(
+        [
+            "archive",
+            str(tmp_path / "no-such-manifest.jsonl"),
+            "--script",
+            str(script),
+            "--out",
+            str(tmp_path / "bundle.zip"),
+        ]
+    )
+    assert rc == cli.EXIT_MANIFEST
+    assert "not found" in capsys.readouterr().err
+
+
+def test_archive_on_missing_script_exits_config_code(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun, capsys: pytest.CaptureFixture[str]
+) -> None:
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+    cli.main(
+        [
+            "run",
+            "--grid",
+            "a=1,2",
+            "--workers",
+            "1",
+            "--out",
+            str(out),
+            str(script),
+        ]
+    )
+    capsys.readouterr()
+
+    rc = cli.main(
+        [
+            "archive",
+            str(out / "manifest.jsonl"),
+            "--script",
+            str(tmp_path / "does-not-exist.script"),
+            "--out",
+            str(tmp_path / "bundle.zip"),
+        ]
+    )
+    assert rc == cli.EXIT_CONFIG
+    assert "script not found" in capsys.readouterr().err
+
+
+def test_archive_rejects_script_drift(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun, capsys: pytest.CaptureFixture[str]
+) -> None:
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+    cli.main(
+        [
+            "run",
+            "--grid",
+            "a=1,2",
+            "--workers",
+            "1",
+            "--out",
+            str(out),
+            str(script),
+        ]
+    )
+    capsys.readouterr()
+
+    script.write_text(
+        "% GMAT mission\nCreate Spacecraft Sat;\nCreate ForceModel FM;\n", encoding="utf-8"
+    )
+
+    rc = cli.main(
+        [
+            "archive",
+            str(out / "manifest.jsonl"),
+            "--script",
+            str(script),
+            "--out",
+            str(tmp_path / "bundle.zip"),
+        ]
+    )
+    assert rc == cli.EXIT_CONFIG
+    assert "script hash mismatch" in capsys.readouterr().err
+
+
+def test_archive_help_lists_flags(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["archive", "--help"])
+    assert exc_info.value.code == 0
+    out = capsys.readouterr().out
+    assert "--include-logs" in out
+    assert "--allow-script-drift" in out
+    assert "--out" in out
+
+
 # ---- _parse_backend_arg -------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

- New `Sweep.archive(out, *, include_logs=False) -> Path` and `gmat-sweep archive MANIFEST --out bundle.zip [--include-logs] [--allow-script-drift]` CLI subcommand that pack a finished sweep — script, manifest, per-run Parquet outputs, generated reproduce-recipe README, and a `sha256sum`-compatible `MANIFEST.hash` — into one deterministic `.zip`.
- Bundled manifest's `output_paths`/`log_path` are rewritten to bundle-relative `runs/run-<id>/<basename>` so the aggregator resolves them against the unzip directory; `ZipInfo` timestamps and member ordering are pinned so two archives of the same manifest are byte-equal.
- Cookbook gains a new **Pattern 4 — Archival deposit (Zenodo / JOSS)** section with a worked example for both the API and CLI flows.

## Bundle layout

```
bundle.zip
|-- README.md            generated reproduce recipe + manifest summary
|-- script/<name>        copy of the .script the manifest references
|-- manifest.jsonl       paths rewritten to be bundle-relative
|-- MANIFEST.hash        sha256sum -c compatible
`-- runs/run-<id>/...    per-run Parquets (and worker.log if --include-logs)
```

## Test plan

- [x] `uv run pytest tests/test_archive.py` — 10 tests, including the issue's headline DoD: 16-run grid → archive → unzip → `Sweep.from_manifest(...).resume().to_dataframe()` is bit-equal to the original aggregated frame.
- [x] `uv run pytest tests/test_cli.py` — covers the new `archive` subcommand including the byte-equal CLI ↔ API equivalence assertion.
- [x] `uv run pytest tests/test_recipe_snippets.py` — the new cookbook code blocks compile.
- [x] `uv run pytest -m "not integration"` — 577 passed, 8 optional-extra skips, no regressions.
- [x] `uv run ruff check` and `uv run ruff format --check`.
- [x] `uv run mypy src/gmat_sweep tests` (strict) — 68 files clean.
- [x] `uv run --group docs mkdocs build --strict`.
- [ ] Real-GMAT integration smoke (`tests/test_reference_sweep.py`) — not run in this WSL env; will rely on CI.

Closes #93