### PR TITLE
monte_carlo_extend: bit-deterministic Monte Carlo augmentation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -10,7 +10,11 @@ auto-generated from docstrings via
 
 ::: gmat_sweep.monte_carlo
 
+::: gmat_sweep.monte_carlo_extend
+
 ::: gmat_sweep.latin_hypercube
+
+::: gmat_sweep.latin_hypercube_extend
 
 ::: gmat_sweep.Sweep
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -16,6 +16,8 @@ The subcommands:
 - [`explicit`](#explicit) — explicit-row sweep from a CSV or Parquet design.
 - [`resume`](#resume) — re-run only the failed and missing entries from a
   prior manifest.
+- [`extend`](#extend) — append more bit-deterministic Monte Carlo runs to an
+  existing sweep.
 - [`show`](#show) — print a one-line summary of a manifest.
 
 `gmat-sweep --help` lists them. Each subcommand has its own `--help`.
@@ -209,6 +211,42 @@ loaded. Its canonical SHA-256 must equal the manifest's `script_sha256`; see
 
 A missing `MANIFEST` exits with code `3`; a missing `--script` or a hash
 mismatch exits with code `2`.
+
+## `extend`
+
+Append `N` more bit-deterministic Monte Carlo runs to an existing sweep.
+The base manifest's `seed` and `perturb` mapping are reused so the new
+draws are bit-equal to the same indices of a fresh
+`monte_carlo(n=old_n + N)` call.
+
+```bash
+gmat-sweep extend ./mc-out/manifest.jsonl \
+    --n 1000 \
+    --script mission.script \
+    --workers 8
+```
+
+Required positional: `MANIFEST` — an existing Monte Carlo
+`manifest.jsonl`. Grid, explicit-row, and Latin hypercube manifests
+exit with code `2` (their stochastic semantics don't admit clean
+extension).
+
+Required flags:
+
+- `--n N` — number of additional stochastic runs to append, ≥ 1.
+- `--script PATH` — the same GMAT `.script` the original sweep loaded.
+  Same hash-drift contract as `resume`; add `--allow-script-drift` to
+  proceed past a mismatch.
+
+`extend` refuses if the base sweep has any `failed` or missing runs in
+its original `[0, n)` range — the underlying error names them and
+points at `gmat-sweep resume`. Run `resume` first, then `extend`.
+
+A missing `MANIFEST` exits with code `3`; a non-Monte-Carlo manifest,
+an incomplete base sweep, a missing `--script`, or a hash mismatch
+exits with code `2`. See
+[Monte Carlo § Extending an existing sweep](monte-carlo.md#extending-an-existing-sweep)
+for the full determinism contract.
 
 ## `show`
 

--- a/docs/manifest-schema.md
+++ b/docs/manifest-schema.md
@@ -196,6 +196,30 @@ in-memory `entries` list therefore has exactly one entry per
 the latest status. See [Resume](resume.md) for the resume flow that
 relies on this.
 
+## Monte Carlo extensions
+
+[`monte_carlo_extend()`][gmat_sweep.monte_carlo_extend] appends new
+runs to an existing Monte Carlo manifest at `run_id` range
+`[old_n, old_n + n)`. The header's `parameter_spec.n` is **not**
+rewritten — it stays at the original sweep's size — and no new header
+fields are added on disk. The cumulative count of extension runs is
+recoverable from the entries themselves; the convenience accessor is:
+
+```python
+manifest = Manifest.load("./sweep/manifest.jsonl")
+manifest.extension_run_count  # 0 for fresh sweeps; N after extend(n=N)
+```
+
+The total run count on disk after any number of extensions is
+`max(e.run_id for e in manifest.entries) + 1`, the same expression
+that already covers `Ctrl-C`'d sweeps where `len(entries) <
+parameter_spec["n"]`.
+
+The `_kind` of a Monte Carlo manifest stays `"monte_carlo"` after
+extension; only Monte Carlo manifests support extension at all
+(`latin_hypercube` and grid sweeps refuse — see
+[Monte Carlo § Extending an existing sweep](monte-carlo.md#extending-an-existing-sweep)).
+
 ## Compatibility policy
 
 The on-disk shape is frozen as `schema_version=1`. The exposed constant

--- a/docs/monte-carlo.md
+++ b/docs/monte-carlo.md
@@ -89,6 +89,73 @@ df_two = monte_carlo("mission.script", n=20, seed=42, perturb={
 This matters when an analysis grows: extending a 1-D `perturb` to a 4-D
 one mid-investigation should not invalidate the 1-D results.
 
+## Extending an existing sweep
+
+A 1000-run dispersion that turned out to need 2000 doesn't have to start
+over. [`monte_carlo_extend()`][gmat_sweep.monte_carlo_extend] runs only
+the new 1000 against the original sweep's manifest and returns the full
+2000-run aggregated DataFrame:
+
+```python
+from gmat_sweep import monte_carlo, monte_carlo_extend
+
+# Original sweep.
+df_1000 = monte_carlo(
+    "mission.script",
+    n=1000,
+    perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
+    seed=42,
+    out="./dispersion",
+)
+
+# Decide later that 2000 was the right size after all.
+df_2000 = monte_carlo_extend(
+    "./dispersion/manifest.jsonl",
+    "mission.script",
+    n=1000,
+)
+```
+
+The first 1000 `run_id`s in `df_2000` are bit-equal to `df_1000` —
+[`numpy.random.SeedSequence.spawn`][seed-spawn] is position-deterministic,
+so per-run sub-seeds at indices `0..999` are independent of how many
+total samples were requested. Equivalently, `df_2000` is bit-equal to a
+fresh `monte_carlo(n=2000, seed=42, ...)` call: extend on top of `n=1000`
+is indistinguishable from running `n=2000` from scratch.
+
+[seed-spawn]: https://numpy.org/doc/stable/reference/random/parallel.html
+
+The original `perturb` mapping and `seed` are read from the manifest
+header — the caller does not (and cannot) change them. Adding new
+perturbed parameters mid-sweep would break determinism; if the analysis
+needs a different distribution shape, run a fresh sweep instead.
+
+`monte_carlo_extend` refuses if the base sweep has any `failed` or
+missing runs in its original `[0, n)` range, naming them and pointing at
+[`Sweep.resume()`][gmat_sweep.Sweep.resume]. Mixing extension over an
+unfinished base would produce a manifest with gaps in the original
+range that downstream readers couldn't interpret — fill them in first,
+then extend.
+
+The on-disk header's `parameter_spec.n` stays frozen at the original
+sweep's size (manifest headers are append-only). Use
+[`Manifest.extension_run_count`][gmat_sweep.Manifest.extension_run_count]
+to read the cumulative count of extension runs, or the simpler
+`max(e.run_id for e in manifest.entries) + 1` for the total run count
+on disk.
+
+### Why Latin hypercube can't be extended
+
+[`latin_hypercube_extend()`][gmat_sweep.latin_hypercube_extend] exists
+to refuse the operation cleanly. Extending a Latin hypercube sweep
+would change the per-axis stratification of every sample (the `n` bins
+under [`scipy.stats.qmc.LatinHypercube`][scipy-lh] repartition when `n`
+changes), so there is no slice of a larger LH draw that reproduces the
+original `n` samples bit-for-bit. If you need more samples for an LH
+study, run a fresh `latin_hypercube(n=old_n + new)` from scratch.
+
+[scipy-lh]: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.qmc.LatinHypercube.html
+
 ## Worked example: launch dispersion
 
 A typical injection-error analysis perturbs the post-burn state vector

--- a/src/gmat_sweep/__init__.py
+++ b/src/gmat_sweep/__init__.py
@@ -10,7 +10,13 @@ from gmat_sweep.aggregate import (
     lazy_multiindex,
     sweep_summary,
 )
-from gmat_sweep.api import latin_hypercube, monte_carlo, sweep
+from gmat_sweep.api import (
+    latin_hypercube,
+    latin_hypercube_extend,
+    monte_carlo,
+    monte_carlo_extend,
+    sweep,
+)
 from gmat_sweep.backends import LocalJoblibPool, Pool
 from gmat_sweep.errors import (
     BackendError,
@@ -22,6 +28,7 @@ from gmat_sweep.errors import (
 from gmat_sweep.grids import (
     expand_grid_to_run_specs,
     expand_latin_hypercube_to_run_specs,
+    expand_monte_carlo_extension_to_run_specs,
     expand_monte_carlo_to_run_specs,
     expand_samples_to_run_specs,
     full_factorial,
@@ -69,16 +76,19 @@ __all__ = [
     "canonical_script_sha256",
     "expand_grid_to_run_specs",
     "expand_latin_hypercube_to_run_specs",
+    "expand_monte_carlo_extension_to_run_specs",
     "expand_monte_carlo_to_run_specs",
     "expand_samples_to_run_specs",
     "full_factorial",
     "latin_hypercube",
+    "latin_hypercube_extend",
     "latin_hypercube_samples",
     "lazy_contacts",
     "lazy_ephemerides",
     "lazy_fused_reports",
     "lazy_multiindex",
     "monte_carlo",
+    "monte_carlo_extend",
     "sweep",
     "sweep_summary",
 ]

--- a/src/gmat_sweep/api.py
+++ b/src/gmat_sweep/api.py
@@ -25,7 +25,13 @@ from gmat_sweep.sweep import Sweep
 if TYPE_CHECKING:
     import pandas as pd
 
-__all__ = ["latin_hypercube", "monte_carlo", "sweep"]
+__all__ = [
+    "latin_hypercube",
+    "latin_hypercube_extend",
+    "monte_carlo",
+    "monte_carlo_extend",
+    "sweep",
+]
 
 # Manifest filename inside the sweep's output directory. Picked to match the
 # JSON Lines format suffix for grep-friendliness; downstream consumers
@@ -315,6 +321,115 @@ def latin_hypercube(
         backend=backend,
         out=out,
         progress=progress,
+    )
+
+
+def monte_carlo_extend(
+    manifest: str | Path,
+    script: str | Path,
+    *,
+    n: int,
+    backend: Pool | None = None,
+    allow_script_drift: bool = False,
+    progress: bool = True,
+) -> pd.DataFrame:
+    """Append ``n`` more bit-deterministic Monte Carlo runs to an existing sweep.
+
+    Loads the manifest written by a prior :func:`monte_carlo` call,
+    dispatches ``n`` new runs at ``run_id`` range
+    ``[old_n, old_n + n)`` (where ``old_n`` is the cumulative high-water
+    mark including any prior extensions), and returns the aggregated
+    DataFrame over **all** runs (original + every extension applied so
+    far). Per-parameter draws at the new ``run_id``\\ s are bit-equal to
+    the same indices of a fresh ``monte_carlo(n=old_n+n, seed=...)``
+    call thanks to the position-determinism of
+    :func:`numpy.random.SeedSequence.spawn`.
+
+    The original ``perturb`` mapping and ``seed`` are read from the
+    manifest's ``parameter_spec`` — the caller does not (and cannot)
+    change them. Adding new perturbed parameters mid-sweep is not
+    supported and would break determinism.
+
+    Parameters
+    ----------
+    manifest:
+        Path to the existing ``manifest.jsonl``. Its parent is the
+        sweep's ``output_dir`` and must still exist on disk —
+        successful runs' Parquet files are read from there as-is when
+        the aggregated DataFrame is built.
+    script:
+        Path to the same GMAT ``.script`` the original sweep loaded.
+        Its canonical SHA-256 must equal the manifest's
+        ``script_sha256`` unless ``allow_script_drift`` is set —
+        otherwise the original runs and the new ones would have loaded
+        different scripts and the aggregated DataFrame would mix them.
+    n:
+        Number of additional runs to dispatch. Must be ``>= 1``.
+    backend:
+        Execution backend; same semantics as :func:`monte_carlo`.
+    allow_script_drift:
+        ``False`` (default) raises :class:`SweepConfigError` on a hash
+        mismatch with both hashes in the message. ``True`` proceeds
+        anyway and emits a :class:`RuntimeWarning`. Same surface as
+        :meth:`gmat_sweep.Sweep.from_manifest`.
+    progress:
+        Whether to draw the :mod:`tqdm` progress bar over the new runs.
+
+    Returns
+    -------
+    pandas.DataFrame
+        ``(run_id, time)``-MultiIndexed frame whose ``run_id``
+        cardinality is ``old_n + n``.
+
+    Raises
+    ------
+    SweepConfigError
+        If the manifest's ``parameter_spec._kind`` is not
+        ``"monte_carlo"``, ``n < 1``, the script hash drifted with
+        ``allow_script_drift=False``, or the base sweep is incomplete
+        (any ``run_id`` in ``[0, old_n)`` is failed or missing).
+    """
+    # Local import to avoid a Sweep ↔ api import cycle at module load.
+    from gmat_sweep.sweep import Sweep
+
+    with _resolve_pool(backend) as pool:
+        sweep_obj = Sweep.from_manifest(
+            manifest,
+            script,
+            backend=pool,
+            allow_script_drift=allow_script_drift,
+            progress=progress,
+        ).extend(n=n)
+        return sweep_obj.to_dataframe()
+
+
+def latin_hypercube_extend(
+    manifest: str | Path,
+    script: str | Path,
+    *,
+    n: int,
+    backend: Pool | None = None,
+    allow_script_drift: bool = False,
+    progress: bool = True,
+) -> pd.DataFrame:
+    """Refuse to extend a Latin hypercube sweep — no bit-equivalence semantics.
+
+    Always raises :class:`SweepConfigError`. Extending an LH sweep
+    changes the per-axis stratification of every existing sample (the
+    ``n`` bins repartition under
+    :class:`scipy.stats.qmc.LatinHypercube`), so there is no slice of
+    a larger LH draw that reproduces the original ``n`` samples
+    bit-for-bit. The function exists to **refuse cleanly** rather than
+    silently produce wrong draws — its signature mirrors
+    :func:`monte_carlo_extend` so a caller writing a generic
+    "extend whatever sweep this is" wrapper gets a clear error rather
+    than an :class:`AttributeError`.
+    """
+    raise SweepConfigError(
+        "latin_hypercube_extend is unsupported: extending a Latin hypercube sweep "
+        "changes the stratification of every existing sample, so the new draws "
+        "would not be bit-equal to the originals. Use monte_carlo_extend on a "
+        "Monte Carlo manifest, or run a fresh latin_hypercube(n=old_n + new) sweep."
     )
 
 

--- a/src/gmat_sweep/cli.py
+++ b/src/gmat_sweep/cli.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from gmat_sweep.api import latin_hypercube, monte_carlo, sweep
+from gmat_sweep.api import latin_hypercube, monte_carlo, monte_carlo_extend, sweep
 from gmat_sweep.backends.dask import DaskPool
 from gmat_sweep.backends.joblib import LocalJoblibPool
 from gmat_sweep.backends.mpi import MPIPool
@@ -512,6 +512,30 @@ def _cmd_archive(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
+def _cmd_extend(args: argparse.Namespace) -> int:
+    manifest_path = Path(args.manifest)
+    if not manifest_path.is_file():
+        print(f"gmat-sweep: manifest not found: {manifest_path}", file=sys.stderr)
+        return EXIT_MANIFEST
+    script = Path(args.script)
+    if not script.is_file():
+        print(f"gmat-sweep: script not found: {script}", file=sys.stderr)
+        return EXIT_CONFIG
+
+    with _build_pool(args) as pool:
+        monte_carlo_extend(
+            manifest_path,
+            script,
+            n=args.n,
+            backend=pool,
+            allow_script_drift=args.allow_script_drift,
+        )
+
+    manifest = Manifest.load(manifest_path)
+    print(_format_summary(manifest, manifest_path.parent))
+    return EXIT_OK
+
+
 def _cmd_resume(args: argparse.Namespace) -> int:
     manifest_path = Path(args.manifest)
     if not manifest_path.is_file():
@@ -803,6 +827,58 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     _add_backend_flag(explicit)
     explicit.set_defaults(func=_cmd_explicit)
+
+    extend = subparsers.add_parser(
+        "extend",
+        help="Append more bit-deterministic Monte Carlo runs to an existing sweep.",
+        description=(
+            "Load a Monte Carlo manifest.jsonl, dispatch N additional runs at "
+            "run_id range [old_n, old_n + N), and reuse the manifest's seed and "
+            "perturb mapping so the new draws are bit-equal to the same indices "
+            "of a fresh monte_carlo(n=old_n + N) call. Refuses if the base "
+            "sweep has any failed or missing runs in [0, old_n) — call "
+            "'gmat-sweep resume' first to fill those in."
+        ),
+    )
+    extend.add_argument(
+        "manifest",
+        metavar="MANIFEST",
+        help="Path to a Monte Carlo manifest.jsonl produced by a prior sweep.",
+    )
+    extend.add_argument(
+        "--n",
+        type=int,
+        required=True,
+        metavar="N",
+        help="Number of additional stochastic runs to append (>= 1).",
+    )
+    extend.add_argument(
+        "--script",
+        required=True,
+        metavar="PATH",
+        help=(
+            "Path to the same GMAT .script the original sweep loaded. Its "
+            "canonical SHA-256 must equal the manifest's script_sha256 unless "
+            "--allow-script-drift is set."
+        ),
+    )
+    extend.add_argument(
+        "--workers",
+        type=int,
+        default=-1,
+        metavar="N",
+        help="Number of subprocess workers. Default -1 uses every available core.",
+    )
+    extend.add_argument(
+        "--allow-script-drift",
+        action="store_true",
+        help=(
+            "Proceed even if the script's canonical hash differs from the manifest's. "
+            "Emits a RuntimeWarning."
+        ),
+    )
+    _add_backend_flag(extend)
+    extend.set_defaults(func=_cmd_extend)
 
     resume = subparsers.add_parser(
         "resume",

--- a/src/gmat_sweep/grids.py
+++ b/src/gmat_sweep/grids.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
 __all__ = [
     "expand_grid_to_run_specs",
     "expand_latin_hypercube_to_run_specs",
+    "expand_monte_carlo_extension_to_run_specs",
     "expand_monte_carlo_to_run_specs",
     "expand_samples_to_run_specs",
     "full_factorial",
@@ -229,6 +230,81 @@ def expand_monte_carlo_to_run_specs(
 
     specs: list[RunSpec] = []
     for run_id, run_seed in enumerate(run_seeds):
+        overrides: dict[str, Any] = {}
+        for k in sorted_keys:
+            sub_seed = derive_param_seed(run_seed, k)
+            overrides[k] = sample(perturb[k], sub_seed)
+        specs.append(
+            RunSpec(
+                script_path=script_path_obj,
+                overrides=overrides,
+                output_dir=base_output_dir / f"run-{run_id}",
+                run_id=run_id,
+                seed=run_seed,
+                run_options={},
+            )
+        )
+    return specs
+
+
+def expand_monte_carlo_extension_to_run_specs(
+    perturb: Mapping[str, DistSpec],
+    old_n: int,
+    n: int,
+    seed: int | None,
+    script_path: str | Path,
+    output_dir: str | Path,
+) -> list[RunSpec]:
+    """Build :class:`RunSpec` instances for the *extension* slice of an MC sweep.
+
+    Mirrors :func:`expand_monte_carlo_to_run_specs` but emits only the
+    ``[old_n, old_n + n)`` tail. The two key facts that make this slice
+    bit-equal to the same indices of a fresh ``monte_carlo(n=old_n+n, ...)``
+    call:
+
+    1. :func:`numpy.random.SeedSequence.spawn` is position-deterministic —
+       the ``i``-th child depends only on ``(parent, i)``, not on ``n``. So
+       :func:`derive_run_seeds(seed, total) <gmat_sweep.distributions.derive_run_seeds>`
+       at indices ``[old_n, total)`` matches the same indices of a fresh
+       ``derive_run_seeds(seed, total)`` call regardless of how the original
+       sweep was sized.
+    2. Per-parameter sub-seeds are derived from
+       :func:`derive_param_seed(run_seed, name) <gmat_sweep.distributions.derive_param_seed>`,
+       which keys on the parameter name. The extension reuses the same
+       ``perturb`` mapping by construction (extension does not let the caller
+       change distributions), so each parameter's sub-seed at every extended
+       ``run_id`` is bit-equal to a fresh sweep at the same total ``n``.
+
+    Together these two facts give the bit-equivalence the
+    :func:`gmat_sweep.monte_carlo_extend` contract rests on.
+
+    Raises :class:`SweepConfigError` if ``perturb`` is empty, ``old_n < 0``,
+    ``n < 1``, or any parameter spec fails its own validation in
+    :func:`to_rv_frozen <gmat_sweep.distributions.to_rv_frozen>`.
+    """
+    if not perturb:
+        raise SweepConfigError("monte_carlo_extend requires a non-empty perturb mapping")
+    if old_n < 0:
+        raise SweepConfigError(f"monte_carlo_extend requires old_n >= 0, got {old_n}")
+    if n < 1:
+        raise SweepConfigError(f"monte_carlo_extend requires n >= 1, got {n}")
+
+    sorted_keys = sorted(perturb)
+    for k in sorted_keys:
+        to_rv_frozen(perturb[k])
+
+    # Spawn over the full [0, old_n + n) range so per-run seeds at indices
+    # >= old_n are bit-equal to a fresh n=old_n+n call. SeedSequence.spawn
+    # is position-deterministic so we could in principle skip the first
+    # old_n entries, but spawn is microseconds and matching the existing
+    # expander's call shape verbatim is what proves equivalence.
+    run_seeds = derive_run_seeds(seed, old_n + n)
+    script_path_obj = Path(script_path)
+    base_output_dir = Path(output_dir)
+
+    specs: list[RunSpec] = []
+    for run_id in range(old_n, old_n + n):
+        run_seed = run_seeds[run_id]
         overrides: dict[str, Any] = {}
         for k in sorted_keys:
             sub_seed = derive_param_seed(run_seed, k)

--- a/src/gmat_sweep/manifest.py
+++ b/src/gmat_sweep/manifest.py
@@ -315,6 +315,29 @@ class Manifest:
         present = {e.run_id for e in self.entries}
         return [rid for rid in expected_run_ids if rid not in present]
 
+    @property
+    def extension_run_count(self) -> int:
+        """Cumulative number of extension runs appended beyond the original sweep.
+
+        Derived as ``max(0, max(run_id for entries) + 1 - parameter_spec["n"])``
+        for Monte Carlo manifests; ``0`` for any other ``parameter_spec``
+        kind or for an MC manifest that has not been extended. The on-disk
+        header is not rewritten on extension (manifest headers are
+        append-only), so this is the canonical way to ask "how many
+        :func:`gmat_sweep.monte_carlo_extend` calls have landed on top of
+        this sweep's original ``n``."
+        """
+        kind = self.parameter_spec.get("_kind")
+        if kind != "monte_carlo":
+            return 0
+        original_n_raw = self.parameter_spec.get("n")
+        if not isinstance(original_n_raw, int):
+            return 0
+        if not self.entries:
+            return 0
+        max_run_id = max(e.run_id for e in self.entries)
+        return max(0, max_run_id + 1 - original_n_raw)
+
 
 def _fsync_dir(directory: Path) -> None:
     # Directory fsync ensures the new file's metadata (existence, size) is

--- a/src/gmat_sweep/sweep.py
+++ b/src/gmat_sweep/sweep.py
@@ -306,6 +306,106 @@ class Sweep:
         self._manifest = Manifest.load(self._manifest_path)
         return self
 
+    def extend(self, *, n: int) -> Sweep:
+        """Append ``n`` more bit-deterministic Monte Carlo runs to a loaded sweep.
+
+        Only valid on a :class:`Sweep` produced by :meth:`from_manifest`
+        whose manifest's ``parameter_spec._kind`` is ``"monte_carlo"``.
+        The new runs occupy ``run_id`` range ``[old_n, old_n + n)`` where
+        ``old_n`` is the cumulative high-water mark on disk
+        (``parameter_spec["n"] + manifest.extension_run_count``); their
+        per-parameter draws are bit-equal to the same indices of a fresh
+        ``monte_carlo(n=old_n+n, ...)`` call thanks to the position-
+        determinism of :func:`numpy.random.SeedSequence.spawn`.
+
+        Refuses with :class:`SweepConfigError` if any ``run_id`` in
+        ``[0, old_n)`` is missing on disk or has a ``failed`` latest
+        status — extending across an unfinished base would silently
+        produce a manifest with gaps. Call :meth:`resume` first to fill
+        them in.
+
+        Returns ``self`` for chaining (typical use is
+        ``sweep.extend(n=...).to_dataframe()``).
+        """
+        if not self._loaded_from_manifest or self._manifest is None:
+            raise RuntimeError("Sweep.extend requires a Sweep built via Sweep.from_manifest")
+        manifest = self._manifest
+
+        kind = manifest.parameter_spec.get("_kind")
+        if kind != "monte_carlo":
+            raise SweepConfigError(
+                f"Sweep.extend only applies to Monte Carlo sweeps; "
+                f"this manifest is parameter_spec._kind={kind!r}"
+            )
+
+        original_n = int(manifest.parameter_spec["n"])
+        old_n = original_n + manifest.extension_run_count
+
+        # Refuse on a torn base — extending past gaps would mix run_ids in a
+        # way the aggregated DataFrame can't recover from.
+        gaps_failed = [rid for rid in manifest.find_failed() if rid < old_n]
+        gaps_missing = manifest.find_missing(range(old_n))
+        if gaps_failed or gaps_missing:
+            details = []
+            if gaps_failed:
+                details.append(f"failed: {sorted(gaps_failed)}")
+            if gaps_missing:
+                details.append(f"missing: {sorted(gaps_missing)}")
+            raise SweepConfigError(
+                "Sweep.extend refuses to append onto an incomplete base sweep "
+                f"(run_ids in [0, {old_n}) — {'; '.join(details)}). "
+                "Call .resume() first to fill the gaps, then extend."
+            )
+
+        if n < 1:
+            raise SweepConfigError(f"Sweep.extend requires n >= 1, got {n}")
+
+        # Local imports keep gmat_sweep.sweep cycle-free at import time.
+        from gmat_sweep.distributions import _deserialise_perturb
+        from gmat_sweep.grids import expand_monte_carlo_extension_to_run_specs
+
+        perturb = _deserialise_perturb(manifest.parameter_spec["perturb"])
+        seed = manifest.parameter_spec.get("seed")
+        new_runs = expand_monte_carlo_extension_to_run_specs(
+            perturb,
+            old_n=old_n,
+            n=n,
+            seed=None if seed is None else int(seed),
+            script_path=self._script_path,
+            output_dir=self._output_dir,
+        )
+        self._enforce_debug_pool_single_spec(new_runs)
+
+        specs_by_run_id: dict[int, RunSpec] = {s.run_id: s for s in new_runs}
+        futures: list[Future[RunOutcome]] = [self._backend.submit(s) for s in new_runs]
+
+        progress_bar = tqdm(
+            total=len(new_runs),
+            disable=not self._progress,
+            desc="gmat-sweep extend",
+            unit="run",
+        )
+        try:
+            for outcome in self._backend.as_completed(futures):
+                spec = specs_by_run_id[outcome.run_id]
+                entry = ManifestEntry.from_outcome(
+                    outcome,
+                    overrides=spec.overrides,
+                    log_path=spec.output_dir / _WORKER_LOG_NAME,
+                )
+                manifest.append_entry(entry)
+                progress_bar.update(1)
+        finally:
+            progress_bar.close()
+
+        # Track the new specs on the Sweep so a follow-up resume() (e.g. if
+        # a worker in this batch failed) can find them in self._runs.
+        self._runs.extend(new_runs)
+
+        # Reload to dedupe by run_id last-wins, matching resume().
+        self._manifest = Manifest.load(self._manifest_path)
+        return self
+
     def to_manifest(self) -> Manifest:
         """Return the manifest populated by :meth:`run`."""
         if self._manifest is None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1188,6 +1188,117 @@ def test_resume_help_lists_allow_script_drift(capsys: pytest.CaptureFixture[str]
     assert "--script" in out
 
 
+# ---- extend subcommand --------------------------------------------------
+
+
+def test_extend_appends_new_runs_and_prints_combined_summary(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun, capsys: pytest.CaptureFixture[str]
+) -> None:
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+
+    rc = cli.main(
+        [
+            "monte-carlo",
+            "--n",
+            "4",
+            "--perturb",
+            "Sat.SMA=normal:7100:50",
+            "--seed",
+            "42",
+            "--workers",
+            "1",
+            "--out",
+            str(out),
+            str(script),
+        ]
+    )
+    assert rc == 0
+    capsys.readouterr()
+
+    rc = cli.main(
+        [
+            "extend",
+            str(out / "manifest.jsonl"),
+            "--n",
+            "6",
+            "--script",
+            str(script),
+            "--workers",
+            "1",
+        ]
+    )
+    assert rc == 0
+    summary = capsys.readouterr().out.splitlines()[0]
+    assert "10 runs" in summary  # 4 original + 6 extended
+    assert "10 ok" in summary
+
+
+def test_extend_on_missing_manifest_exits_manifest_code(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    script = _write_script(tmp_path)
+    rc = cli.main(
+        [
+            "extend",
+            str(tmp_path / "no-such-manifest.jsonl"),
+            "--n",
+            "2",
+            "--script",
+            str(script),
+        ]
+    )
+    assert rc == cli.EXIT_MANIFEST
+    assert "not found" in capsys.readouterr().err
+
+
+def test_extend_on_grid_manifest_exits_config_code(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A grid manifest is structurally valid but extend refuses it — the
+    SweepConfigError surfaces as exit code 2."""
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+    cli.main(
+        [
+            "run",
+            "--grid",
+            "Sat.SMA=7000:7100:2",
+            "--workers",
+            "1",
+            "--out",
+            str(out),
+            str(script),
+        ]
+    )
+    capsys.readouterr()
+
+    rc = cli.main(
+        [
+            "extend",
+            str(out / "manifest.jsonl"),
+            "--n",
+            "3",
+            "--script",
+            str(script),
+        ]
+    )
+    assert rc == cli.EXIT_CONFIG
+    assert "Monte Carlo" in capsys.readouterr().err
+
+
+def test_extend_help_lists_allow_script_drift(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["extend", "--help"])
+    assert exc_info.value.code == 0
+    out = capsys.readouterr().out
+    assert "--allow-script-drift" in out
+    assert "--script" in out
+    assert "--n" in out
+
+
 # ---- archive subcommand -------------------------------------------------
 
 

--- a/tests/test_monte_carlo_determinism.py
+++ b/tests/test_monte_carlo_determinism.py
@@ -21,7 +21,7 @@ from typing import Any
 
 import pandas as pd
 
-from gmat_sweep.api import monte_carlo
+from gmat_sweep.api import monte_carlo, monte_carlo_extend
 from gmat_sweep.backends.joblib import LocalJoblibPool
 from gmat_sweep.grids import expand_monte_carlo_to_run_specs
 from tests.conftest import FakeGmatRun, FakeMission, FakeResults
@@ -158,6 +158,86 @@ def test_adding_a_second_perturbed_parameter_preserves_first_dataframe_draws(
     )
 
     pd.testing.assert_series_equal(df_one["x"], df_two["x"])
+
+
+# ---- monte_carlo_extend bit-equivalence (issue #92) ----------------------
+
+
+def test_extend_preserves_original_run_ids_bit_for_bit(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    """A 100-run MC followed by ``monte_carlo_extend(n=200)`` produces a
+    300-run aggregated DataFrame whose first 100 ``run_id``\\ s match the
+    original 100 bit-for-bit. Pinned at the user-visible DataFrame level
+    via the SMA echo so the assertion catches any silent draw drift."""
+    script = _write_script(tmp_path)
+    _install_sma_echoing_loader(fake_gmat_run)
+    out = tmp_path / "out"
+
+    df_pre = monte_carlo(
+        script,
+        n=100,
+        perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
+        seed=42,
+        backend=LocalJoblibPool(workers=1),
+        out=out,
+        progress=False,
+    )
+
+    df_post = monte_carlo_extend(
+        out / "manifest.jsonl",
+        script,
+        n=200,
+        backend=LocalJoblibPool(workers=1),
+        progress=False,
+    )
+
+    assert df_post.index.get_level_values("run_id").nunique() == 300
+    pd.testing.assert_frame_equal(
+        df_post.loc[df_post.index.get_level_values("run_id") < 100],
+        df_pre,
+    )
+
+
+def test_extend_matches_fresh_full_size_sweep_at_overlap(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    """A fresh 300-run ``monte_carlo(n=300)`` produces a DataFrame whose
+    first 100 ``run_id``\\ s match the extended sweep's first 100
+    bit-for-bit. The contract: extend(n=200) on top of a 100-run base is
+    indistinguishable from monte_carlo(n=300) at every run_id < 300."""
+    script = _write_script(tmp_path)
+    _install_sma_echoing_loader(fake_gmat_run)
+
+    base_out = tmp_path / "base"
+    monte_carlo(
+        script,
+        n=100,
+        perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
+        seed=42,
+        backend=LocalJoblibPool(workers=1),
+        out=base_out,
+        progress=False,
+    )
+    df_extended = monte_carlo_extend(
+        base_out / "manifest.jsonl",
+        script,
+        n=200,
+        backend=LocalJoblibPool(workers=1),
+        progress=False,
+    )
+
+    df_fresh = monte_carlo(
+        script,
+        n=300,
+        perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
+        seed=42,
+        backend=LocalJoblibPool(workers=1),
+        out=tmp_path / "fresh",
+        progress=False,
+    )
+
+    pd.testing.assert_frame_equal(df_extended, df_fresh)
 
 
 # ---- cross-process determinism -------------------------------------------

--- a/tests/test_monte_carlo_extend.py
+++ b/tests/test_monte_carlo_extend.py
@@ -1,0 +1,348 @@
+"""Structural tests for monte_carlo_extend / latin_hypercube_extend (issue #92).
+
+End-to-end bit-equivalence assertions live in
+``test_monte_carlo_determinism.py`` next to the rest of the determinism
+contract; this file holds the validation, refusal, and Manifest-property
+tests that don't need a running sweep.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pytest
+
+from gmat_sweep.api import latin_hypercube, latin_hypercube_extend, monte_carlo, monte_carlo_extend
+from gmat_sweep.backends.joblib import LocalJoblibPool
+from gmat_sweep.errors import SweepConfigError
+from gmat_sweep.grids import expand_monte_carlo_extension_to_run_specs
+from gmat_sweep.manifest import Manifest
+from tests.conftest import FakeGmatRun, FakeMission, FakeResults
+
+
+def _write_script(tmp_path: Path) -> Path:
+    path = tmp_path / "mission.script"
+    path.write_text("% GMAT mission\nCreate Spacecraft Sat;\n", encoding="utf-8")
+    return path
+
+
+def _install_payload_loader(fake_gmat_run: FakeGmatRun) -> None:
+    """Loader whose runs always return a one-row constant report."""
+    payload = pd.DataFrame({"time": pd.to_datetime(["2026-05-04T00:00:00"]), "x": [1.0]})
+
+    def _run(**_: Any) -> FakeResults:
+        return FakeResults(reports={"R": payload})
+
+    fake_gmat_run.install_loader(run_hook=_run)
+
+
+# ---- expand_monte_carlo_extension_to_run_specs ---------------------------
+
+
+def test_extension_expander_emits_only_the_requested_tail(tmp_path: Path) -> None:
+    specs = expand_monte_carlo_extension_to_run_specs(
+        perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
+        old_n=100,
+        n=20,
+        seed=42,
+        script_path=tmp_path / "mission.script",
+        output_dir=tmp_path / "out",
+    )
+    assert [s.run_id for s in specs] == list(range(100, 120))
+    # Output dirs follow the same run-<run_id> convention as the original.
+    assert specs[0].output_dir.name == "run-100"
+    assert specs[-1].output_dir.name == "run-119"
+
+
+def test_extension_expander_overlap_is_bit_equal_to_original(tmp_path: Path) -> None:
+    """Extending [old_n, old_n + n) draws the same per-parameter values as
+    a fresh expand_monte_carlo_to_run_specs(total) call at the same indices.
+
+    This is the property the high-level contract rests on, exposed at the
+    expander layer so a regression in :func:`numpy.random.SeedSequence.spawn`
+    or in our derivation surfaces here rather than at end-to-end DataFrame
+    comparison."""
+    from gmat_sweep.grids import expand_monte_carlo_to_run_specs
+
+    perturb = {
+        "Sat.SMA": ("normal", 7100.0, 50.0),
+        "Sat.INC": ("uniform", 0.0, 90.0),
+    }
+    fresh = expand_monte_carlo_to_run_specs(
+        perturb=perturb,
+        n=300,
+        seed=42,
+        script_path=tmp_path / "mission.script",
+        output_dir=tmp_path / "out",
+    )
+    extension = expand_monte_carlo_extension_to_run_specs(
+        perturb=perturb,
+        old_n=100,
+        n=200,
+        seed=42,
+        script_path=tmp_path / "mission.script",
+        output_dir=tmp_path / "out",
+    )
+
+    assert [s.overrides for s in extension] == [s.overrides for s in fresh[100:300]]
+    assert [s.seed for s in extension] == [s.seed for s in fresh[100:300]]
+
+
+def test_extension_expander_validates_inputs(tmp_path: Path) -> None:
+    perturb = {"Sat.SMA": ("normal", 7100.0, 50.0)}
+    script_path = tmp_path / "mission.script"
+    output_dir = tmp_path / "out"
+    with pytest.raises(SweepConfigError, match="non-empty perturb"):
+        expand_monte_carlo_extension_to_run_specs(
+            perturb={},
+            old_n=10,
+            n=5,
+            seed=42,
+            script_path=script_path,
+            output_dir=output_dir,
+        )
+    with pytest.raises(SweepConfigError, match="old_n >= 0"):
+        expand_monte_carlo_extension_to_run_specs(
+            perturb=perturb,
+            old_n=-1,
+            n=5,
+            seed=42,
+            script_path=script_path,
+            output_dir=output_dir,
+        )
+    with pytest.raises(SweepConfigError, match="n >= 1"):
+        expand_monte_carlo_extension_to_run_specs(
+            perturb=perturb,
+            old_n=10,
+            n=0,
+            seed=42,
+            script_path=script_path,
+            output_dir=output_dir,
+        )
+
+
+# ---- Manifest.extension_run_count ----------------------------------------
+
+
+def test_extension_run_count_is_zero_for_fresh_monte_carlo(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    script = _write_script(tmp_path)
+    _install_payload_loader(fake_gmat_run)
+    out = tmp_path / "out"
+    monte_carlo(
+        script,
+        n=10,
+        perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
+        seed=42,
+        backend=LocalJoblibPool(workers=1),
+        out=out,
+        progress=False,
+    )
+    manifest = Manifest.load(out / "manifest.jsonl")
+    assert manifest.extension_run_count == 0
+
+
+def test_extension_run_count_is_positive_after_extend(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    script = _write_script(tmp_path)
+    _install_payload_loader(fake_gmat_run)
+    out = tmp_path / "out"
+    monte_carlo(
+        script,
+        n=10,
+        perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
+        seed=42,
+        backend=LocalJoblibPool(workers=1),
+        out=out,
+        progress=False,
+    )
+    monte_carlo_extend(
+        out / "manifest.jsonl",
+        script,
+        n=15,
+        backend=LocalJoblibPool(workers=1),
+        progress=False,
+    )
+    manifest = Manifest.load(out / "manifest.jsonl")
+    assert manifest.extension_run_count == 15
+    # parameter_spec.n stays frozen at the original value — header is append-only.
+    assert manifest.parameter_spec["n"] == 10
+
+
+def test_extension_run_count_is_zero_for_grid_manifest(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    """The derivation only applies to MC sweeps; a grid manifest (which has
+    no concept of cumulative extension) reports zero."""
+    from gmat_sweep.api import sweep
+
+    script = _write_script(tmp_path)
+    _install_payload_loader(fake_gmat_run)
+    out = tmp_path / "out"
+    sweep(
+        script,
+        grid={"Sat.SMA": [7000.0, 7100.0, 7200.0]},
+        backend=LocalJoblibPool(workers=1),
+        out=out,
+        progress=False,
+    )
+    manifest = Manifest.load(out / "manifest.jsonl")
+    assert manifest.extension_run_count == 0
+
+
+# ---- monte_carlo_extend refusal paths ------------------------------------
+
+
+def test_extend_refuses_grid_manifest(tmp_path: Path, fake_gmat_run: FakeGmatRun) -> None:
+    from gmat_sweep.api import sweep
+
+    script = _write_script(tmp_path)
+    _install_payload_loader(fake_gmat_run)
+    out = tmp_path / "out"
+    sweep(
+        script,
+        grid={"Sat.SMA": [7000.0, 7100.0]},
+        backend=LocalJoblibPool(workers=1),
+        out=out,
+        progress=False,
+    )
+    with pytest.raises(SweepConfigError, match="only applies to Monte Carlo"):
+        monte_carlo_extend(
+            out / "manifest.jsonl",
+            script,
+            n=5,
+            backend=LocalJoblibPool(workers=1),
+            progress=False,
+        )
+
+
+def test_extend_refuses_when_base_has_failed_runs(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    """A torn base sweep — even one failed run — must block extension and
+    direct the user at .resume() first. The contiguity invariant on
+    [0, old_n) keeps the manifest interpretable downstream."""
+    from types import SimpleNamespace
+
+    script = _write_script(tmp_path)
+    payload = pd.DataFrame({"time": pd.to_datetime(["2026-05-04T00:00:00"]), "x": [1.0]})
+    fail_run_ids = {2, 5}
+    seen: list[int] = []
+
+    def _load(path: Any, **_: Any) -> FakeMission:
+        mission = FakeMission(script_path=Path(path))
+        my_id = len(seen)
+        seen.append(my_id)
+
+        def _run(**_kwargs: Any) -> FakeResults:
+            if my_id in fail_run_ids:
+                raise RuntimeError("synthetic failure")
+            return FakeResults(reports={"R": payload})
+
+        mission.run_hook = _run
+        fake_gmat_run.last_mission = mission
+        return mission
+
+    fake_gmat_run.module.Mission = SimpleNamespace(load=_load)  # type: ignore[attr-defined]
+    out = tmp_path / "out"
+    monte_carlo(
+        script,
+        n=10,
+        perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
+        seed=42,
+        backend=LocalJoblibPool(workers=1),
+        out=out,
+        progress=False,
+    )
+
+    with pytest.raises(SweepConfigError, match="incomplete base sweep"):
+        monte_carlo_extend(
+            out / "manifest.jsonl",
+            script,
+            n=5,
+            backend=LocalJoblibPool(workers=1),
+            progress=False,
+        )
+
+
+def test_extend_validates_n_positive(tmp_path: Path, fake_gmat_run: FakeGmatRun) -> None:
+    script = _write_script(tmp_path)
+    _install_payload_loader(fake_gmat_run)
+    out = tmp_path / "out"
+    monte_carlo(
+        script,
+        n=4,
+        perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
+        seed=42,
+        backend=LocalJoblibPool(workers=1),
+        out=out,
+        progress=False,
+    )
+    with pytest.raises(SweepConfigError, match="n >= 1"):
+        monte_carlo_extend(
+            out / "manifest.jsonl",
+            script,
+            n=0,
+            backend=LocalJoblibPool(workers=1),
+            progress=False,
+        )
+
+
+def test_extend_refuses_on_script_drift(tmp_path: Path, fake_gmat_run: FakeGmatRun) -> None:
+    """A drifted script triggers Sweep.from_manifest's hash check before any
+    runs dispatch — same surface as resume."""
+    script = _write_script(tmp_path)
+    _install_payload_loader(fake_gmat_run)
+    out = tmp_path / "out"
+    monte_carlo(
+        script,
+        n=4,
+        perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
+        seed=42,
+        backend=LocalJoblibPool(workers=1),
+        out=out,
+        progress=False,
+    )
+    script.write_text("% drifted contents\n", encoding="utf-8")
+    with pytest.raises(SweepConfigError, match="script hash mismatch"):
+        monte_carlo_extend(
+            out / "manifest.jsonl",
+            script,
+            n=2,
+            backend=LocalJoblibPool(workers=1),
+            progress=False,
+        )
+
+
+# ---- latin_hypercube_extend ----------------------------------------------
+
+
+def test_latin_hypercube_extend_refuses_with_clear_message(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    """latin_hypercube_extend raises immediately with a message that names
+    'stratification' so callers grepping for the reason find it."""
+    script = _write_script(tmp_path)
+    _install_payload_loader(fake_gmat_run)
+    out = tmp_path / "out"
+    latin_hypercube(
+        script,
+        n=8,
+        perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
+        seed=42,
+        backend=LocalJoblibPool(workers=1),
+        out=out,
+        progress=False,
+    )
+    with pytest.raises(SweepConfigError, match="stratification"):
+        latin_hypercube_extend(
+            out / "manifest.jsonl",
+            script,
+            n=4,
+            backend=LocalJoblibPool(workers=1),
+            progress=False,
+        )


### PR DESCRIPTION
## Summary

- `monte_carlo_extend(manifest, script, *, n, backend, allow_script_drift=False, progress=True)` runs only the new `n` samples on top of an existing sweep; the original `run_id`s' draws are bit-equal to the same indices of a fresh `monte_carlo(n=old_n + n, seed=...)`. Extends the surface signature from the issue with `script` to match `Sweep.from_manifest` (the manifest stores only the `script_sha256`, not the path).
- `latin_hypercube_extend` raises `SweepConfigError` immediately — extending an LH sweep would change the per-axis stratification of every sample.
- `Sweep.extend(n=...)` is the underlying method, gated on `_loaded_from_manifest` like `resume`. Refuses on a torn base (any `failed` or missing run in `[0, old_n)`) and points at `.resume()`.
- `Manifest.extension_run_count` is a derived property — no on-disk header field. Computed from `max(run_id) + 1 - parameter_spec["n"]` for MC manifests; zero otherwise.
- `gmat-sweep extend MANIFEST --n N --script PATH` is the CLI subcommand. Same `--allow-script-drift` and backend flags as `resume`.

## Test plan

- [ ] `uv run pytest` — 682 unit tests pass locally (1 skipped: mpi4py not installed in dev env, expected).
- [ ] `uv run ruff check`, `uv run ruff format --check`, `uv run mypy` all clean.
- [ ] DoD bit-equivalence: `test_extend_preserves_original_run_ids_bit_for_bit`, `test_extend_matches_fresh_full_size_sweep_at_overlap` in `test_monte_carlo_determinism.py`.
- [ ] Refusal paths covered: grid manifest, incomplete base sweep, `n < 1`, script drift, LH manifest.
- [ ] CLI: happy path + missing manifest + grid-manifest refusal + `--help` lists the new flags.
- [ ] Docs: new "Extending an existing sweep" section in `docs/monte-carlo.md`, schema notes in `docs/manifest-schema.md`, subcommand entry in `docs/cli.md`.

Closes #92.