### PR TITLE
Resolve sweep out= paths to absolute; add smoke-canary-image CI cell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,15 +347,23 @@ jobs:
       # step below; the explicit `__status=="failed"` check fails the cell
       # on any captured run failure (the API itself never raises on a single
       # failed run — it lands as a `failed` row).
+      # `out=` is passed straight through to gmat-run as `working_dir`, which
+      # the GMAT API resolves against the image's baked-in `OUTPUT_PATH`
+      # (`/opt/gmat/output/` in `gmat_startup_file.txt`). A relative path here
+      # would land at `/opt/gmat/output/<rel>/sat.report` — a directory that
+      # doesn't exist and isn't writable. Resolving to an absolute path
+      # under `$PWD` sidesteps that without touching the image config.
       - name: Vision-snippet grid sweep
         run: |
           python - <<'PY'
+          from pathlib import Path
+
           from gmat_sweep import sweep
 
           df = sweep(
               "tests/data/leo_basic.script",
               grid={"Sat.SMA": [7000, 7100, 7200]},
-              out="./grid-out",
+              out=Path("./grid-out").resolve(),
           )
           print(df)
           if (df["__status"] == "failed").any():
@@ -364,6 +372,8 @@ jobs:
       - name: 4-run monte_carlo
         run: |
           python - <<'PY'
+          from pathlib import Path
+
           from gmat_sweep import monte_carlo
 
           df = monte_carlo(
@@ -371,7 +381,7 @@ jobs:
               n=4,
               perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
               seed=42,
-              out="./mc-out",
+              out=Path("./mc-out").resolve(),
           )
           print(df)
           if (df["__status"] == "failed").any():

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,3 +316,68 @@ jobs:
         run: kubectl apply -f tests/k8s/sweep-pvc.yaml
       - run: uv sync --all-groups --extra k8s
       - run: uv run pytest tests/test_backend_equivalence.py tests/test_backend_throughput.py -m "integration and slow" -k "k8s" -s
+
+  # Smoke-canary against the canonical `ghcr.io/astro-tools/gmat:Rxxxxa` image.
+  # The image carries a verbatim GMAT install with gmatpy importable in pyenv-
+  # managed Python 3.10/3.11/3.12; running the four-line vision snippet plus a
+  # short Monte Carlo inside it is the cheapest signal that the in-tree
+  # `gmat-sweep` and the published image are still ABI/runtime-compatible.
+  # Each GMAT tag gets its own cell. The image is consumed verbatim — no
+  # apt installs, no startup-file edits, no plugin strips.
+  smoke-canary-image:
+    name: smoke canary (${{ matrix.gmat-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        gmat-version: [R2025a, R2026a]
+    container:
+      image: ghcr.io/astro-tools/gmat:${{ matrix.gmat-version }}
+    steps:
+      - uses: actions/checkout@v4
+      # Editable install against the image's default Python (3.12, first in
+      # the image's `pyenv global` list). `[dask,ray]` matches the extras
+      # combination the matrix `test:` cell uses, so the canary exercises
+      # the same import surface a real user would land on.
+      - name: Install gmat-sweep with dask + ray extras
+        run: pip install -e ".[dask,ray]"
+      # Mirrors `docs/getting-started.md` "four-line vision snippet" against
+      # the in-tree LEO fixture. `out=...` keeps the manifest for the show
+      # step below; the explicit `__status=="failed"` check fails the cell
+      # on any captured run failure (the API itself never raises on a single
+      # failed run — it lands as a `failed` row).
+      - name: Vision-snippet grid sweep
+        run: |
+          python - <<'PY'
+          from gmat_sweep import sweep
+
+          df = sweep(
+              "tests/data/leo_basic.script",
+              grid={"Sat.SMA": [7000, 7100, 7200]},
+              out="./grid-out",
+          )
+          print(df)
+          if (df["__status"] == "failed").any():
+              raise SystemExit("smoke-canary: grid sweep produced failed runs")
+          PY
+      - name: 4-run monte_carlo
+        run: |
+          python - <<'PY'
+          from gmat_sweep import monte_carlo
+
+          df = monte_carlo(
+              "tests/data/leo_basic.script",
+              n=4,
+              perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
+              seed=42,
+              out="./mc-out",
+          )
+          print(df)
+          if (df["__status"] == "failed").any():
+              raise SystemExit("smoke-canary: monte_carlo produced failed runs")
+          PY
+      - name: gmat-sweep show
+        run: |
+          gmat-sweep show ./grid-out/manifest.jsonl
+          gmat-sweep show ./mc-out/manifest.jsonl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,23 +347,15 @@ jobs:
       # step below; the explicit `__status=="failed"` check fails the cell
       # on any captured run failure (the API itself never raises on a single
       # failed run — it lands as a `failed` row).
-      # `out=` is passed straight through to gmat-run as `working_dir`, which
-      # the GMAT API resolves against the image's baked-in `OUTPUT_PATH`
-      # (`/opt/gmat/output/` in `gmat_startup_file.txt`). A relative path here
-      # would land at `/opt/gmat/output/<rel>/sat.report` — a directory that
-      # doesn't exist and isn't writable. Resolving to an absolute path
-      # under `$PWD` sidesteps that without touching the image config.
       - name: Vision-snippet grid sweep
         run: |
           python - <<'PY'
-          from pathlib import Path
-
           from gmat_sweep import sweep
 
           df = sweep(
               "tests/data/leo_basic.script",
               grid={"Sat.SMA": [7000, 7100, 7200]},
-              out=Path("./grid-out").resolve(),
+              out="./grid-out",
           )
           print(df)
           if (df["__status"] == "failed").any():
@@ -372,8 +364,6 @@ jobs:
       - name: 4-run monte_carlo
         run: |
           python - <<'PY'
-          from pathlib import Path
-
           from gmat_sweep import monte_carlo
 
           df = monte_carlo(
@@ -381,7 +371,7 @@ jobs:
               n=4,
               perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
               seed=42,
-              out=Path("./mc-out").resolve(),
+              out="./mc-out",
           )
           print(df)
           if (df["__status"] == "failed").any():

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,3 +381,20 @@ jobs:
         run: |
           gmat-sweep show ./grid-out/manifest.jsonl
           gmat-sweep show ./mc-out/manifest.jsonl
+      # Always-run diagnostic: on a failed cell, dump the per-run details
+      # (`--detail` orders failed rows first) plus the raw manifest so the
+      # captured GMAT stderr is visible in the job log without needing to
+      # download artefacts. No-op on a green cell beyond extra log lines.
+      - name: Diagnostics on failure
+        if: failure()
+        run: |
+          for d in grid-out mc-out; do
+            echo "===== $d ====="
+            if [ -f "./$d/manifest.jsonl" ]; then
+              gmat-sweep show --detail "./$d/manifest.jsonl" || true
+              echo "----- raw $d/manifest.jsonl -----"
+              cat "./$d/manifest.jsonl"
+            else
+              echo "no manifest at ./$d/manifest.jsonl"
+            fi
+          done

--- a/src/gmat_sweep/api.py
+++ b/src/gmat_sweep/api.py
@@ -39,7 +39,7 @@ def sweep(
     grid: Mapping[str, Iterable[Any]] | None = None,
     samples: pd.DataFrame | None = None,
     backend: Pool | None = None,
-    out: Path | None = None,
+    out: str | Path | None = None,
     seed: int | None = None,
     progress: bool = True,
 ) -> pd.DataFrame:
@@ -84,7 +84,10 @@ def sweep(
         returned DataFrame — the temp dir survives until the caller drops the
         DataFrame, mirroring the :meth:`gmat_run.Mission.run` Results lifetime
         trick. Pass an explicit path to keep the per-run Parquet files and
-        the manifest after the call returns.
+        the manifest after the call returns. Relative paths are resolved to
+        absolute before per-run directories are created, so manifest entries
+        and the ``working_dir`` handed to GMAT do not depend on the caller's
+        CWD or on GMAT's installed ``OUTPUT_PATH``.
     seed:
         Optional integer recorded on the manifest header. ``sweep()`` itself
         does not consume it for grid or explicit-row sweeps; the value lives
@@ -165,7 +168,7 @@ def monte_carlo(
     perturb: Mapping[str, DistSpec],
     seed: int | None = None,
     backend: Pool | None = None,
-    out: Path | None = None,
+    out: str | Path | None = None,
     progress: bool = True,
 ) -> pd.DataFrame:
     """Run a Monte Carlo dispersion sweep over a GMAT mission.
@@ -245,7 +248,7 @@ def latin_hypercube(
     perturb: Mapping[str, DistSpec],
     seed: int | None = None,
     backend: Pool | None = None,
-    out: Path | None = None,
+    out: str | Path | None = None,
     progress: bool = True,
 ) -> pd.DataFrame:
     """Run a Latin hypercube sweep over a GMAT mission.
@@ -337,7 +340,7 @@ def _run_sweep(
     parameter_spec: dict[str, Any],
     sweep_seed: int | None,
     backend: Pool | None,
-    out: Path | None,
+    out: str | Path | None,
     progress: bool,
 ) -> pd.DataFrame:
     """Shared orchestration for the public entry points.
@@ -355,7 +358,14 @@ def _run_sweep(
         output_dir = Path(tempdir.name)
     else:
         tempdir = None
-        output_dir = Path(out)
+        # `output_dir` becomes each `RunSpec.output_dir`, which is forwarded to
+        # `gmat_run.Mission.run(working_dir=...)` and ultimately to the GMAT
+        # API. GMAT resolves a relative `working_dir` against its installed
+        # `OUTPUT_PATH` (e.g. `/opt/gmat/output/` in the canonical container
+        # image), which is rarely what the caller wants. Resolve to absolute
+        # so per-run paths land where the user pointed regardless of GMAT's
+        # configured output root.
+        output_dir = Path(out).resolve()
         output_dir.mkdir(parents=True, exist_ok=True)
 
     runs = build_runs(output_dir)

--- a/src/gmat_sweep/sweep.py
+++ b/src/gmat_sweep/sweep.py
@@ -211,7 +211,11 @@ class Sweep:
             script hash drifted and ``allow_script_drift`` is ``False``, or
             the manifest's ``parameter_spec`` carries an unknown ``_kind``.
         """
-        manifest_path_obj = Path(manifest_path)
+        # Resolve to absolute so the derived `output_dir` (and every
+        # subsequent per-run path it seeds) is GMAT-safe. Matches the
+        # `_run_sweep` resolution on the fresh-sweep path; see the
+        # OUTPUT_PATH note there for why.
+        manifest_path_obj = Path(manifest_path).resolve()
         script_path_obj = Path(script_path)
         output_dir = manifest_path_obj.parent
         if not output_dir.exists():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -108,6 +108,28 @@ def test_sweep_creates_out_directory_when_missing(
     assert (out / "manifest.jsonl").exists()
 
 
+def test_sweep_resolves_relative_out_to_absolute(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # GMAT resolves a relative `working_dir` against its installed
+    # `OUTPUT_PATH` (e.g. `/opt/gmat/output/` in the canonical container
+    # image), so a relative `out=` would land per-run files somewhere
+    # other than where the user pointed. Public entry points must
+    # absolutise before per-run dirs are seeded.
+    script = _write_script(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    sweep(script, grid={"Sat.SMA": [7000.0]}, backend=LocalJoblibPool(workers=1), out="rel-out")
+
+    manifest_path = tmp_path / "rel-out" / "manifest.jsonl"
+    manifest = Manifest.load(manifest_path)
+    [entry] = manifest.entries
+    assert entry.log_path is not None
+    assert Path(entry.log_path).is_absolute()
+
+
 # ---- no out: temp dir lifetime --------------------------------------------
 
 


### PR DESCRIPTION
## Summary
- **Fix**: `sweep()` / `monte_carlo()` / `latin_hypercube()` and `Sweep.from_manifest` now resolve `out=` (or the manifest path) to absolute before per-run directories are seeded. A relative `out=` was forwarded into `gmat_run.Mission.run(working_dir=...)` and on into the GMAT API, which resolves a relative `working_dir` against its installed `OUTPUT_PATH` rather than the caller's CWD — fine on a `setup-gmat`-installed runner, broken on the canonical `ghcr.io/astro-tools/gmat` image where `OUTPUT_PATH` is baked to `/opt/gmat/output/`. Also widens the `out:` annotation on the three public wrappers from `Path | None` to `str | Path | None` so the documented `out="./sweep"` form matches the (already-permissive) runtime.
- **Canary**: new `smoke-canary-image` CI job, matrix `R2025a` / `R2026a`, runs every PR. Each cell uses the job-level `container:` directive to run inside `ghcr.io/astro-tools/gmat:<tag>`, `pip install -e ".[dask,ray]"`s the in-tree gmat-sweep, then drives the four-line vision-snippet grid sweep (with documented relative `out="./grid-out"`) plus a 4-run `monte_carlo`, finishing with `gmat-sweep show` on both manifests. Image is consumed verbatim — no apt installs, no startup-file edits. An `if: failure()` step dumps `gmat-sweep show --detail` plus the raw `manifest.jsonl` so any future drift surfaces with the captured GMAT stderr in the job log.

## How the canary did its job on day one
The first push of just the canary went red on both R2025a and R2026a — every grid run landed as `__status: failed`. The diagnostic dump showed `Subscriber Exception: Cannot open report file: /opt/gmat/output/grid-out/run-N/sat.report` — exactly the path-prepend behavior described above. The fix in this PR addresses the root cause; the canary then runs the documented form unchanged.

## Test plan
- [ ] CI: both `smoke canary (R2025a)` and `smoke canary (R2026a)` cells go green.
- [ ] CI: the existing `test (...)` matrix still goes green (the `out:` widening is backwards-compatible; the `_run_sweep` resolution preserves `mkdir(parents=True, exist_ok=True)`).
- [ ] Regression: new unit test `test_sweep_resolves_relative_out_to_absolute` confirms a relative `out=` produces an absolute manifest `log_path`.
- [ ] Sanity-check post-merge: pin `gmat-run` to a deliberately-too-low version on a throwaway branch and confirm the cell turns red — the deliberate-ABI-mismatch acceptance check from the issue's "Definition of done".

Closes #89
