### PR TITLE
Add CITATION.cff and JOSS paper skeleton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,21 @@ jobs:
       - run: pip install .
       - run: python -c "import gmat_sweep"
 
+  # Validate CITATION.cff against the Citation File Format v1.2.0 schema.
+  # cffconvert is installed standalone (not via uv sync) because it is a
+  # CI-only schema check, not part of the dev or runtime dependency graph.
+  citation:
+    name: citation file (cffconvert)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install cffconvert==2.0.0
+      - run: cffconvert --validate -i CITATION.cff
+
   # Per-backend throughput regression: runs the 50-run scaled variant of the
   # canonical reference benchmark on each of LocalJoblibPool / DaskPool /
   # RayPool and asserts each backend's measured throughput meets the floor

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,27 @@
+cff-version: 1.2.0
+message: "If you use gmat-sweep in academic work, please cite it using the metadata below."
+title: gmat-sweep
+abstract: >-
+  gmat-sweep is a Python library that runs parameter sweeps and Monte Carlo
+  dispersions over NASA General Mission Analysis Tool (GMAT) missions in
+  parallel. It fans a working .script across subprocess workers, aggregates
+  each run's outputs into multi-indexed pandas DataFrames, and writes a
+  reproducible JSON Lines manifest so any sweep can be resumed or re-run
+  bit-for-bit.
+type: software
+authors:
+  - given-names: Dimitrije
+    family-names: Jankovic
+version: 0.3.0
+date-released: "2026-05-08"
+license: MIT
+repository-code: "https://github.com/astro-tools/gmat-sweep"
+url: "https://github.com/astro-tools/gmat-sweep"
+keywords:
+  - gmat
+  - astrodynamics
+  - orbital-mechanics
+  - mission-analysis
+  - monte-carlo
+  - parameter-sweep
+  - parallel

--- a/joss/paper.bib
+++ b/joss/paper.bib
@@ -1,10 +1,9 @@
-% v0.4-cycle skeleton bibliography for joss/paper.md.
+% Skeleton bibliography for joss/paper.md.
 %
 % These entries exist so the paper.md skeleton has live citations to
 % reference and so the JOSS pandoc-citeproc pipeline can be exercised
 % end-to-end. Bibliographic detail (DOIs, exact page ranges, accessed
-% dates) should be verified during the v1.0 paper drafting before
-% submission to JOSS.
+% dates) should be verified before submission to JOSS.
 
 @inproceedings{gmat-nasa,
   author    = {Hughes, Steven P. and Qureshi, Rizwan H. and Cooley, Steven D. and Parker, Jeffrey J.},

--- a/joss/paper.bib
+++ b/joss/paper.bib
@@ -1,0 +1,54 @@
+% v0.4-cycle skeleton bibliography for joss/paper.md.
+%
+% These entries exist so the paper.md skeleton has live citations to
+% reference and so the JOSS pandoc-citeproc pipeline can be exercised
+% end-to-end. Bibliographic detail (DOIs, exact page ranges, accessed
+% dates) should be verified during the v1.0 paper drafting before
+% submission to JOSS.
+
+@inproceedings{gmat-nasa,
+  author    = {Hughes, Steven P. and Qureshi, Rizwan H. and Cooley, Steven D. and Parker, Jeffrey J.},
+  title     = {Verification and Validation of the General Mission Analysis Tool ({GMAT})},
+  booktitle = {AIAA/AAS Astrodynamics Specialist Conference},
+  year      = {2014},
+  publisher = {American Institute of Aeronautics and Astronautics}
+}
+
+@misc{gmat-run,
+  author = {Jankovic, Dimitrije},
+  title  = {{gmat-run}: A {Pythonic} single-run wrapper for {NASA} {GMAT}},
+  year   = {2026},
+  url    = {https://github.com/astro-tools/gmat-run}
+}
+
+@misc{joblib,
+  author = {{Joblib Development Team}},
+  title  = {Joblib: Running {Python} functions as pipeline jobs},
+  year   = {2026},
+  url    = {https://joblib.readthedocs.io/}
+}
+
+@inproceedings{dask,
+  author    = {Rocklin, Matthew},
+  title     = {{Dask}: Parallel Computation with Blocked Algorithms and Task Scheduling},
+  booktitle = {Proceedings of the 14th Python in Science Conference (SciPy 2015)},
+  year      = {2015}
+}
+
+@inproceedings{ray,
+  author    = {Moritz, Philipp and Nishihara, Robert and Wang, Stephanie and Tumanov, Alexey and Liaw, Richard and Liang, Eric and Elibol, Melih and Yang, Zongheng and Paul, William and Jordan, Michael I. and Stoica, Ion},
+  title     = {{Ray}: A Distributed Framework for Emerging {AI} Applications},
+  booktitle = {13th USENIX Symposium on Operating Systems Design and Implementation (OSDI 18)},
+  year      = {2018},
+  pages     = {561--577}
+}
+
+@article{scipy,
+  author  = {Virtanen, Pauli and Gommers, Ralf and Oliphant, Travis E. and others},
+  title   = {{SciPy} 1.0: Fundamental Algorithms for Scientific Computing in {Python}},
+  journal = {Nature Methods},
+  year    = {2020},
+  volume  = {17},
+  pages   = {261--272},
+  doi     = {10.1038/s41592-019-0686-2}
+}

--- a/joss/paper.md
+++ b/joss/paper.md
@@ -20,11 +20,11 @@ bibliography: paper.bib
 ---
 
 <!--
-This file is a v0.4-cycle skeleton. The narrative content is intentionally
-stub-level; the paper itself is drafted as part of the v1.0 adoption push
-(see issue #94). When expanding this paper, replace the TODO markers below
-with real prose, verify every bib entry in paper.bib, and confirm the author
-ORCID + affiliation reflect the submitting state at JOSS submission time.
+This file is a skeleton. The narrative content is intentionally stub-level;
+flesh it out before submitting to JOSS. When expanding this paper, replace
+the TODO markers below with real prose, verify every bib entry in paper.bib,
+and confirm the author ORCID + affiliation reflect the submitting state at
+JOSS submission time.
 -->
 
 # Summary
@@ -37,7 +37,7 @@ fans the run set across subprocess workers, aggregates each run's outputs
 into multi-indexed `pandas` DataFrames, and writes a JSON Lines manifest
 so any sweep is reproducible and resumable.
 
-<!-- v1.0 TODO: expand the summary into the standard JOSS three-paragraph form. -->
+<!-- TODO: expand the summary into the standard JOSS three-paragraph form. -->
 
 # Statement of need
 
@@ -57,7 +57,7 @@ the well-validated distributions in SciPy [@scipy], and per-run sub-seeds
 derive deterministically from a user-supplied root seed so a resumed
 sweep samples the same values for any given run identifier.
 
-<!-- v1.0 TODO: contrast with adjacent tooling and expand on the gap. -->
+<!-- TODO: contrast with adjacent tooling and expand on the gap. -->
 
 # Functionality overview
 
@@ -92,7 +92,7 @@ status. A killed sweep restarts from the manifest and re-runs only the
 missing or failed entries; the underlying `gmat-run` [@gmat-run]
 single-run primitive carries the per-run isolation contract.
 
-<!-- v1.0 TODO: add benchmark figures and a worked example. -->
+<!-- TODO: add benchmark figures and a worked example. -->
 
 # Acknowledgements
 
@@ -100,6 +100,6 @@ The author thanks the GMAT development team at NASA Goddard Space Flight
 Center for maintaining the underlying mission-analysis platform that
 `gmat-sweep` builds upon.
 
-<!-- v1.0 TODO: acknowledge specific reviewers, contributors, and funding sources at submission time. -->
+<!-- TODO: acknowledge specific reviewers, contributors, and funding sources at submission time. -->
 
 # References

--- a/joss/paper.md
+++ b/joss/paper.md
@@ -1,0 +1,105 @@
+---
+title: 'gmat-sweep: Parallel parameter sweeps and Monte Carlo dispersions over NASA GMAT missions'
+tags:
+  - Python
+  - astrodynamics
+  - orbital mechanics
+  - mission analysis
+  - Monte Carlo
+  - parameter sweep
+  - parallel computing
+  - GMAT
+authors:
+  - name: Dimitrije Jankovic
+    affiliation: 1
+affiliations:
+  - name: Independent researcher
+    index: 1
+date: 9 May 2026
+bibliography: paper.bib
+---
+
+<!--
+This file is a v0.4-cycle skeleton. The narrative content is intentionally
+stub-level; the paper itself is drafted as part of the v1.0 adoption push
+(see issue #94). When expanding this paper, replace the TODO markers below
+with real prose, verify every bib entry in paper.bib, and confirm the author
+ORCID + affiliation reflect the submitting state at JOSS submission time.
+-->
+
+# Summary
+
+`gmat-sweep` is a Python library for running parameter sweeps and Monte
+Carlo dispersions over NASA's General Mission Analysis Tool [GMAT,
+@gmat-nasa] in parallel. Given a working `.script` mission and either a
+parameter grid, an explicit run table, or a perturbation distribution, it
+fans the run set across subprocess workers, aggregates each run's outputs
+into multi-indexed `pandas` DataFrames, and writes a JSON Lines manifest
+so any sweep is reproducible and resumable.
+
+<!-- v1.0 TODO: expand the summary into the standard JOSS three-paragraph form. -->
+
+# Statement of need
+
+Mission-analysis workflows routinely require running the same GMAT mission
+hundreds or thousands of times under varied initial conditions, perturbed
+parameters, or stochastic dispersions. GMAT's own scripting layer offers
+no first-class abstraction for parametric or Monte Carlo execution, and
+running independent missions sequentially leaves modern multi-core and
+cluster hardware idle.
+
+`gmat-sweep` fills that gap with four entry points (`sweep`,
+`monte_carlo`, `latin_hypercube`, and an explicit-row variant of `sweep`)
+and a pluggable backend layer that targets local thread/process pools via
+`joblib` [@joblib], distributed clusters via Dask [@dask] or Ray [@ray],
+HPC schedulers via MPI, and Kubernetes Jobs. Statistical sampling reuses
+the well-validated distributions in SciPy [@scipy], and per-run sub-seeds
+derive deterministically from a user-supplied root seed so a resumed
+sweep samples the same values for any given run identifier.
+
+<!-- v1.0 TODO: contrast with adjacent tooling and expand on the gap. -->
+
+# Functionality overview
+
+## Parameter sweeps
+
+`sweep()` accepts either a full-factorial grid over one or more
+dotted-path fields of the GMAT script, or an explicit `pandas` DataFrame
+of run parameters. The aggregated output is a `(run_id, time)`-indexed
+DataFrame that streams from per-run Parquet files, so sweeps with tens of
+thousands of runs do not have to fit in memory.
+
+## Monte Carlo and Latin hypercube
+
+`monte_carlo()` and `latin_hypercube()` build on the same execution
+machinery but draw their parameter rows from named distributions
+(`normal`, `uniform`, `lognormal`, etc.) before dispatch. The seeding
+contract guarantees bit-reproducible draws across runs and resumes.
+
+## Cluster backends
+
+A single `Pool` abstraction lets the same `sweep()` call dispatch to a
+local pool, a Dask cluster, a Ray cluster, an MPI communicator, or a
+Kubernetes job pool by switching only the `backend=` argument. A
+cross-backend equivalence suite asserts that the choice of backend is
+purely an execution-only knob with no observable effect on results.
+
+## Reproducibility and resumability
+
+Every sweep emits a JSON Lines manifest fingerprinting the canonical
+script SHA-256, software versions, full parameter spec, and per-run
+status. A killed sweep restarts from the manifest and re-runs only the
+missing or failed entries; the underlying `gmat-run` [@gmat-run]
+single-run primitive carries the per-run isolation contract.
+
+<!-- v1.0 TODO: add benchmark figures and a worked example. -->
+
+# Acknowledgements
+
+The author thanks the GMAT development team at NASA Goddard Space Flight
+Center for maintaining the underlying mission-analysis platform that
+`gmat-sweep` builds upon.
+
+<!-- v1.0 TODO: acknowledge specific reviewers, contributors, and funding sources at submission time. -->
+
+# References


### PR DESCRIPTION
## Summary

- New `CITATION.cff` (CFF v1.2.0) at the repo root, pinned to the v0.3.0 release. GitHub will render the "Cite this repository" sidebar automatically once this lands. Version + `date-released` will be bumped during the v0.4 release-cut PR alongside `CHANGELOG.md` and `pyproject.toml`.
- New `joss/paper.md` and `joss/paper.bib` skeletons. Sections are stub-level per the issue scope (Summary, Statement of need, Functionality overview, Acknowledgements, References) — actual paper drafting is part of the v1.0 push. All bib entries are referenced in the paper, all citations resolve to a bib entry.
- New `citation` CI job runs `cffconvert==2.0.0 --validate -i CITATION.cff` on every PR. Pinned, no `uv sync` (CI-only schema check, not a dev dependency).

## Notes / outstanding decisions

- Issue body lists `Paramat / joblib / Dask / Ray / SciPy` as bib entries. I do not know what Paramat refers to — possibly a typo. Omitted from `paper.bib` rather than fabricating a citation; please add or correct if it was intended.
- `paper.md` author entry uses "Independent researcher" affiliation and omits ORCID. Both are flagged with `<!-- v1.0 TODO -->` markers to be resolved at JOSS submission time.
- Bib bibliographic detail (DOIs, page ranges) is best-effort skeleton-quality. The bib file's header comment instructs the v1.0 drafter to verify each entry before submission.

## Test plan

- [x] `cffconvert --validate -i CITATION.cff` passes locally.
- [x] `paper.md` YAML frontmatter parses cleanly.
- [x] All `@key` citations in `paper.md` resolve to a bib entry, and every bib entry is cited.
- [ ] New `citation` CI job passes on this PR.
- [ ] After merge + v0.4 tag, GitHub renders the "Cite this repository" sidebar entry on the repo homepage.

Closes #94