### PR TITLE
sweep_diff: pairwise sweep DataFrame comparison helper

### DIFF
--- a/docs/aggregation.md
+++ b/docs/aggregation.md
@@ -226,6 +226,101 @@ excluded from every statistic. Pass `dropna=False` to keep them — the
 NaT marker rows from non-ok runs land as a NaT-keyed group in the
 output (mostly NaN, with `count_ok` reflecting the contribution).
 
+## Comparing two sweeps
+
+Once you have two sweep DataFrames of the same shape — baseline vs.
+perturbed, before vs. after a `.script` edit, two backends on the same
+sweep — [`sweep_diff`][gmat_sweep.sweep_diff] turns them into a single
+diff frame ready for plotting.
+
+```python
+from pathlib import Path
+
+from gmat_sweep import Manifest, lazy_multiindex, sweep_diff
+
+baseline = lazy_multiindex(Manifest.load(Path("./baseline/manifest.jsonl")), Path("./baseline"))
+perturbed = lazy_multiindex(Manifest.load(Path("./perturbed/manifest.jsonl")), Path("./perturbed"))
+
+# Per-row absolute and relative diff for every shared numeric column.
+diff = sweep_diff(baseline, perturbed)
+
+# (run_id, time) → Sat.SMA shifted by exactly +50 km, everywhere.
+diff[["Sat.SMA__diff", "Sat.SMA__rel"]].head()
+```
+
+For each numeric column shared between the two inputs, `sweep_diff`
+emits `<col>__diff = b - a` and/or `<col>__rel = (b - a) / a`. Columns
+present on only one side, and shared columns whose dtype is non-numeric,
+are silently dropped — the contract is "compare the comparable".
+
+### Output shape
+
+| Column | Meaning |
+|--------|---------|
+| `<col>__diff` | absolute difference, `b - a` |
+| `<col>__rel` | relative difference, `(b - a) / a` (NaN where `a == 0`) |
+| `__status_diff` | `"ok"` when both sides are `__status="ok"`; otherwise `"<a_status>/<b_status>"` (e.g. `"failed/ok"`). Omitted when neither input has a `__status` column. |
+
+The row index matches the inputs' (aligned) index — typically
+`(run_id, time)` or just `run_id` after the `on="run_id"` collapse below.
+
+### `how` selects which suffixes appear
+
+| `how` | Columns |
+|-------|---------|
+| `"absolute"` | only `<col>__diff` |
+| `"relative"` | only `<col>__rel` |
+| `"both"` (default) | both, interleaved as `<col>__diff`, `<col>__rel`, `<col2>__diff`, `<col2>__rel`, … |
+
+### `on=None` vs `on="run_id"`
+
+- `on=None` (default) — align on the existing index (typically
+  `(run_id, time)`). The diff is per-row, per-time-step.
+- `on="run_id"` — collapse each side to its per-run **final-step row**
+  via `groupby(level="run_id").last()`, then diff. Output is indexed by
+  `run_id`. The natural shape for "did the dispersion of the final
+  state change?" comparisons.
+
+### Tolerance masking
+
+`tolerance=` masks every diff whose absolute value is strictly below
+the cutoff to NaN — both `__diff` and the matching `__rel` are masked
+at the same positions, so the surviving non-NaN entries highlight the
+meaningful changes only.
+
+```python
+# Single cutoff applied to every column.
+diff = sweep_diff(baseline, perturbed, tolerance=1e-6)
+
+# Per-column cutoffs — useful when columns carry mixed units.
+def cutoff(col: str) -> float:
+    return 1e-3 if col.endswith(".SMA") else 1e-6  # km vs. km/s
+
+diff = sweep_diff(baseline, perturbed, tolerance=cutoff)
+```
+
+### Failed and skipped runs
+
+`__status_diff` records the per-row pair so a downstream filter or plot
+can drop or annotate them:
+
+```python
+clean = diff.loc[diff["__status_diff"] == "ok"]
+mismatched = diff.loc[diff["__status_diff"] != "ok"]
+```
+
+A row where one side failed and the other succeeded surfaces as
+`"failed/ok"` (or the symmetric `"ok/failed"`), with the data columns
+NaN — failed runs do not produce numeric outputs to subtract.
+
+### Index alignment
+
+`sweep_diff` aligns the two inputs on the intersection of their
+indexes. Keys present on only one side are silently dropped. The
+function does **not** reshape across `parameter_spec` shapes — diffing a
+grid sweep against a Monte Carlo sweep is the user's responsibility to
+align (e.g. via `df.reset_index().set_index([...])`) before calling.
+
 ## Migrating from v0.1
 
 v0.1 used a bare `<name>.parquet` per-run layout and keyed

--- a/docs/api.md
+++ b/docs/api.md
@@ -70,6 +70,8 @@ auto-generated from docstrings via
 
 ::: gmat_sweep.sweep_summary
 
+::: gmat_sweep.sweep_diff
+
 ::: gmat_sweep.mc_convergence
 
 ## Plotting

--- a/src/gmat_sweep/__init__.py
+++ b/src/gmat_sweep/__init__.py
@@ -9,6 +9,7 @@ from gmat_sweep.aggregate import (
     lazy_fused_reports,
     lazy_multiindex,
     mc_convergence,
+    sweep_diff,
     sweep_summary,
 )
 from gmat_sweep.api import (
@@ -92,5 +93,6 @@ __all__ = [
     "monte_carlo",
     "monte_carlo_extend",
     "sweep",
+    "sweep_diff",
     "sweep_summary",
 ]

--- a/src/gmat_sweep/aggregate.py
+++ b/src/gmat_sweep/aggregate.py
@@ -55,15 +55,18 @@ __all__ = [
     "lazy_fused_reports",
     "lazy_multiindex",
     "mc_convergence",
+    "sweep_diff",
     "sweep_summary",
 ]
 
 _VALID_BY: tuple[str, ...] = ("time", "run_id")
 _VALID_INCLUDE: tuple[str, ...] = ("mean", "std", "min", "max", "count_ok")
+_VALID_HOW: tuple[str, ...] = ("absolute", "relative", "both")
 
 
 _RUN_ID_COL = "run_id"
 _STATUS_COL = "__status"
+_STATUS_DIFF_COL = "__status_diff"
 _TIME_COL = "time"
 _INTERVAL_ID_COL = "interval_id"
 
@@ -864,6 +867,177 @@ def _running_stats(values: Any, *, n_offset: int) -> pd.DataFrame:
             "se_mean": se_mean,
         }
     )
+
+
+def sweep_diff(
+    df_a: pd.DataFrame,
+    df_b: pd.DataFrame,
+    *,
+    on: str | None = None,
+    how: str = "both",
+    tolerance: float | Callable[[str], float] | None = None,
+) -> pd.DataFrame:
+    """Pairwise compare two same-shape sweep DataFrames into a diff frame.
+
+    Aligns ``df_a`` and ``df_b`` on the intersection of their indexes,
+    picks the numeric columns shared between them, and emits per-column
+    ``<col>__diff = b - a`` and/or ``<col>__rel = (b - a) / a`` columns
+    ready for plotting against the rest of the sweep helpers.
+
+    Parameters
+    ----------
+    df_a, df_b
+        Sweep DataFrames to compare. Both must share the same index level
+        names (e.g. both ``(run_id, time)``); otherwise
+        :class:`gmat_sweep.errors.SweepConfigError` is raised. Index keys
+        present in only one side are silently dropped from the output.
+    on
+        ``None`` (default) compares row-by-row on the existing index.
+        ``"run_id"`` collapses each side via
+        ``groupby(level="run_id").last()`` first — the per-run final-step
+        view, useful for "did the dispersion of the final state change?"
+        comparisons. Other values are not supported.
+    how
+        ``"absolute"`` emits only ``<col>__diff = b - a``. ``"relative"``
+        emits only ``<col>__rel = (b - a) / a`` (entries where ``a == 0``
+        land as NaN). ``"both"`` (default) emits both, interleaved per
+        source column.
+    tolerance
+        ``None`` (default) emits raw diffs. A ``float`` masks every diff
+        whose absolute value is strictly below the cutoff to NaN — both
+        the ``__diff`` and the matching ``__rel`` entry are masked at the
+        same positions, so the output highlights only the meaningful
+        changes. A callable is invoked once per source column as
+        ``tolerance(col_name) -> float`` to produce a per-column cutoff,
+        which is the right shape when the data columns carry mixed units
+        (e.g. ``Sat.X`` in km vs. ``Sat.VX`` in km/s).
+
+    Returns
+    -------
+    pandas.DataFrame
+        Same index as the (aligned) inputs. One column per
+        ``(<source-column>, suffix)`` pair, where suffix is ``__diff`` or
+        ``__rel`` per ``how``. When at least one side carries a
+        ``__status`` column, an extra trailing ``__status_diff`` column
+        encodes the per-row status pair: ``"ok"`` when both sides are
+        ``"ok"``, otherwise ``"<a_status>/<b_status>"`` (e.g.
+        ``"failed/ok"``, ``"ok/skipped"``).
+
+    Raises
+    ------
+    SweepConfigError
+        ``how`` is not one of ``"absolute"``, ``"relative"``, ``"both"``;
+        ``on`` is neither ``None`` nor ``"run_id"``; ``df_a`` and ``df_b``
+        do not share the same index level names; or ``on="run_id"`` was
+        passed against a frame whose index has no ``run_id`` level.
+
+    Examples
+    --------
+    >>> from gmat_sweep import sweep, sweep_diff
+    >>> baseline = sweep("mission.script", grid={"Sat.SMA": [7000.0]}, out=...)  # doctest: +SKIP
+    >>> perturbed = sweep("mission.script", grid={"Sat.SMA": [7050.0]}, out=...)  # doctest: +SKIP
+    >>> diff = sweep_diff(baseline, perturbed, on="run_id")  # doctest: +SKIP
+    >>> diff[["Sat.SMA__diff", "Sat.SMA__rel"]]  # doctest: +SKIP
+    """
+    if how not in _VALID_HOW:
+        raise SweepConfigError(
+            f"sweep_diff: how={how!r} is not supported; pass one of {list(_VALID_HOW)}"
+        )
+
+    if on is not None and on != _RUN_ID_COL:
+        raise SweepConfigError(
+            f"sweep_diff: on={on!r} is not supported in this release; "
+            f"pass on=None or on={_RUN_ID_COL!r}"
+        )
+
+    a_names = list(df_a.index.names or [])
+    b_names = list(df_b.index.names or [])
+    if a_names != b_names:
+        raise SweepConfigError(
+            f"sweep_diff: df_a and df_b must share the same index level names; "
+            f"got {a_names} vs {b_names}"
+        )
+
+    if on == _RUN_ID_COL:
+        if _RUN_ID_COL not in a_names:
+            raise SweepConfigError(
+                f"sweep_diff: on={_RUN_ID_COL!r} requires a {_RUN_ID_COL!r} "
+                f"index level; got {a_names}"
+            )
+        if df_a.index.nlevels > 1:
+            df_a = df_a.groupby(level=_RUN_ID_COL).last()
+            df_b = df_b.groupby(level=_RUN_ID_COL).last()
+
+    a_status = df_a[_STATUS_COL] if _STATUS_COL in df_a.columns else None
+    b_status = df_b[_STATUS_COL] if _STATUS_COL in df_b.columns else None
+    a_data = df_a.drop(columns=[_STATUS_COL], errors="ignore")
+    b_data = df_b.drop(columns=[_STATUS_COL], errors="ignore")
+
+    shared_cols = [c for c in a_data.columns if c in b_data.columns]
+    numeric_cols = [
+        c
+        for c in shared_cols
+        if pd.api.types.is_numeric_dtype(a_data[c]) and pd.api.types.is_numeric_dtype(b_data[c])
+    ]
+
+    common_index = df_a.index.intersection(df_b.index, sort=False)
+    a_data = a_data.loc[common_index, numeric_cols]
+    b_data = b_data.loc[common_index, numeric_cols]
+
+    diff_block = b_data.subtract(a_data)
+    if how in ("relative", "both"):
+        with np.errstate(divide="ignore", invalid="ignore"):
+            rel_block = diff_block.divide(a_data)
+        rel_block = rel_block.replace([np.inf, -np.inf], np.nan)
+    else:
+        rel_block = None
+
+    if tolerance is not None:
+        for col in numeric_cols:
+            cutoff = float(tolerance(col)) if callable(tolerance) else float(tolerance)
+            mask = diff_block[col].abs() < cutoff
+            if how in ("absolute", "both"):
+                diff_block.loc[mask, col] = np.nan
+            if rel_block is not None:
+                rel_block.loc[mask, col] = np.nan
+
+    diff_named = diff_block.rename(columns={c: f"{c}__diff" for c in numeric_cols})
+    rel_named = (
+        rel_block.rename(columns={c: f"{c}__rel" for c in numeric_cols})
+        if rel_block is not None
+        else None
+    )
+
+    if how == "absolute":
+        result = diff_named
+    elif how == "relative":
+        assert rel_named is not None
+        result = rel_named
+    else:
+        assert rel_named is not None
+        interleaved: list[str] = []
+        for c in numeric_cols:
+            interleaved.append(f"{c}__diff")
+            interleaved.append(f"{c}__rel")
+        result = pd.concat([diff_named, rel_named], axis=1)[interleaved]
+
+    if a_status is not None or b_status is not None:
+        a_aligned = (
+            a_status.reindex(common_index).fillna("ok").astype(str)
+            if a_status is not None
+            else pd.Series("ok", index=common_index, dtype=object)
+        )
+        b_aligned = (
+            b_status.reindex(common_index).fillna("ok").astype(str)
+            if b_status is not None
+            else pd.Series("ok", index=common_index, dtype=object)
+        )
+        both_ok = (a_aligned == "ok") & (b_aligned == "ok")
+        status_diff = (a_aligned + "/" + b_aligned).astype(object)
+        status_diff[both_ok] = "ok"
+        result[_STATUS_DIFF_COL] = status_diff
+
+    return cast(pd.DataFrame, result.sort_index())
 
 
 def _running_stats_per_time(series: pd.Series[Any]) -> pd.DataFrame:

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -16,6 +16,7 @@ from gmat_sweep.aggregate import (
     lazy_fused_reports,
     lazy_multiindex,
     mc_convergence,
+    sweep_diff,
     sweep_summary,
 )
 from gmat_sweep.errors import SweepConfigError
@@ -983,3 +984,249 @@ def test_mc_convergence_works_without_status_column() -> None:
     conv = mc_convergence(df, "miss", terminal_only=True)
     assert len(conv) == 4
     assert list(conv["n"]) == [1, 2, 3, 4]
+
+
+# ---------------------------------------------------------------------------
+# sweep_diff
+# ---------------------------------------------------------------------------
+
+
+def _diff_df(
+    *,
+    n_runs: int = 3,
+    n_steps: int = 2,
+    sma_offset: float = 0.0,
+    statuses: dict[int, str] | None = None,
+    include_status: bool = True,
+) -> pd.DataFrame:
+    """A ``(run_id, time)``-MultiIndexed sweep frame with two numeric columns.
+
+    Each ok run carries ``Sat.SMA = 7000 + run_id + sma_offset + step*0.01``
+    and ``Sat.X = (run_id + 1) * 10.0 + step`` (kept strictly positive so
+    self-diff of `__rel` is well-defined — ``0/0`` is NaN, not zero).
+    Non-ok runs collapse to one NaT-time, NaN-data marker row, matching
+    the rest of this test module's convention.
+    """
+    statuses = statuses or {}
+    rows: list[dict[str, object]] = []
+    times = pd.to_datetime([f"2026-05-09T00:00:0{i}" for i in range(n_steps)])
+    for run_id in range(n_runs):
+        status = statuses.get(run_id, "ok")
+        if status != "ok":
+            row: dict[str, object] = {
+                "run_id": run_id,
+                "time": pd.NaT,
+                "Sat.SMA": float("nan"),
+                "Sat.X": float("nan"),
+            }
+            if include_status:
+                row["__status"] = status
+            rows.append(row)
+            continue
+        for step, t in enumerate(times):
+            row = {
+                "run_id": run_id,
+                "time": t,
+                "Sat.SMA": 7000.0 + run_id + sma_offset + step * 0.01,
+                "Sat.X": float(run_id + 1) * 10.0 + step,
+            }
+            if include_status:
+                row["__status"] = "ok"
+            rows.append(row)
+    return cast(pd.DataFrame, pd.DataFrame(rows).set_index(["run_id", "time"]))
+
+
+def test_sweep_diff_self_diff_is_zero_everywhere() -> None:
+    """DoD criterion 1: a sweep diffed against a copy of itself is zero."""
+    df = _diff_df(n_runs=4, n_steps=3)
+    diff = sweep_diff(df, df.copy())
+
+    # Every numeric column gets a __diff and a __rel under how="both".
+    assert set(diff.columns) >= {"Sat.SMA__diff", "Sat.SMA__rel", "Sat.X__diff", "Sat.X__rel"}
+    np.testing.assert_array_equal(diff["Sat.SMA__diff"].to_numpy(), 0.0)
+    np.testing.assert_array_equal(diff["Sat.X__diff"].to_numpy(), 0.0)
+    np.testing.assert_array_equal(diff["Sat.SMA__rel"].to_numpy(), 0.0)
+    np.testing.assert_array_equal(diff["Sat.X__rel"].to_numpy(), 0.0)
+
+
+def test_sweep_diff_perturbed_sma_produces_nonzero_diff() -> None:
+    """DoD criterion 2: SMA=7000 vs SMA=7050 produces a non-zero __diff column."""
+    a = _diff_df(n_runs=3, n_steps=2)
+    b = _diff_df(n_runs=3, n_steps=2, sma_offset=50.0)
+    diff = sweep_diff(a, b)
+
+    # Sat.SMA shifted by exactly +50 per row; Sat.X unchanged.
+    np.testing.assert_array_equal(diff["Sat.SMA__diff"].to_numpy(), 50.0)
+    np.testing.assert_array_equal(diff["Sat.X__diff"].to_numpy(), 0.0)
+
+
+def test_sweep_diff_default_how_is_both_with_interleaved_columns() -> None:
+    a = _diff_df(n_runs=2, n_steps=2)
+    b = _diff_df(n_runs=2, n_steps=2, sma_offset=1.0)
+    diff = sweep_diff(a, b)
+
+    # Default how="both" interleaves diff/rel per source column.
+    cols = [c for c in diff.columns if c != "__status_diff"]
+    assert cols == ["Sat.SMA__diff", "Sat.SMA__rel", "Sat.X__diff", "Sat.X__rel"]
+
+
+def test_sweep_diff_how_absolute_emits_only_diff_columns() -> None:
+    a = _diff_df(n_runs=2, n_steps=2)
+    b = _diff_df(n_runs=2, n_steps=2, sma_offset=1.0)
+    diff = sweep_diff(a, b, how="absolute")
+
+    cols = [c for c in diff.columns if c != "__status_diff"]
+    assert cols == ["Sat.SMA__diff", "Sat.X__diff"]
+
+
+def test_sweep_diff_how_relative_emits_only_rel_columns() -> None:
+    a = _diff_df(n_runs=2, n_steps=2)
+    b = _diff_df(n_runs=2, n_steps=2, sma_offset=1.0)
+    diff = sweep_diff(a, b, how="relative")
+
+    cols = [c for c in diff.columns if c != "__status_diff"]
+    assert cols == ["Sat.SMA__rel", "Sat.X__rel"]
+
+
+def test_sweep_diff_relative_division_by_zero_is_nan() -> None:
+    """``a == 0`` rows in the baseline produce NaN in __rel, not inf."""
+    times = pd.to_datetime(["2026-05-09T00:00:00"])
+    a = pd.DataFrame({"run_id": [0], "time": times, "x": [0.0], "__status": ["ok"]}).set_index(
+        ["run_id", "time"]
+    )
+    b = pd.DataFrame({"run_id": [0], "time": times, "x": [5.0], "__status": ["ok"]}).set_index(
+        ["run_id", "time"]
+    )
+
+    diff = sweep_diff(a, b, how="relative")
+    assert pd.isna(diff["x__rel"].iloc[0])
+
+
+def test_sweep_diff_on_run_id_collapses_time_level_to_terminal_row() -> None:
+    a = _diff_df(n_runs=3, n_steps=4)
+    b = _diff_df(n_runs=3, n_steps=4, sma_offset=10.0)
+    diff = sweep_diff(a, b, on="run_id")
+
+    # Output is indexed by run_id only.
+    assert diff.index.name == "run_id"
+    assert list(diff.index) == [0, 1, 2]
+
+    # Terminal-row Sat.SMA differs by exactly the offset (constant across runs).
+    np.testing.assert_array_equal(diff["Sat.SMA__diff"].to_numpy(), 10.0)
+
+
+def test_sweep_diff_tolerance_float_masks_below_threshold_diffs() -> None:
+    a = _diff_df(n_runs=3, n_steps=2)
+    # Shift Sat.X by exactly 1, Sat.SMA by 0.005 (under 0.01 tolerance).
+    b = _diff_df(n_runs=3, n_steps=2, sma_offset=0.005)
+    b = b.assign(**{"Sat.X": b["Sat.X"] + 1.0})
+
+    diff = sweep_diff(a, b, tolerance=0.01)
+
+    # Sat.SMA diff (0.005) is below the cutoff → masked to NaN everywhere.
+    assert diff["Sat.SMA__diff"].isna().all()
+    assert diff["Sat.SMA__rel"].isna().all()
+    # Sat.X diff (1.0) is above the cutoff → preserved.
+    np.testing.assert_array_equal(diff["Sat.X__diff"].to_numpy(), 1.0)
+
+
+def test_sweep_diff_tolerance_callable_applies_per_column_cutoff() -> None:
+    a = _diff_df(n_runs=2, n_steps=2)
+    b = _diff_df(n_runs=2, n_steps=2, sma_offset=2.0)
+    b = b.assign(**{"Sat.X": b["Sat.X"] + 2.0})
+
+    # Mask Sat.SMA below 5.0 (so diff=2 is masked) but only mask Sat.X below
+    # 1.0 (so diff=2 survives).
+    cutoffs = {"Sat.SMA": 5.0, "Sat.X": 1.0}
+    diff = sweep_diff(a, b, tolerance=lambda col: cutoffs[col])
+
+    assert diff["Sat.SMA__diff"].isna().all()
+    np.testing.assert_array_equal(diff["Sat.X__diff"].to_numpy(), 2.0)
+
+
+def test_sweep_diff_status_diff_encodes_pair_when_either_side_not_ok() -> None:
+    a = _diff_df(n_runs=4, n_steps=2, statuses={1: "failed"})
+    b = _diff_df(n_runs=4, n_steps=2, statuses={2: "skipped"})
+    diff = sweep_diff(a, b, on="run_id")
+
+    # run 0 / 3 are ok on both sides → "ok"
+    # run 1 failed on a, ok on b → "failed/ok"
+    # run 2 ok on a, skipped on b → "ok/skipped"
+    assert diff.loc[0, "__status_diff"] == "ok"
+    assert diff.loc[1, "__status_diff"] == "failed/ok"
+    assert diff.loc[2, "__status_diff"] == "ok/skipped"
+    assert diff.loc[3, "__status_diff"] == "ok"
+
+
+def test_sweep_diff_status_diff_omitted_when_neither_side_has_status() -> None:
+    a = _diff_df(n_runs=2, n_steps=2, include_status=False)
+    b = _diff_df(n_runs=2, n_steps=2, sma_offset=1.0, include_status=False)
+    diff = sweep_diff(a, b)
+
+    assert "__status_diff" not in diff.columns
+
+
+def test_sweep_diff_status_diff_treats_missing_side_as_ok() -> None:
+    a = _diff_df(n_runs=3, n_steps=2, statuses={1: "failed"})
+    b = _diff_df(n_runs=3, n_steps=2, sma_offset=1.0, include_status=False)
+    diff = sweep_diff(a, b, on="run_id")
+
+    # b has no __status — treat its side as "ok" for every run.
+    assert diff.loc[0, "__status_diff"] == "ok"
+    assert diff.loc[1, "__status_diff"] == "failed/ok"
+    assert diff.loc[2, "__status_diff"] == "ok"
+
+
+def test_sweep_diff_drops_non_shared_and_non_numeric_columns() -> None:
+    a = _diff_df(n_runs=2, n_steps=2)
+    b = _diff_df(n_runs=2, n_steps=2, sma_offset=1.0)
+    # Add an a-only numeric column and a shared non-numeric column.
+    a = a.assign(extra=1.0, label="aaa")
+    b = b.assign(label="bbb")
+
+    diff = sweep_diff(a, b)
+
+    # extra is a-only → dropped. label is shared but non-numeric → dropped.
+    cols = [c for c in diff.columns if c != "__status_diff"]
+    assert all("extra" not in c and "label" not in c for c in cols)
+    assert "Sat.SMA__diff" in cols
+    assert "Sat.X__diff" in cols
+
+
+def test_sweep_diff_index_intersection_drops_keys_present_on_only_one_side() -> None:
+    a = _diff_df(n_runs=4, n_steps=1)
+    # Drop run_id=3 from b — sweep_diff should align on the intersection.
+    b = _diff_df(n_runs=4, n_steps=1, sma_offset=1.0).drop(index=3, level="run_id")
+
+    diff = sweep_diff(a, b)
+
+    surviving_run_ids = sorted({rid for rid, _ in diff.index})
+    assert surviving_run_ids == [0, 1, 2]
+
+
+def test_sweep_diff_rejects_unknown_how() -> None:
+    a = _diff_df(n_runs=2, n_steps=2)
+    with pytest.raises(SweepConfigError, match=r"how=.*not supported"):
+        sweep_diff(a, a.copy(), how="median")
+
+
+def test_sweep_diff_rejects_unsupported_on() -> None:
+    a = _diff_df(n_runs=2, n_steps=2)
+    with pytest.raises(SweepConfigError, match=r"on=.*not supported"):
+        sweep_diff(a, a.copy(), on="time")
+
+
+def test_sweep_diff_rejects_mismatched_index_level_names() -> None:
+    a = _diff_df(n_runs=2, n_steps=2)
+    # Rename b's secondary level to break the index-level-name match.
+    b = a.copy()
+    b.index = b.index.set_names(["run_id", "interval_id"])
+
+    with pytest.raises(SweepConfigError, match=r"same index level names"):
+        sweep_diff(a, b)
+
+
+def test_sweep_diff_rejects_on_run_id_when_index_has_no_run_id_level() -> None:
+    df = _diff_df(n_runs=2, n_steps=2).reset_index().set_index("time")
+    with pytest.raises(SweepConfigError, match=r"requires a 'run_id' index level"):
+        sweep_diff(df, df.copy(), on="run_id")


### PR DESCRIPTION
## Summary

- New `gmat_sweep.sweep_diff(df_a, df_b, *, on=None, how="both", tolerance=None)` for comparing two same-shape sweep DataFrames into a `(run_id, time)`- (or `run_id`-) indexed diff frame.
- Per shared numeric column emits `<col>__diff = b - a` and/or `<col>__rel = (b - a) / a`; `on="run_id"` first collapses each side to its per-run final-step row; `tolerance` (float or per-column callable) masks sub-threshold diffs in both `__diff` and `__rel`; `__status` from each side encodes into a single trailing `__status_diff` column (`"ok"` or `"<a>/<b>"` like `"failed/ok"`).
- Documented on `docs/aggregation.md` with a worked baseline-vs-perturbed example and tables for `how`, `on`, tolerance shapes, and the `__status_diff` encoding.

## Test plan

- [x] Self-diff is zero on every numeric column (DoD criterion 1).
- [x] `Sat.SMA = 7000` vs `Sat.SMA = 7050` produces a non-zero `Sat.SMA__diff` and zero on unchanged columns (DoD criterion 2).
- [x] `how="absolute"` / `"relative"` / `"both"` select the right column suffixes; `"both"` interleaves per source column.
- [x] `on="run_id"` collapses the time level and indexes output by `run_id`.
- [x] Float `tolerance` masks below-threshold diffs in both `__diff` and `__rel`; per-column callable applies different cutoffs per column.
- [x] `(b - a) / 0` lands as NaN, no warning.
- [x] `__status_diff` encodes `"ok"`, `"failed/ok"`, `"ok/skipped"`; omitted when neither side has `__status`; missing side treated as `"ok"`.
- [x] Non-shared and non-numeric columns silently dropped; index keys present on only one side dropped via intersection.
- [x] Rejects unknown `how`, unsupported `on`, mismatched index level names, and `on="run_id"` against an index without a `run_id` level.
- [x] `uv run ruff check` / `ruff format --check` / `mypy` clean; full non-integration suite (715 passed) clean; `aggregate.py` coverage at the 95% gate.

Closes #96