### PR TITLE
mc_convergence: running mean / SE-of-mean diagnostic helper

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -70,9 +70,13 @@ auto-generated from docstrings via
 
 ::: gmat_sweep.sweep_summary
 
+::: gmat_sweep.mc_convergence
+
 ## Plotting
 
 ::: gmat_sweep.plotting.sweep_band_plot
+
+::: gmat_sweep.plotting.mc_convergence_plot
 
 ## Exceptions
 

--- a/docs/monte-carlo.md
+++ b/docs/monte-carlo.md
@@ -204,6 +204,65 @@ ok = df[df["__status"] == "ok"]
 failed = df[df["__status"] == "failed"]
 ```
 
+## Convergence diagnostics
+
+Once a Monte Carlo finishes, the next question is "did I draw enough
+samples?". [`mc_convergence()`][gmat_sweep.mc_convergence] reduces every
+run to one scalar under a metric of your choice, then reports the
+running mean, running standard deviation, and standard error of the mean
+across `run_id` prefixes — `n = 1, 2, …, N`. A flattening centre and a
+shrinking `se_mean` curve indicate that the estimator has stabilised:
+
+```python
+from gmat_sweep import mc_convergence
+
+# Pick a metric — here, the final-time miss distance per run.
+conv = mc_convergence(df, "MissDistance", terminal_only=True)
+conv.tail()
+#         n  running_mean  running_std    se_mean
+# 1995  1996      127.34      14.21     0.318
+# 1996  1997      127.32      14.20     0.318
+# ...
+```
+
+`se_mean` is the parametric standard error `running_std / sqrt(n)` (with
+`ddof=1`); for `N(0, σ²)` draws it tracks `σ / sqrt(n)` to within
+small-sample noise — the operational definition of "converged" most
+analyses use.
+
+For derived metrics that aren't already a column of `df`, pass a callable
+that reduces a per-run subframe to a float:
+
+```python
+import numpy as np
+
+def final_state_miss(sub):
+    """Distance from the nominal final state for one run."""
+    return float(np.linalg.norm(sub.iloc[-1][["X", "Y", "Z"]].to_numpy() - nominal_xyz))
+
+conv = mc_convergence(df, final_state_miss)
+```
+
+`terminal_only=False` (the default for column-name metrics) keeps every
+time step and emits one running curve per `time`, so you can ask "did
+each step's mean stabilise?" rather than only the terminal state. The
+output gains a leading `time` column and is otherwise identical.
+
+The companion plot helper renders the running mean and the ±1·SE band:
+
+```python
+from gmat_sweep.plotting import mc_convergence_plot
+
+ax = mc_convergence_plot(conv)
+ax.figure.savefig("convergence.png")
+```
+
+`mc_convergence` is **not** a formal stationarity test — Geweke,
+Gelman-Rubin, and the rest of the MCMC convergence machinery solve a
+different problem (correlated draws from a chain) than independent
+Monte Carlo. The diagnostic here is the parametric SE curve; if it has
+plateaued, the mean has converged.
+
 ## See also
 
 - [Parameter spec → Stochastic specs](parameter-spec.md#stochastic-specs)

--- a/src/gmat_sweep/__init__.py
+++ b/src/gmat_sweep/__init__.py
@@ -8,6 +8,7 @@ from gmat_sweep.aggregate import (
     lazy_ephemerides,
     lazy_fused_reports,
     lazy_multiindex,
+    mc_convergence,
     sweep_summary,
 )
 from gmat_sweep.api import (
@@ -87,6 +88,7 @@ __all__ = [
     "lazy_ephemerides",
     "lazy_fused_reports",
     "lazy_multiindex",
+    "mc_convergence",
     "monte_carlo",
     "monte_carlo_extend",
     "sweep",

--- a/src/gmat_sweep/aggregate.py
+++ b/src/gmat_sweep/aggregate.py
@@ -45,7 +45,7 @@ import pyarrow.dataset as ds
 from gmat_sweep.errors import SweepConfigError
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
 
     from gmat_sweep.manifest import Manifest, ManifestEntry
 
@@ -54,6 +54,7 @@ __all__ = [
     "lazy_ephemerides",
     "lazy_fused_reports",
     "lazy_multiindex",
+    "mc_convergence",
     "sweep_summary",
 ]
 
@@ -718,3 +719,171 @@ def sweep_summary(
         names=["statistic", "field"],
     )
     return result
+
+
+_RUNNING_COLUMNS: tuple[str, ...] = ("running_mean", "running_std", "se_mean")
+
+
+def mc_convergence(
+    df: pd.DataFrame,
+    metric: str | Callable[[pd.DataFrame], float],
+    *,
+    terminal_only: bool = False,
+) -> pd.DataFrame:
+    """Diagnose Monte Carlo convergence: running mean / std / SE of the mean over run-id prefixes.
+
+    Reduces ``df`` to a per-run scalar (or per-run-per-time scalar) under
+    ``metric`` and reports cumulative statistics across the first
+    ``n = 1..N`` runs in ``run_id`` order. Standard error of the mean is
+    ``running_std / sqrt(n)`` with a sample standard deviation
+    (``ddof=1``); ``n=1`` rows therefore carry ``NaN`` for both
+    ``running_std`` and ``se_mean``. Failed and skipped runs are dropped
+    via ``__status`` before the prefix scan, so the ``n`` axis reflects
+    successful runs only.
+
+    Parameters
+    ----------
+    df
+        ``(run_id, time)``-MultiIndexed DataFrame as returned by
+        :func:`gmat_sweep.sweep`, :func:`gmat_sweep.monte_carlo`, or
+        :func:`gmat_sweep.latin_hypercube`. A ``__status`` column, if
+        present, is used to drop non-ok runs.
+    metric
+        Either a column name in ``df`` or a callable
+        ``(per_run_subframe) -> float``. The callable is invoked once per
+        ``run_id`` with that run's ``time``-indexed slice (``__status``
+        dropped) and must return a single float — useful for derived
+        metrics like final-step miss distance.
+    terminal_only
+        ``True`` collapses the time index by taking ``.last()`` per run
+        for column-name metrics — the canonical "did the dispersion of
+        the final state converge?" view. ``False`` (default) keeps every
+        time step and emits one running curve per ``time``. Ignored for
+        callable metrics, which already return one scalar per run.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Long-form frame with columns ``n``, ``running_mean``,
+        ``running_std``, ``se_mean``. When ``terminal_only=False`` and
+        ``metric`` is a column name, an additional leading ``time``
+        column carries the per-time grouping. The frame is sorted by
+        ``time`` (when present) then ``n`` ascending.
+
+    Raises
+    ------
+    SweepConfigError
+        ``df.index`` is not a MultiIndex with a ``run_id`` level; the
+        column-name ``metric`` is not in ``df``; or the callable
+        ``metric`` does not return a numeric scalar.
+
+    Examples
+    --------
+    >>> from gmat_sweep import mc_convergence
+    >>> conv = mc_convergence(df, "MissDistance", terminal_only=True)  # doctest: +SKIP
+    >>> conv.tail()  # doctest: +SKIP
+            n  running_mean  running_std       se_mean
+    995   996      ...           ...           ...
+    """
+    if df.index.nlevels < 2 or _RUN_ID_COL not in (df.index.names or []):
+        raise SweepConfigError(
+            f"mc_convergence: df.index must have a {_RUN_ID_COL!r} level "
+            f"(got names={list(df.index.names or [])})"
+        )
+
+    working = df
+    if _STATUS_COL in working.columns:
+        working = working.loc[working[_STATUS_COL] == "ok"]
+    working = working.drop(columns=[_STATUS_COL], errors="ignore")
+
+    if callable(metric):
+        per_run = _reduce_callable_metric(working, metric)
+        return _running_stats(per_run.to_numpy(), n_offset=1)
+
+    if metric not in working.columns:
+        raise SweepConfigError(
+            f"mc_convergence: metric={metric!r} is not a column of df and is not callable"
+        )
+
+    if terminal_only:
+        per_run_series = working.groupby(level=_RUN_ID_COL)[metric].last().sort_index()
+        return _running_stats(per_run_series.to_numpy(), n_offset=1)
+
+    return _running_stats_per_time(working[metric])
+
+
+def _reduce_callable_metric(
+    df: pd.DataFrame,
+    metric: Callable[[pd.DataFrame], float],
+) -> pd.Series[Any]:
+    values: dict[int, float] = {}
+    for run_id, sub in df.groupby(level=_RUN_ID_COL, sort=True):
+        # Drop the run_id index level so the user-facing subframe is
+        # a plain time-indexed DataFrame.
+        sub_local = cast(pd.DataFrame, sub.droplevel(_RUN_ID_COL))
+        result = metric(sub_local)
+        try:
+            values[int(cast(int, run_id))] = float(result)
+        except (TypeError, ValueError) as exc:
+            raise SweepConfigError(
+                f"mc_convergence: callable metric must return a numeric scalar; "
+                f"run_id={run_id} returned {type(result).__name__}"
+            ) from exc
+    return pd.Series(values, name="metric").sort_index()
+
+
+def _running_stats(values: Any, *, n_offset: int) -> pd.DataFrame:
+    """Vectorised running mean/std/SE over the first k entries for k = 1..len(values)."""
+    arr = np.asarray(values, dtype=float)
+    n_total = arr.size
+    if n_total == 0:
+        empty: dict[str, pd.Series[Any]] = {"n": pd.Series([], dtype="int64")}
+        for col in _RUNNING_COLUMNS:
+            empty[col] = pd.Series([], dtype=float)
+        return pd.DataFrame(empty)
+
+    ks = np.arange(n_offset, n_offset + n_total, dtype=np.int64)
+    counts = np.arange(1, n_total + 1, dtype=float)
+    cumsum = np.cumsum(arr)
+    cumsum_sq = np.cumsum(arr * arr)
+    running_mean = cumsum / counts
+    # Sample variance via the cumulative-moments identity. Clip negatives
+    # from float-rounding when all values agree before sqrt.
+    with np.errstate(invalid="ignore"):
+        var = (cumsum_sq - counts * running_mean * running_mean) / np.where(
+            counts > 1, counts - 1, np.nan
+        )
+    var = np.clip(var, 0.0, None)
+    running_std = np.sqrt(var)
+    se_mean = running_std / np.sqrt(counts)
+    return pd.DataFrame(
+        {
+            "n": ks,
+            "running_mean": running_mean,
+            "running_std": running_std,
+            "se_mean": se_mean,
+        }
+    )
+
+
+def _running_stats_per_time(series: pd.Series[Any]) -> pd.DataFrame:
+    # series is indexed by (run_id, time). Sort by run_id within each time
+    # group so the prefix scan is well-defined, then apply _running_stats
+    # to each group. pandas-stubs types reorder_levels' first arg as
+    # ``list[int]``, so cast to Any for the level-name path.
+    levels: Any = [_TIME_COL, _RUN_ID_COL]
+    sorted_series = series.reorder_levels(levels).sort_index()
+
+    parts: list[pd.DataFrame] = []
+    for time_value, group in sorted_series.groupby(level=_TIME_COL, sort=True):
+        block = _running_stats(group.to_numpy(), n_offset=1)
+        block.insert(0, _TIME_COL, time_value)
+        parts.append(block)
+
+    if not parts:
+        empty = pd.DataFrame({col: pd.Series([], dtype=float) for col in _RUNNING_COLUMNS})
+        empty.insert(0, "n", pd.Series([], dtype="int64"))
+        empty.insert(0, _TIME_COL, pd.Series([], dtype="datetime64[ns]"))
+        return empty
+
+    return pd.concat(parts, axis=0, ignore_index=True)

--- a/src/gmat_sweep/plotting.py
+++ b/src/gmat_sweep/plotting.py
@@ -44,7 +44,7 @@ if TYPE_CHECKING:
 
     from gmat_sweep.manifest import Manifest
 
-__all__ = ["sweep_band_plot", "sweep_corner", "sweep_heatmap"]
+__all__ = ["mc_convergence_plot", "sweep_band_plot", "sweep_corner", "sweep_heatmap"]
 
 
 def sweep_corner(
@@ -548,4 +548,85 @@ def sweep_band_plot(
     x_label = summary.index.name or "index"
     ax.set_xlabel(str(x_label))
     ax.set_ylabel(column)
+    return ax
+
+
+def mc_convergence_plot(
+    conv: pd.DataFrame,
+    *,
+    ax: Axes | None = None,
+    **kwargs: Any,
+) -> Axes:
+    """Plot a Monte Carlo convergence curve from :func:`gmat_sweep.mc_convergence` output.
+
+    Renders the running mean as a line and the ``±1·SE`` envelope as a
+    shaded :meth:`matplotlib.axes.Axes.fill_between` band, with ``n``
+    (sample count) on the x-axis. Visualises whether the per-run scalar
+    metric has stabilised: a flattening centre line and a shrinking band
+    indicate convergence.
+
+    Parameters
+    ----------
+    conv
+        Long-form convergence DataFrame as returned by
+        :func:`gmat_sweep.mc_convergence` with ``terminal_only=True``
+        (or with a callable metric). Must carry the columns ``n``,
+        ``running_mean``, and ``se_mean``. The per-time shape returned
+        by ``terminal_only=False`` is not supported in this release —
+        filter to a single ``time`` first or aggregate to terminal-only.
+    ax
+        Optional pre-existing :class:`matplotlib.axes.Axes`. ``None``
+        (default) creates a fresh figure with size ``(8, 4)`` inches.
+    **kwargs
+        Forwarded to the centre :meth:`matplotlib.axes.Axes.plot` call
+        (e.g. ``label=``, ``linestyle=``, ``linewidth=``). The band's
+        ``fill_between`` reuses the line colour at ``alpha=0.25``.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+        The Axes carrying the convergence plot.
+
+    Raises
+    ------
+    SweepConfigError
+        ``conv`` is missing one of the required columns, or carries the
+        per-time ``time`` column from the ``terminal_only=False`` shape.
+    """
+    import matplotlib.pyplot as plt
+
+    required = {"n", "running_mean", "se_mean"}
+    missing = required - set(conv.columns)
+    if missing:
+        raise SweepConfigError(
+            f"mc_convergence_plot: input is missing required column(s) {sorted(missing)}; "
+            f"got columns {list(conv.columns)}"
+        )
+    if "time" in conv.columns:
+        raise SweepConfigError(
+            "mc_convergence_plot: per-time convergence frames are not supported; "
+            "filter to a single time (e.g. conv[conv['time'] == t]) or rerun "
+            "mc_convergence(terminal_only=True)"
+        )
+
+    if ax is None:
+        _, ax = plt.subplots(figsize=(8, 4))
+
+    n = conv["n"].to_numpy()
+    mean = conv["running_mean"].to_numpy()
+    se = conv["se_mean"].to_numpy()
+
+    plot_kwargs: dict[str, Any] = {"label": "running mean", **kwargs}
+    (line,) = ax.plot(n, mean, **plot_kwargs)
+    ax.fill_between(
+        n,
+        mean - se,
+        mean + se,
+        color=line.get_color(),
+        alpha=0.25,
+        label="±1·SE",
+    )
+
+    ax.set_xlabel("n")
+    ax.set_ylabel("running mean")
     return ax

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -14,6 +15,7 @@ from gmat_sweep.aggregate import (
     lazy_ephemerides,
     lazy_fused_reports,
     lazy_multiindex,
+    mc_convergence,
     sweep_summary,
 )
 from gmat_sweep.errors import SweepConfigError
@@ -799,3 +801,185 @@ def test_sweep_summary_rejects_missing_index_level() -> None:
     df = _summary_df(n_runs=2, n_steps=2).reset_index().set_index("run_id")
     with pytest.raises(SweepConfigError, match=r"does not have a 'time' level"):
         sweep_summary(df)
+
+
+# ---------------------------------------------------------------------------
+# mc_convergence
+# ---------------------------------------------------------------------------
+
+
+def _conv_df(
+    *,
+    n_runs: int,
+    n_steps: int = 1,
+    statuses: dict[int, str] | None = None,
+    seed: int = 42,
+    sigma: float = 1.0,
+) -> pd.DataFrame:
+    """A ``(run_id, time)``-MultiIndexed test frame for mc_convergence.
+
+    Each ok run has ``n_steps`` rows; the per-run final ``miss`` value is
+    drawn from ``N(0, sigma^2)`` under a fixed numpy generator. Earlier
+    rows linearly ramp from 0 to the terminal value, so callable metrics
+    that pull the last row see the same draw as ``terminal_only=True``.
+    """
+    statuses = statuses or {}
+    rng = np.random.default_rng(seed)
+    terminal = rng.normal(loc=0.0, scale=sigma, size=n_runs)
+    rows: list[dict[str, object]] = []
+    times = pd.to_datetime([f"2026-05-04T00:00:0{i}" for i in range(n_steps)])
+    for run_id in range(n_runs):
+        status = statuses.get(run_id, "ok")
+        if status != "ok":
+            rows.append(
+                {
+                    "run_id": run_id,
+                    "time": pd.NaT,
+                    "miss": float("nan"),
+                    "__status": status,
+                }
+            )
+            continue
+        for step, t in enumerate(times):
+            ramp = (step + 1) / n_steps
+            rows.append(
+                {
+                    "run_id": run_id,
+                    "time": t,
+                    "miss": float(terminal[run_id]) * ramp,
+                    "__status": "ok",
+                }
+            )
+    return cast(pd.DataFrame, pd.DataFrame(rows).set_index(["run_id", "time"]))
+
+
+def test_mc_convergence_terminal_only_columns_and_shape() -> None:
+    df = _conv_df(n_runs=10)
+    conv = mc_convergence(df, "miss", terminal_only=True)
+
+    assert list(conv.columns) == ["n", "running_mean", "running_std", "se_mean"]
+    assert len(conv) == 10
+    assert list(conv["n"]) == list(range(1, 11))
+    # n=1 has no sample variance under ddof=1.
+    assert pd.isna(conv.loc[0, "running_std"])
+    assert pd.isna(conv.loc[0, "se_mean"])
+
+
+def test_mc_convergence_matches_hand_rolled_cumulative_stats() -> None:
+    df = _conv_df(n_runs=20)
+    conv = mc_convergence(df, "miss", terminal_only=True)
+
+    terminal = df.groupby(level="run_id")["miss"].last().to_numpy()
+    for k in (1, 2, 5, 10, 20):
+        prefix = terminal[:k]
+        expected_mean = float(prefix.mean())
+        row = conv.loc[k - 1]
+        assert row["running_mean"] == pytest.approx(expected_mean)
+        if k == 1:
+            assert pd.isna(row["running_std"])
+            assert pd.isna(row["se_mean"])
+        else:
+            expected_std = float(prefix.std(ddof=1))
+            assert row["running_std"] == pytest.approx(expected_std)
+            assert row["se_mean"] == pytest.approx(expected_std / np.sqrt(k))
+
+
+def test_mc_convergence_se_curve_matches_sigma_over_sqrt_n() -> None:
+    """Definition-of-done check: ``se_mean(n) ~ sigma / sqrt(n)`` to within MC noise."""
+    sigma = 2.5
+    df = _conv_df(n_runs=2000, sigma=sigma, seed=20260509)
+    conv = mc_convergence(df, "miss", terminal_only=True)
+
+    # The terminal-row SE should land within ~10% of the analytic ceiling
+    # at n=2000 (large enough to suppress the small-sample noise).
+    final = conv.iloc[-1]
+    analytic = sigma / np.sqrt(int(final["n"]))
+    assert abs(float(final["se_mean"]) - analytic) / analytic < 0.10
+
+    # The SE curve's late-n decay rate should track 1/sqrt(n): compare two
+    # samples at n=500 and n=2000 — the ratio should be close to 2.
+    def se_at(n: int) -> float:
+        return float(conv.loc[conv["n"] == n, "se_mean"].iloc[0])
+
+    ratio = se_at(500) / se_at(2000)
+    assert 1.7 < ratio < 2.3
+
+
+def test_mc_convergence_drops_failed_and_skipped_runs() -> None:
+    df = _conv_df(n_runs=8, statuses={2: "failed", 5: "skipped"})
+    conv = mc_convergence(df, "miss", terminal_only=True)
+
+    # 6 ok runs survive after status-filtering.
+    assert len(conv) == 6
+    assert list(conv["n"]) == [1, 2, 3, 4, 5, 6]
+
+
+def test_mc_convergence_callable_metric() -> None:
+    df = _conv_df(n_runs=5)
+    # Callable that returns the final-time absolute value of "miss".
+    conv = mc_convergence(df, lambda sub: float(abs(sub["miss"].iloc[-1])))
+
+    expected = df.groupby(level="run_id")["miss"].last().abs().to_numpy()
+    np.testing.assert_allclose(conv["running_mean"].iloc[-1], expected.mean())
+    assert list(conv.columns) == ["n", "running_mean", "running_std", "se_mean"]
+
+
+def test_mc_convergence_callable_metric_receives_time_indexed_subframe() -> None:
+    df = _conv_df(n_runs=3, n_steps=2)
+    seen_indices: list[Any] = []
+
+    def metric(sub: pd.DataFrame) -> float:
+        seen_indices.append(list(sub.index.names))
+        return float(sub["miss"].iloc[-1])
+
+    mc_convergence(df, metric)
+    # Each sub-frame should have run_id stripped — only the time level remains.
+    assert all(names == ["time"] for names in seen_indices)
+
+
+def test_mc_convergence_callable_metric_bad_return_raises() -> None:
+    df = _conv_df(n_runs=3)
+
+    def bad_metric(sub: pd.DataFrame) -> Any:  # returns a Series, not a float
+        return sub["miss"]
+
+    with pytest.raises(SweepConfigError, match=r"numeric scalar"):
+        mc_convergence(df, bad_metric)
+
+
+def test_mc_convergence_terminal_only_false_emits_per_time_block() -> None:
+    df = _conv_df(n_runs=4, n_steps=3)
+    conv = mc_convergence(df, "miss", terminal_only=False)
+
+    assert list(conv.columns) == ["time", "n", "running_mean", "running_std", "se_mean"]
+    # 3 unique time steps x 4 prefix sizes = 12 rows.
+    assert len(conv) == 12
+    # Per-time blocks each carry n=1..4 in order.
+    for _t, block in conv.groupby("time"):
+        assert list(block["n"]) == [1, 2, 3, 4]
+    # The terminal time slice should reproduce the terminal_only=True curve.
+    terminal_time = conv["time"].iloc[-1]
+    last_block = conv.loc[conv["time"] == terminal_time].reset_index(drop=True)
+    terminal_conv = mc_convergence(df, "miss", terminal_only=True)
+    pd.testing.assert_series_equal(
+        last_block["running_mean"], terminal_conv["running_mean"], check_names=False
+    )
+
+
+def test_mc_convergence_rejects_unknown_column() -> None:
+    df = _conv_df(n_runs=3)
+    with pytest.raises(SweepConfigError, match=r"not a column of df"):
+        mc_convergence(df, "nope")
+
+
+def test_mc_convergence_rejects_missing_run_id_index() -> None:
+    df = _conv_df(n_runs=3).reset_index().set_index("time")
+    with pytest.raises(SweepConfigError, match=r"must have a 'run_id' level"):
+        mc_convergence(df, "miss")
+
+
+def test_mc_convergence_works_without_status_column() -> None:
+    df = _conv_df(n_runs=4).drop(columns=["__status"])
+    conv = mc_convergence(df, "miss", terminal_only=True)
+    assert len(conv) == 4
+    assert list(conv["n"]) == [1, 2, 3, 4]

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -17,10 +17,15 @@ matplotlib.use("Agg")
 
 from matplotlib.collections import PathCollection, PolyCollection, QuadMesh  # noqa: E402
 
-from gmat_sweep.aggregate import sweep_summary  # noqa: E402
+from gmat_sweep.aggregate import mc_convergence, sweep_summary  # noqa: E402
 from gmat_sweep.errors import SweepConfigError  # noqa: E402
 from gmat_sweep.manifest import Manifest, ManifestEntry  # noqa: E402
-from gmat_sweep.plotting import sweep_band_plot, sweep_corner, sweep_heatmap  # noqa: E402
+from gmat_sweep.plotting import (  # noqa: E402
+    mc_convergence_plot,
+    sweep_band_plot,
+    sweep_corner,
+    sweep_heatmap,
+)
 
 
 def _ts(seconds: int = 0) -> datetime:
@@ -437,3 +442,65 @@ def test_sweep_band_plot_rejects_summary_without_centre() -> None:
     summary = sweep_summary(df, q=(0.1, 0.9), include=())  # no q=0.5, no mean
     with pytest.raises(SweepConfigError, match=r"no centre statistic"):
         sweep_band_plot(summary, "v")
+
+
+# ---------------------------------------------------------------------------
+# mc_convergence_plot
+# ---------------------------------------------------------------------------
+
+
+def _convergence_df(n_runs: int = 30, *, seed: int = 42) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    terminal = rng.normal(loc=0.0, scale=1.0, size=n_runs)
+    rows: list[dict[str, Any]] = []
+    for run_id in range(n_runs):
+        rows.append(
+            {
+                "run_id": run_id,
+                "time": pd.Timestamp("2026-05-04T00:00:00"),
+                "miss": float(terminal[run_id]),
+                "__status": "ok",
+            }
+        )
+    df = pd.DataFrame(rows).set_index(["run_id", "time"])
+    return mc_convergence(df, "miss", terminal_only=True)
+
+
+def test_mc_convergence_plot_returns_axes_with_line_and_band() -> None:
+    conv = _convergence_df()
+    ax = mc_convergence_plot(conv)
+
+    assert len(ax.lines) == 1
+    polys = [c for c in ax.collections if isinstance(c, PolyCollection)]
+    assert len(polys) == 1
+    assert ax.get_xlabel() == "n"
+    assert ax.get_ylabel() == "running mean"
+
+
+def test_mc_convergence_plot_line_x_is_n_and_y_is_running_mean() -> None:
+    conv = _convergence_df(n_runs=10)
+    ax = mc_convergence_plot(conv)
+
+    line = ax.lines[0]
+    np.testing.assert_array_equal(line.get_xdata(), conv["n"].to_numpy())
+    np.testing.assert_array_equal(line.get_ydata(), conv["running_mean"].to_numpy())
+
+
+def test_mc_convergence_plot_rejects_per_time_frame() -> None:
+    conv = pd.DataFrame(
+        {
+            "time": pd.to_datetime(["2026-05-04T00:00:00"]),
+            "n": [1],
+            "running_mean": [0.0],
+            "running_std": [float("nan")],
+            "se_mean": [float("nan")],
+        }
+    )
+    with pytest.raises(SweepConfigError, match=r"per-time"):
+        mc_convergence_plot(conv)
+
+
+def test_mc_convergence_plot_rejects_missing_columns() -> None:
+    conv = pd.DataFrame({"n": [1, 2], "running_mean": [0.0, 0.1]})  # no se_mean
+    with pytest.raises(SweepConfigError, match=r"missing required column"):
+        mc_convergence_plot(conv)


### PR DESCRIPTION
## Summary

- `gmat_sweep.mc_convergence(df, metric, *, terminal_only=False)` returns per-prefix running mean / std / SE-of-mean across `run_id` prefixes — answers "did my Monte Carlo converge?" for a chosen metric.
- `metric` accepts a column name (with `terminal_only=True` for the per-run last value, or `terminal_only=False` for one running curve per `time` step) or a callable `(per_run_subframe) -> float` for derived metrics like final-state miss distance.
- Vectorised cumulative-moments computation, sample std (`ddof=1`), so `n=1` rows carry `NaN` for `running_std` / `se_mean`.
- Companion `gmat_sweep.plotting.mc_convergence_plot(conv, ax=None)` plots the running mean with a `±1·SE` shaded band (matplotlib gated on the `[plot]` extra, lazy-imported).
- Documented on `docs/monte-carlo.md` (new "Convergence diagnostics" section) and registered in `docs/api.md`.

## Test plan

- [x] `uv run pytest` (697 passed, 1 skipped — only the pre-existing mpi4py skip)
- [x] `uv run ruff check`
- [x] `uv run ruff format --check`
- [x] `uv run mypy`
- [x] DoD analytic check: `se_mean` curve for `N(0, σ²)` draws tracks `σ / √n` to within ~10 % at `n=2000` and the `n=500 / n=2000` ratio lands in `[1.7, 2.3]`.

Closes #95