### PR TITLE
Bump overall coverage gate to >=90%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,14 @@ jobs:
         # under `tests/test_backends_{dask,ray}.py` can spin up a real
         # `distributed.LocalCluster` / `ray.init()`. `--extra plot` so the
         # plotting-helper tests under `tests/test_plotting.py` can import
-        # matplotlib. The lint, typecheck, and minimal-install jobs
-        # deliberately keep their syncs narrower.
-        run: uv sync --all-groups --extra dask --extra ray --extra plot
+        # matplotlib. `--extra k8s` so the mock-based unit tests in
+        # `tests/test_backends_kubernetes.py` (which `pytest.importorskip`
+        # the kubernetes client) can run here and contribute to the
+        # coverage gate — the real-cluster k8s integration tests still
+        # live in the dedicated `backend-k8s` job below. The lint,
+        # typecheck, and minimal-install jobs deliberately keep their
+        # syncs narrower.
+        run: uv sync --all-groups --extra dask --extra ray --extra plot --extra k8s
 
       - name: Run pytest
         # `-m "(integration or not integration) and not slow"` overrides the
@@ -62,9 +67,9 @@ jobs:
       # data is identical across runners. The four per-file gates match
       # CONTRIBUTING.md.
 
-      - name: Enforce overall coverage (>=85%)
+      - name: Enforce overall coverage (>=90%)
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' && matrix.gmat-version == 'R2026a'
-        run: uv run coverage report --fail-under=85
+        run: uv run coverage report --fail-under=90
 
       - name: Enforce grids.py coverage (>=95%)
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' && matrix.gmat-version == 'R2026a'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,15 +45,18 @@ you are touching the worker, pool, or aggregation paths.
 
 CI enforces coverage gates on the Ubuntu / Python 3.12 cell:
 
-- Overall coverage must be ≥ 85%.
+- Overall coverage must be ≥ 90%.
 - Each of `src/gmat_sweep/grids.py`, `src/gmat_sweep/distributions.py`,
   `src/gmat_sweep/manifest.py`, and `src/gmat_sweep/aggregate.py` must be ≥ 95%.
 
-To reproduce locally:
+To reproduce locally, sync the same extras the gate cell installs (`--extra
+k8s` is needed alongside `dask`/`ray`/`plot` so the mock-based kubernetes
+backend tests run instead of skipping at `pytest.importorskip`):
 
 ```bash
+uv sync --all-groups --extra dask --extra ray --extra plot --extra k8s
 uv run pytest -m "integration or not integration" --cov
-uv run coverage report --fail-under=85
+uv run coverage report --fail-under=90
 uv run coverage report --include='src/gmat_sweep/grids.py' --fail-under=95
 uv run coverage report --include='src/gmat_sweep/distributions.py' --fail-under=95
 uv run coverage report --include='src/gmat_sweep/manifest.py' --fail-under=95


### PR DESCRIPTION
## Summary

- Bump the overall-coverage gate on the Ubuntu / Python 3.12 / R2026a cell from `>=85%` to `>=90%`.
- Add `--extra k8s` to the gate cell's `Install project` step so the existing mock-based unit tests in `tests/test_backends_kubernetes.py` (which `pytest.importorskip("kubernetes")`) run there and contribute to the combined coverage report instead of skipping. The real-cluster k8s integration tests still live in the dedicated `backend-k8s` job.
- Update `CONTRIBUTING.md` with the new gate value and a corrected reproducer (the `uv sync --all-groups --extra dask --extra ray --extra plot --extra k8s` line was missing).

Net effect on the gate cell: `backends/kubernetes.py` `0% -> 92%`, overall `87% -> 96%`. The four per-file 95% gates (`grids`, `distributions`, `manifest`, `aggregate`) are unchanged and still green (100% / 100% / 100% / 98% locally).

## Test plan

- [ ] CI's `Enforce overall coverage (>=90%)` step is green on the Ubuntu / py3.12 / R2026a matrix combination.
- [ ] All four `Enforce <module>.py coverage (>=95%)` steps are still green.
- [ ] The full matrix (`test (...)`, `lint`, `typecheck`, `minimal install smoke`, `backend-k8s`, `backend-throughput`, `backend-equivalence`, `backend-mpi`, `smoke-canary-image`) is green.

Closes #90