### PR TITLE
sweep_summary: per-time-step median/quantile band aggregator

### DIFF
--- a/docs/aggregation.md
+++ b/docs/aggregation.md
@@ -160,6 +160,72 @@ on small sweeps. The result frame is identical either way.
 are typically tiny (one row per pass) and the streaming overhead is not
 worth the knob.
 
+## Summarising across runs
+
+`gmat-sweep` returns one row per `(run_id, time)` — every run kept,
+every time step kept. The canonical next step for dispersion analysis
+is to collapse across runs at each time step into per-time
+statistics: median, 5th and 95th percentile, mean, std, and a count of
+ok contributions. [`sweep_summary`][gmat_sweep.sweep_summary] does
+exactly that and pairs with
+[`sweep_band_plot`][gmat_sweep.plotting.sweep_band_plot] (gated on the
+`[plot]` extra) for the matching figure.
+
+```python
+from pathlib import Path
+
+from gmat_sweep import Manifest, lazy_multiindex, sweep_summary
+from gmat_sweep.plotting import sweep_band_plot
+
+manifest = Manifest.load(Path("./sweep/manifest.jsonl"))
+df = lazy_multiindex(manifest, Path("./sweep"))
+
+# Default: per-time-step 5/50/95 + mean + std across runs.
+summary = sweep_summary(df)
+
+# (time, q=0.5) slice — the median Sat.X over time across all runs.
+median_x = summary[("q0.5", "Sat.X")]
+
+# Median + 5–95% band for Sat.X.
+ax = sweep_band_plot(summary, "Sat.X")
+ax.figure.savefig("sat_x_band.png")
+```
+
+### Output shape
+
+The result is a single DataFrame whose row index is the unique values
+of the `by` level and whose column index is a two-level
+`pandas.MultiIndex`:
+
+| Column | Meaning |
+|--------|---------|
+| `(statistic, field)` | one column per `(statistic, original-column)` pair |
+
+Statistic labels are exactly the entries of `include` followed by
+`f"q{q_val}"` for each requested quantile — e.g. `"mean"`, `"std"`,
+`"q0.05"`, `"q0.5"`, `"q0.95"` for the defaults. `count_ok` counts
+non-NaN values per group; useful for spotting time steps where many
+runs produced NaNs.
+
+### `by="time"` vs `by="run_id"`
+
+- `by="time"` (default) — collapse across runs at each time step. The
+  natural input for "median over time with a 5/95% band".
+- `by="run_id"` — collapse across time steps within each run. The
+  natural input for per-run summary metrics (e.g. mean Sat.X over the
+  whole trajectory).
+
+Other values raise `SweepConfigError`. Categorical groupings and
+arbitrary `by=` keys are intentionally out of scope in this release.
+
+### Failed and skipped runs
+
+By default (`dropna=True`) `sweep_summary` filters rows where
+`__status != "ok"` before aggregating, so failed and skipped runs are
+excluded from every statistic. Pass `dropna=False` to keep them — the
+NaT marker rows from non-ok runs land as a NaT-keyed group in the
+output (mostly NaN, with `count_ok` reflecting the contribution).
+
 ## Migrating from v0.1
 
 v0.1 used a bare `<name>.parquet` per-run layout and keyed

--- a/docs/api.md
+++ b/docs/api.md
@@ -64,6 +64,12 @@ auto-generated from docstrings via
 
 ::: gmat_sweep.lazy_fused_reports
 
+::: gmat_sweep.sweep_summary
+
+## Plotting
+
+::: gmat_sweep.plotting.sweep_band_plot
+
 ## Exceptions
 
 ::: gmat_sweep.GmatSweepError

--- a/src/gmat_sweep/__init__.py
+++ b/src/gmat_sweep/__init__.py
@@ -8,6 +8,7 @@ from gmat_sweep.aggregate import (
     lazy_ephemerides,
     lazy_fused_reports,
     lazy_multiindex,
+    sweep_summary,
 )
 from gmat_sweep.api import latin_hypercube, monte_carlo, sweep
 from gmat_sweep.backends import LocalJoblibPool, Pool
@@ -79,4 +80,5 @@ __all__ = [
     "lazy_multiindex",
     "monte_carlo",
     "sweep",
+    "sweep_summary",
 ]

--- a/src/gmat_sweep/aggregate.py
+++ b/src/gmat_sweep/aggregate.py
@@ -26,6 +26,10 @@ through pandas one fragment at a time so peak conversion memory is one
 batch, not one full sweep. ``spool=False`` flips to an eager
 fragment-at-a-time read for small sweeps where the streaming overhead is
 not worth it; the result DataFrame is identical.
+
+:func:`sweep_summary` collapses the parent DataFrame across runs into a
+per-``time`` (or per-``run_id``) statistics frame — the canonical input
+for "median +/- 95% band over time" dispersion plots.
 """
 
 from __future__ import annotations
@@ -45,7 +49,16 @@ if TYPE_CHECKING:
 
     from gmat_sweep.manifest import Manifest, ManifestEntry
 
-__all__ = ["lazy_contacts", "lazy_ephemerides", "lazy_fused_reports", "lazy_multiindex"]
+__all__ = [
+    "lazy_contacts",
+    "lazy_ephemerides",
+    "lazy_fused_reports",
+    "lazy_multiindex",
+    "sweep_summary",
+]
+
+_VALID_BY: tuple[str, ...] = ("time", "run_id")
+_VALID_INCLUDE: tuple[str, ...] = ("mean", "std", "min", "max", "count_ok")
 
 
 _RUN_ID_COL = "run_id"
@@ -565,3 +578,143 @@ def _empty_fused_frame(flat_to_tuple: dict[str, tuple[str, str]]) -> pd.DataFram
         ),
         columns=pd.MultiIndex.from_tuples(cols, names=["report", "field"]),
     )
+
+
+def sweep_summary(
+    df: pd.DataFrame,
+    *,
+    by: str = _TIME_COL,
+    q: Sequence[float] = (0.05, 0.5, 0.95),
+    include: Sequence[str] = ("mean", "std"),
+    dropna: bool = True,
+) -> pd.DataFrame:
+    """Summarise a sweep DataFrame across runs at each ``by`` key.
+
+    Turns a ``(run_id, time)``-MultiIndexed DataFrame — as returned by
+    :func:`lazy_multiindex`, :func:`gmat_sweep.sweep`,
+    :func:`gmat_sweep.monte_carlo`, or :func:`gmat_sweep.latin_hypercube`
+    — into a per-``by`` statistics frame: one row per unique ``by``
+    value, one column per ``(statistic, original-column)`` pair under a
+    two-level :class:`pandas.MultiIndex`. The default
+    ``q=(0.05, 0.5, 0.95)`` matches the standard 5/50/95 dispersion bands
+    and feeds directly into :func:`gmat_sweep.plotting.sweep_band_plot`.
+
+    Parameters
+    ----------
+    df
+        Input DataFrame indexed by ``(run_id, time)`` (or any other
+        2-level :class:`pandas.MultiIndex` whose levels include the
+        requested ``by`` key). A ``__status`` column, if present, is
+        treated as a per-run status flag and excluded from the statistic
+        columns.
+    by
+        Index level to group on. ``"time"`` (default) collapses across
+        runs at each time step. ``"run_id"`` collapses across time
+        steps within each run. Other values raise
+        :class:`gmat_sweep.errors.SweepConfigError` — categorical or
+        arbitrary keys are out of scope in this release.
+    q
+        Quantiles to compute. Each entry must be a float in the open
+        interval ``(0, 1)``. The default returns the 5th, 50th, and
+        95th percentiles. Pass an empty tuple to skip quantiles.
+    include
+        Non-quantile statistics to compute, in the order they appear in
+        the output's column-level ``"statistic"`` index. Allowed values:
+        ``"mean"``, ``"std"``, ``"min"``, ``"max"``, ``"count_ok"``.
+        ``"count_ok"`` is the per-group count of non-NaN values in each
+        data column. Pass an empty tuple to skip the non-quantile stats
+        and emit only quantiles.
+    dropna
+        ``True`` (default) drops rows whose ``__status != "ok"`` before
+        aggregating, so failed and skipped runs are excluded from every
+        statistic. ``False`` keeps them — their NaT/NaN marker rows
+        contribute a NaT (or run-id) group to the output, mostly NaN.
+        When ``df`` has no ``__status`` column the flag has no effect.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Row index: the unique values of ``df.index.get_level_values(by)``.
+        Column index: a two-level :class:`pandas.MultiIndex`
+        ``("statistic", "field")``. Statistic labels are exactly the
+        entries of ``include`` plus ``f"q{q_val}"`` (e.g. ``"q0.05"``,
+        ``"q0.5"``, ``"q0.95"``) for each requested quantile, in the
+        order ``include`` then ``q``. ``field`` carries the original
+        data-column names.
+
+    Raises
+    ------
+    SweepConfigError
+        ``by`` is not ``"time"`` or ``"run_id"``; any ``q_val`` falls
+        outside ``(0, 1)``; ``include`` contains an unknown statistic;
+        or ``by`` is not an index level of ``df``.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from gmat_sweep import sweep_summary
+    >>> # df is a (run_id, time)-MultiIndexed sweep DataFrame
+    >>> summary = sweep_summary(df)  # doctest: +SKIP
+    >>> summary[("q0.5", "Sat.X")]  # median Sat.X across runs at each time  # doctest: +SKIP
+    """
+    if by not in _VALID_BY:
+        raise SweepConfigError(
+            f"sweep_summary: by={by!r} is not supported in this release; "
+            f"pass one of {list(_VALID_BY)}"
+        )
+
+    bad_q = [val for val in q if not (0.0 < float(val) < 1.0)]
+    if bad_q:
+        raise SweepConfigError(
+            f"sweep_summary: q values must lie in the open interval (0, 1); got {bad_q}"
+        )
+
+    bad_include = [s for s in include if s not in _VALID_INCLUDE]
+    if bad_include:
+        raise SweepConfigError(
+            f"sweep_summary: unknown statistic(s) in include={list(include)}: "
+            f"{bad_include}; allowed: {list(_VALID_INCLUDE)}"
+        )
+
+    if df.index.nlevels < 2 or by not in (df.index.names or []):
+        raise SweepConfigError(
+            f"sweep_summary: df.index does not have a {by!r} level "
+            f"(got names={list(df.index.names or [])})"
+        )
+
+    working = df
+    if dropna and _STATUS_COL in working.columns:
+        working = working.loc[working[_STATUS_COL] == "ok"]
+
+    data = working.drop(columns=[_STATUS_COL], errors="ignore")
+    data_columns = list(data.columns)
+
+    grouped = data.groupby(level=by, dropna=dropna)
+
+    stat_blocks: list[tuple[str, pd.DataFrame]] = []
+    for stat in include:
+        if stat == "count_ok":
+            block = cast(pd.DataFrame, grouped.count())
+        else:
+            block = cast(pd.DataFrame, grouped.agg(stat))
+        stat_blocks.append((stat, block.reindex(columns=data_columns)))
+
+    for q_val in q:
+        block = cast(pd.DataFrame, grouped.quantile(float(q_val)))
+        stat_blocks.append((f"q{q_val}", block.reindex(columns=data_columns)))
+
+    if not stat_blocks:
+        # No statistics requested — return an empty-column frame still keyed
+        # by the unique `by` values so callers can attach their own columns.
+        empty_index = data.index.get_level_values(by).unique()
+        return pd.DataFrame(
+            index=empty_index,
+            columns=pd.MultiIndex.from_arrays([[], []], names=["statistic", "field"]),
+        )
+
+    result = pd.concat(
+        {label: block for label, block in stat_blocks},
+        axis=1,
+        names=["statistic", "field"],
+    )
+    return result

--- a/src/gmat_sweep/plotting.py
+++ b/src/gmat_sweep/plotting.py
@@ -1,7 +1,7 @@
-"""Plot helpers for sweep DataFrames — corner/pair plots and 2-axis heatmaps.
+"""Plot helpers for sweep DataFrames — corner/pair plots, 2-axis heatmaps, and bands.
 
-The two public entry points cover the two figures users hand-roll most
-often on top of a sweep result:
+The public entry points cover the figures users hand-roll most often on
+top of a sweep result:
 
 - :func:`sweep_corner` — pair plot of the perturbed dotted-paths coloured
   by a per-run scalar metric. Useful for Monte Carlo and Latin hypercube
@@ -9,12 +9,17 @@ often on top of a sweep result:
 - :func:`sweep_heatmap` — 2-D grid heatmap. Asserts the sweep was a
   two-axis :func:`gmat_sweep.sweep` grid and pivots the per-run metric
   into a matrix.
+- :func:`sweep_band_plot` — median-and-band plot of one column over time
+  (or run_id), reading a :func:`gmat_sweep.sweep_summary` DataFrame
+  directly.
 
-Both helpers consume the v0.2 ``(run_id, time)``-MultiIndexed DataFrame
-:func:`gmat_sweep.sweep` returns. Per-run parameter values come from
-either the DataFrame itself (when the perturbed dotted-path is also a
-report column) or from ``manifest.entries[i].overrides`` — the resolution
-order is documented per helper.
+The corner/heatmap helpers consume the v0.2
+``(run_id, time)``-MultiIndexed DataFrame :func:`gmat_sweep.sweep`
+returns. Per-run parameter values come from either the DataFrame itself
+(when the perturbed dotted-path is also a report column) or from
+``manifest.entries[i].overrides`` — the resolution order is documented
+per helper. :func:`sweep_band_plot` instead consumes the per-``time``
+(or per-``run_id``) statistics frame :func:`sweep_summary` returns.
 
 This module imports :mod:`matplotlib` lazily (inside each helper) so
 ``import gmat_sweep.plotting`` succeeds without the ``[plot]`` extra; the
@@ -39,7 +44,7 @@ if TYPE_CHECKING:
 
     from gmat_sweep.manifest import Manifest
 
-__all__ = ["sweep_corner", "sweep_heatmap"]
+__all__ = ["sweep_band_plot", "sweep_corner", "sweep_heatmap"]
 
 
 def sweep_corner(
@@ -426,3 +431,121 @@ def _edges_from_centres(centres: NDArray[Any]) -> NDArray[Any]:
     first = sorted_centres[0] - diffs[0] / 2.0
     last = sorted_centres[-1] + diffs[-1] / 2.0
     return np.concatenate(([first], inner, [last]))
+
+
+def sweep_band_plot(
+    summary: pd.DataFrame,
+    column: str,
+    *,
+    ax: Axes | None = None,
+    **kwargs: Any,
+) -> Axes:
+    """Plot one ``column``'s median and quantile band from a ``sweep_summary`` frame.
+
+    Reads the two-level ``("statistic", "field")`` column index produced
+    by :func:`gmat_sweep.sweep_summary`, slices the band — the lowest
+    and highest ``q*`` statistics for ``column`` — and draws a
+    :meth:`matplotlib.axes.Axes.fill_between` shaded band plus a centre
+    line. The centre is the median (``q0.5``) when present, otherwise
+    falls back to ``mean``. The x-axis is the summary's row index
+    (``time`` for ``by="time"``, ``run_id`` for ``by="run_id"``).
+
+    Parameters
+    ----------
+    summary
+        DataFrame as returned by :func:`gmat_sweep.sweep_summary`. Must
+        carry the two-level ``("statistic", "field")`` column index.
+    column
+        Original data-column name to plot — the ``"field"`` slice under
+        every statistic in the summary's column index.
+    ax
+        Optional pre-existing :class:`matplotlib.axes.Axes`. ``None``
+        (default) creates a fresh figure with size ``(8, 4)`` inches.
+    **kwargs
+        Forwarded to the centre :meth:`matplotlib.axes.Axes.plot` call
+        (e.g. ``label=``, ``linestyle=``, ``linewidth=``). The band's
+        ``fill_between`` reuses the line colour at ``alpha=0.25``.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+        The Axes carrying the band plot. Save the figure via
+        ``ax.figure.savefig(...)``.
+
+    Raises
+    ------
+    SweepConfigError
+        ``summary.columns`` is not a 2-level MultiIndex; ``column`` does
+        not appear in the ``"field"`` level; or no centre statistic
+        (neither a quantile nor ``mean``) is available for ``column``.
+    """
+    import matplotlib.pyplot as plt
+
+    if not isinstance(summary.columns, pd.MultiIndex) or summary.columns.nlevels != 2:
+        raise SweepConfigError(
+            "sweep_band_plot: summary must have a 2-level column MultiIndex "
+            "as produced by gmat_sweep.sweep_summary"
+        )
+
+    field_level = summary.columns.get_level_values(1)
+    if column not in field_level:
+        available = sorted(set(field_level))
+        raise SweepConfigError(
+            f"sweep_band_plot: column={column!r} not found in summary; "
+            f"available fields: {available}"
+        )
+
+    stat_level = summary.columns.get_level_values(0)
+    quantile_stats: list[tuple[float, str]] = []
+    for stat in dict.fromkeys(stat_level):
+        if isinstance(stat, str) and stat.startswith("q"):
+            try:
+                quantile_stats.append((float(stat[1:]), stat))
+            except ValueError:
+                continue
+    quantile_stats.sort()
+
+    has_mean = "mean" in set(stat_level)
+
+    centre_stat: str | None = None
+    for q_val, stat in quantile_stats:
+        if q_val == 0.5:
+            centre_stat = stat
+            break
+    if centre_stat is None and has_mean:
+        centre_stat = "mean"
+    if centre_stat is None:
+        raise SweepConfigError(
+            f"sweep_band_plot: column={column!r} has no centre statistic "
+            "(need either q=0.5 or mean in include=)"
+        )
+
+    band: tuple[str, str] | None = (
+        (quantile_stats[0][1], quantile_stats[-1][1]) if len(quantile_stats) >= 2 else None
+    )
+
+    if ax is None:
+        _, ax = plt.subplots(figsize=(8, 4))
+
+    x = summary.index.to_numpy()
+    centre = summary[(centre_stat, column)].to_numpy()
+
+    plot_kwargs: dict[str, Any] = {"label": f"{column} ({centre_stat})", **kwargs}
+    (line,) = ax.plot(x, centre, **plot_kwargs)
+
+    if band is not None:
+        lo = summary[(band[0], column)].to_numpy()
+        hi = summary[(band[1], column)].to_numpy()
+        ax.fill_between(
+            x,
+            lo,
+            hi,
+            color=line.get_color(),
+            alpha=0.25,
+            label=f"{column} ({band[0]} to {band[1]})",
+        )
+
+    x_label = summary.index.name or "index"
+    ax.set_xlabel(str(x_label))
+    ax.set_ylabel(column)
+    return ax

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import cast
 
 import pandas as pd
 import pytest
@@ -13,6 +14,7 @@ from gmat_sweep.aggregate import (
     lazy_ephemerides,
     lazy_fused_reports,
     lazy_multiindex,
+    sweep_summary,
 )
 from gmat_sweep.errors import SweepConfigError
 from gmat_sweep.manifest import Manifest, ManifestEntry
@@ -639,3 +641,161 @@ def test_lazy_contacts_three_kinds_aggregate_independently(tmp_path: Path) -> No
     assert len(reports_df) == 4 * 3
     assert len(eph_df) == 4 * 3
     assert len(contacts_df) == 4 * 2
+
+
+# ---------------------------------------------------------------------------
+# sweep_summary
+# ---------------------------------------------------------------------------
+
+
+def _summary_df(
+    *,
+    n_runs: int = 100,
+    n_steps: int = 4,
+    statuses: dict[int, str] | None = None,
+) -> pd.DataFrame:
+    """A ``(run_id, time)``-MultiIndexed test frame with two data columns."""
+    statuses = statuses or {}
+    rows: list[dict[str, object]] = []
+    times = pd.to_datetime([f"2026-05-04T00:00:0{i}" for i in range(n_steps)])
+    for run_id in range(n_runs):
+        status = statuses.get(run_id, "ok")
+        if status != "ok":
+            rows.append(
+                {
+                    "run_id": run_id,
+                    "time": pd.NaT,
+                    "x": float("nan"),
+                    "y": float("nan"),
+                    "__status": status,
+                }
+            )
+            continue
+        for step, t in enumerate(times):
+            rows.append(
+                {
+                    "run_id": run_id,
+                    "time": t,
+                    "x": float(run_id) + step * 0.1,
+                    "y": float(run_id) * 2.0 - step,
+                    "__status": "ok",
+                }
+            )
+    return cast(pd.DataFrame, pd.DataFrame(rows).set_index(["run_id", "time"]))
+
+
+def test_sweep_summary_default_shape_and_multiindex_columns() -> None:
+    df = _summary_df(n_runs=10, n_steps=3)
+    summary = sweep_summary(df)
+
+    # Row index keyed on the unique time steps from the input.
+    assert summary.index.name == "time"
+    assert len(summary) == 3
+
+    # Column index is a 2-level (statistic, field) MultiIndex with default
+    # mean + std + 5/50/95 quantiles times the 2 data columns (x, y).
+    assert isinstance(summary.columns, pd.MultiIndex)
+    assert summary.columns.names == ["statistic", "field"]
+    statistics = list(dict.fromkeys(summary.columns.get_level_values(0)))
+    assert statistics == ["mean", "std", "q0.05", "q0.5", "q0.95"]
+    fields = list(dict.fromkeys(summary.columns.get_level_values(1)))
+    assert fields == ["x", "y"]
+
+
+def test_sweep_summary_quantile_matches_hand_rolled_groupby() -> None:
+    """DoD criterion: (time, q=0.5) slice equals df.groupby('time').quantile(0.5)."""
+    df = _summary_df(n_runs=100, n_steps=4)
+    summary = sweep_summary(df)
+
+    # Drop __status to mirror sweep_summary's internal data-only view.
+    expected = df.drop(columns=["__status"]).groupby(level="time").quantile(0.5)
+    got = cast(pd.DataFrame, summary["q0.5"])
+    pd.testing.assert_frame_equal(got, expected, check_names=False)
+
+
+def test_sweep_summary_by_run_id_collapses_across_time() -> None:
+    df = _summary_df(n_runs=4, n_steps=5)
+    summary = sweep_summary(df, by="run_id", q=(), include=("mean",))
+
+    assert summary.index.name == "run_id"
+    assert list(summary.index) == [0, 1, 2, 3]
+    # Each run's mean(x) is run_id + mean(0..n_steps-1)*0.1.
+    expected_x = pd.Series(
+        [float(rid) + 0.2 for rid in range(4)],
+        index=pd.Index([0, 1, 2, 3], name="run_id"),
+        name=("mean", "x"),
+    )
+    pd.testing.assert_series_equal(summary[("mean", "x")], expected_x)
+
+
+def test_sweep_summary_count_ok_counts_non_nan_values() -> None:
+    df = _summary_df(n_runs=5, n_steps=3)
+    summary = sweep_summary(df, q=(), include=("count_ok",))
+
+    # Every ok row contributes; per time, count == 5 across all 5 runs.
+    assert (summary[("count_ok", "x")] == 5).all()
+    assert (summary[("count_ok", "y")] == 5).all()
+
+
+def test_sweep_summary_dropna_true_excludes_failed_and_skipped_runs() -> None:
+    df = _summary_df(n_runs=6, n_steps=2, statuses={1: "failed", 4: "skipped"})
+    summary = sweep_summary(df, q=(), include=("count_ok",))
+
+    # 4 ok runs (0, 2, 3, 5) — failed/skipped runs (NaT marker rows) excluded.
+    assert summary.index.name == "time"
+    assert len(summary) == 2
+    assert (summary[("count_ok", "x")] == 4).all()
+
+
+def test_sweep_summary_dropna_false_keeps_marker_rows() -> None:
+    df = _summary_df(n_runs=3, n_steps=2, statuses={2: "failed"})
+    summary = sweep_summary(df, q=(), include=("count_ok",), dropna=False)
+
+    # The NaT marker row from the failed run lands as a NaT-keyed group.
+    assert bool(pd.isna(summary.index).any())
+    # The two real time steps still see 2 ok contributions each.
+    real_rows = summary.loc[summary.index.notna()]
+    assert (real_rows[("count_ok", "x")] == 2).all()
+
+
+def test_sweep_summary_custom_q_and_include() -> None:
+    df = _summary_df(n_runs=20, n_steps=3)
+    summary = sweep_summary(
+        df,
+        q=(0.25, 0.75),
+        include=("min", "max"),
+    )
+    statistics = list(dict.fromkeys(summary.columns.get_level_values(0)))
+    assert statistics == ["min", "max", "q0.25", "q0.75"]
+
+
+def test_sweep_summary_no_status_column_works() -> None:
+    """A frame without __status should aggregate cleanly — dropna is a no-op."""
+    df = _summary_df(n_runs=4, n_steps=2).drop(columns=["__status"])
+    summary = sweep_summary(df, q=(0.5,), include=())
+    assert list(summary.columns.get_level_values(0)) == ["q0.5", "q0.5"]
+    assert len(summary) == 2
+
+
+def test_sweep_summary_rejects_unsupported_by() -> None:
+    df = _summary_df(n_runs=2, n_steps=2)
+    with pytest.raises(SweepConfigError, match=r"by=.*not supported"):
+        sweep_summary(df, by="run")
+
+
+def test_sweep_summary_rejects_q_outside_open_interval() -> None:
+    df = _summary_df(n_runs=2, n_steps=2)
+    with pytest.raises(SweepConfigError, match=r"open interval"):
+        sweep_summary(df, q=(0.0, 0.5))
+
+
+def test_sweep_summary_rejects_unknown_statistic() -> None:
+    df = _summary_df(n_runs=2, n_steps=2)
+    with pytest.raises(SweepConfigError, match=r"unknown statistic"):
+        sweep_summary(df, include=("median",))
+
+
+def test_sweep_summary_rejects_missing_index_level() -> None:
+    df = _summary_df(n_runs=2, n_steps=2).reset_index().set_index("run_id")
+    with pytest.raises(SweepConfigError, match=r"does not have a 'time' level"):
+        sweep_summary(df)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -15,11 +15,12 @@ import pytest
 matplotlib = pytest.importorskip("matplotlib")
 matplotlib.use("Agg")
 
-from matplotlib.collections import PathCollection, QuadMesh  # noqa: E402
+from matplotlib.collections import PathCollection, PolyCollection, QuadMesh  # noqa: E402
 
+from gmat_sweep.aggregate import sweep_summary  # noqa: E402
 from gmat_sweep.errors import SweepConfigError  # noqa: E402
 from gmat_sweep.manifest import Manifest, ManifestEntry  # noqa: E402
-from gmat_sweep.plotting import sweep_corner, sweep_heatmap  # noqa: E402
+from gmat_sweep.plotting import sweep_band_plot, sweep_corner, sweep_heatmap  # noqa: E402
 
 
 def _ts(seconds: int = 0) -> datetime:
@@ -337,3 +338,102 @@ def test_sweep_heatmap_callable_z() -> None:
     ax = sweep_heatmap(df, x="a", y="b", z=z, manifest=manifest)
     mesh = next(c for c in ax.collections if isinstance(c, QuadMesh))
     assert np.asarray(mesh.get_array()).shape == (2, 3)
+
+
+# ---------------------------------------------------------------------------
+# sweep_band_plot
+# ---------------------------------------------------------------------------
+
+
+def _band_summary(n_runs: int = 50, n_steps: int = 4) -> pd.DataFrame:
+    """A sweep-summary frame with two columns for sweep_band_plot tests."""
+    rows: list[dict[str, Any]] = []
+    times = pd.to_datetime([f"2026-05-04T00:00:0{i}" for i in range(n_steps)])
+    for run_id in range(n_runs):
+        for step, t in enumerate(times):
+            rows.append(
+                {
+                    "run_id": run_id,
+                    "time": t,
+                    "value": float(run_id) + step * 0.5,
+                    "other": float(run_id) - step,
+                    "__status": "ok",
+                }
+            )
+    df = pd.DataFrame(rows).set_index(["run_id", "time"])
+    return sweep_summary(df)
+
+
+def test_sweep_band_plot_returns_axes_with_line_and_band() -> None:
+    summary = _band_summary()
+    ax = sweep_band_plot(summary, "value")
+
+    # One line for the centre and one PolyCollection for the fill_between band.
+    assert len(ax.lines) == 1
+    polys = [c for c in ax.collections if isinstance(c, PolyCollection)]
+    assert len(polys) == 1
+    assert ax.get_xlabel() == "time"
+    assert ax.get_ylabel() == "value"
+
+
+def test_sweep_band_plot_uses_q_5_as_centre_and_q_band_extremes() -> None:
+    summary = _band_summary(n_runs=20, n_steps=3)
+    ax = sweep_band_plot(summary, "value")
+
+    centre = ax.lines[0].get_ydata()
+    pd.testing.assert_series_equal(
+        pd.Series(centre, name=("q0.5", "value")),
+        summary[("q0.5", "value")].reset_index(drop=True),
+        check_names=False,
+        check_index=False,
+    )
+
+
+def test_sweep_band_plot_falls_back_to_mean_without_q_5() -> None:
+    rows: list[dict[str, Any]] = []
+    for run_id in range(10):
+        for step in range(3):
+            rows.append(
+                {
+                    "run_id": run_id,
+                    "time": pd.Timestamp(f"2026-05-04T00:00:0{step}"),
+                    "v": float(run_id),
+                    "__status": "ok",
+                }
+            )
+    df = pd.DataFrame(rows).set_index(["run_id", "time"])
+    summary = sweep_summary(df, q=(0.1, 0.9), include=("mean",))
+
+    ax = sweep_band_plot(summary, "v")
+    centre = ax.lines[0].get_ydata()
+    assert centre == pytest.approx(summary[("mean", "v")].to_numpy())
+
+
+def test_sweep_band_plot_rejects_unknown_column() -> None:
+    summary = _band_summary(n_runs=4, n_steps=2)
+    with pytest.raises(SweepConfigError, match=r"not found in summary"):
+        sweep_band_plot(summary, "nope")
+
+
+def test_sweep_band_plot_rejects_flat_column_index() -> None:
+    flat = pd.DataFrame({"x": [1.0, 2.0]}, index=pd.Index([0, 1], name="time"))
+    with pytest.raises(SweepConfigError, match=r"2-level column MultiIndex"):
+        sweep_band_plot(flat, "x")
+
+
+def test_sweep_band_plot_rejects_summary_without_centre() -> None:
+    rows: list[dict[str, Any]] = []
+    for run_id in range(5):
+        for step in range(2):
+            rows.append(
+                {
+                    "run_id": run_id,
+                    "time": pd.Timestamp(f"2026-05-04T00:00:0{step}"),
+                    "v": float(run_id),
+                    "__status": "ok",
+                }
+            )
+    df = pd.DataFrame(rows).set_index(["run_id", "time"])
+    summary = sweep_summary(df, q=(0.1, 0.9), include=())  # no q=0.5, no mean
+    with pytest.raises(SweepConfigError, match=r"no centre statistic"):
+        sweep_band_plot(summary, "v")


### PR DESCRIPTION
## Summary

- Adds `gmat_sweep.sweep_summary(df, *, by="time", q=(0.05, 0.5, 0.95), include=("mean", "std"), dropna=True)` — collapses a `(run_id, time)`-MultiIndexed sweep DataFrame into per-`by` statistics with a 2-level `("statistic", "field")` column MultiIndex. The default 5/50/95 quantiles plus mean/std feed directly into the matching plot helper, and `count_ok` reports the per-group non-NaN count for spotting time steps where many runs produced NaNs.
- Adds `gmat_sweep.plotting.sweep_band_plot(summary, column, *, ax=None, **kwargs)` (gated `[plot]`) — auto-discovers q columns under `(q*, column)` and renders the canonical `fill_between` band + centre line (`q=0.5` if present, else `mean`).
- Docs: new "Summarising across runs" section in `docs/aggregation.md` and mkdocstrings entries for both new symbols in `docs/api.md`.

## Test plan

- [ ] Default `(time, q=0.5)` slice equals hand-rolled `df.groupby("time").quantile(0.5)` (DoD criterion #1, covered by `test_sweep_summary_quantile_matches_hand_rolled_groupby`).
- [ ] `by="run_id"` collapses across time correctly; custom `q` and `include` produce the labelled MultiIndex shape.
- [ ] `dropna=True` excludes failed/skipped runs; `dropna=False` lets the NaT marker rows form a NaT-keyed group.
- [ ] Validation paths raise `SweepConfigError` for unsupported `by`, out-of-range `q`, and unknown `include` entries.
- [ ] `sweep_band_plot` returns an Axes with one line + one PolyCollection; falls back to `mean` when `q=0.5` is absent; rejects flat column indexes and unknown columns.
- [ ] `uv run pytest`, `ruff check`, `ruff format --check`, `mypy` clean locally; `aggregate.py` coverage at 98% (≥95% gate).

Closes #91