### PR TITLE
Polars output engine on sweep / Sweep.to_dataframe (extra [polars])

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,12 @@ jobs:
         # `tests/test_backends_kubernetes.py` (which `pytest.importorskip`
         # the kubernetes client) can run here and contribute to the
         # coverage gate — the real-cluster k8s integration tests still
-        # live in the dedicated `backend-k8s` job below. The lint,
+        # live in the dedicated `backend-k8s` job below. `--extra polars`
+        # so the engine="polars" tests under `tests/test_aggregate.py`
+        # contribute to the aggregate.py coverage gate. The lint,
         # typecheck, and minimal-install jobs deliberately keep their
         # syncs narrower.
-        run: uv sync --all-groups --extra dask --extra ray --extra plot --extra k8s
+        run: uv sync --all-groups --extra dask --extra ray --extra plot --extra k8s --extra polars
 
       - name: Run pytest
         # `-m "(integration or not integration) and not slow"` overrides the

--- a/docs/aggregation.md
+++ b/docs/aggregation.md
@@ -321,6 +321,75 @@ function does **not** reshape across `parameter_spec` shapes — diffing a
 grid sweep against a Monte Carlo sweep is the user's responsibility to
 align (e.g. via `df.reset_index().set_index([...])`) before calling.
 
+## Polars output engine
+
+Pandas is the default and only return type with no extra installed.
+With the `[polars]` extra, every flat-column DataFrame-returning entry
+point in this module accepts an `engine="polars"` keyword that returns
+a [`polars.DataFrame`][polars-df] instead.
+
+```bash
+pip install gmat-sweep[polars]
+```
+
+The MultiIndex on `lazy_multiindex`/`lazy_ephemerides` (`(run_id, time)`)
+and `lazy_contacts` (`(run_id, interval_id)`) is flattened into two
+sorted leading columns; row order, row count, and the non-index column
+set match the pandas-engine equivalent. Polars carries the typed nulls
+across — `NaT` becomes a polars `null` in `Datetime[ns]`, the nullable
+`Int64` `interval_id` round-trips to a polars `Int64` with `null`, and
+`NaN` in numeric columns becomes a `null` in `Float64`.
+
+```python
+from gmat_sweep import sweep
+
+# pandas (default) — returns a (run_id, time)-MultiIndexed pandas DataFrame.
+df = sweep("mission.script", grid={"Sat.SMA": [7000, 7100]}, out=...)
+
+# polars — returns a polars.DataFrame with run_id/time as leading columns.
+plf = sweep("mission.script", grid={"Sat.SMA": [7000, 7100]}, out=..., engine="polars")
+plf.filter(plf["__status"] == "ok").group_by("run_id").agg(...)
+```
+
+The `engine="polars"` knob is available on:
+
+- The top-level entry points: [`sweep`][gmat_sweep.sweep],
+  [`monte_carlo`][gmat_sweep.monte_carlo],
+  [`latin_hypercube`][gmat_sweep.latin_hypercube], and
+  [`monte_carlo_extend`][gmat_sweep.monte_carlo_extend].
+- The `Sweep` orchestrator methods:
+  [`Sweep.to_dataframe`][gmat_sweep.Sweep.to_dataframe],
+  [`Sweep.to_ephemerides`][gmat_sweep.Sweep.to_ephemerides],
+  [`Sweep.to_contacts`][gmat_sweep.Sweep.to_contacts]. The
+  `Sweep.to_polars()` shortcut is equivalent to
+  `Sweep.to_dataframe(engine="polars")`.
+- The standalone aggregators:
+  [`lazy_multiindex`][gmat_sweep.lazy_multiindex],
+  [`lazy_ephemerides`][gmat_sweep.lazy_ephemerides],
+  [`lazy_contacts`][gmat_sweep.lazy_contacts],
+  [`mc_convergence`][gmat_sweep.mc_convergence], and
+  [`sweep_diff`][gmat_sweep.sweep_diff].
+
+Two helpers stay pandas-only because their output carries a column-level
+`MultiIndex` and polars has no native equivalent:
+[`sweep_summary`][gmat_sweep.sweep_summary] (`(statistic, field)`
+columns) and
+[`lazy_fused_reports`][gmat_sweep.lazy_fused_reports] /
+[`Sweep.to_fused_reports`][gmat_sweep.Sweep.to_fused_reports]
+(`(report_name, column)` columns). Convert by hand when you need a
+flat polars frame:
+
+```python
+import polars as pl
+
+summary = sweep_summary(df)
+flat = summary.copy()
+flat.columns = [f"{stat}__{field}" for stat, field in flat.columns]
+plf_summary = pl.from_pandas(flat.reset_index())
+```
+
+[polars-df]: https://docs.pola.rs/api/python/stable/reference/dataframe/index.html
+
 ## Migrating from v0.1
 
 v0.1 used a bare `<name>.parquet` per-run layout and keyed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ ray = ["ray[default]>=2.10"]
 k8s = ["kubernetes>=29,<33"]
 mpi = ["mpi4py>=3.1"]
 plot = ["matplotlib>=3.8"]
+polars = ["polars>=1.0"]
 examples = ["matplotlib>=3.8", "distributed>=2024.1", "ray[default]>=2.10"]
 
 [project.scripts]
@@ -180,6 +181,16 @@ follow_imports = "skip"
 # (which does not install [plot]) keeps passing.
 [[tool.mypy.overrides]]
 module = ["matplotlib", "matplotlib.*"]
+ignore_missing_imports = true
+follow_imports = "skip"
+
+# polars is an optional [polars]-extra dependency; aggregate.py imports it
+# lazily inside _to_polars only, so the default install path never touches
+# polars. polars ships a `py.typed` marker, so `follow_imports = "skip"` is
+# needed alongside `ignore_missing_imports` for the typecheck cell that
+# does not install the extra.
+[[tool.mypy.overrides]]
+module = ["polars", "polars.*"]
 ignore_missing_imports = true
 follow_imports = "skip"
 

--- a/src/gmat_sweep/aggregate.py
+++ b/src/gmat_sweep/aggregate.py
@@ -35,7 +35,7 @@ for "median +/- 95% band over time" dispersion plots.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
 import numpy as np
 import pandas as pd
@@ -46,8 +46,13 @@ from gmat_sweep.errors import SweepConfigError
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
+    from typing import TypeAlias
+
+    import polars as pl
 
     from gmat_sweep.manifest import Manifest, ManifestEntry
+
+    DataFrame: TypeAlias = pd.DataFrame | pl.DataFrame
 
 __all__ = [
     "lazy_contacts",
@@ -62,6 +67,34 @@ __all__ = [
 _VALID_BY: tuple[str, ...] = ("time", "run_id")
 _VALID_INCLUDE: tuple[str, ...] = ("mean", "std", "min", "max", "count_ok")
 _VALID_HOW: tuple[str, ...] = ("absolute", "relative", "both")
+_VALID_ENGINES: tuple[str, ...] = ("pandas", "polars")
+
+
+def _check_engine(engine: str) -> None:
+    if engine not in _VALID_ENGINES:
+        raise SweepConfigError(
+            f"engine={engine!r} is not supported; pass one of {list(_VALID_ENGINES)}"
+        )
+
+
+def _to_polars(df: pd.DataFrame) -> pl.DataFrame:
+    """Flatten a pandas-engine sweep DataFrame into a polars DataFrame.
+
+    The ``(run_id, <secondary>)`` MultiIndex becomes two leading columns;
+    row order is preserved (the input is already ``sort_index``-ed). Polars
+    is imported lazily so the default ``engine="pandas"`` path does not
+    require the ``[polars]`` extra.
+    """
+    try:
+        import polars as pl
+    except ImportError as exc:
+        raise ImportError(
+            "engine='polars' requires the optional polars extra; "
+            "install with: pip install gmat-sweep[polars]"
+        ) from exc
+
+    flat = df.reset_index() if df.index.nlevels > 0 and df.index.names != [None] else df
+    return pl.from_pandas(flat)
 
 
 _RUN_ID_COL = "run_id"
@@ -83,13 +116,41 @@ _SECONDARY_INDEX_MISSING: dict[str, Any] = {
 }
 
 
+@overload
+def lazy_multiindex(
+    manifest: Manifest,
+    output_dir: Path,
+    *,
+    name: str | None = ...,
+    spool: bool = ...,
+    engine: Literal["pandas"] = ...,
+) -> pd.DataFrame: ...
+@overload
+def lazy_multiindex(
+    manifest: Manifest,
+    output_dir: Path,
+    *,
+    name: str | None = ...,
+    spool: bool = ...,
+    engine: Literal["polars"],
+) -> pl.DataFrame: ...
+@overload
+def lazy_multiindex(
+    manifest: Manifest,
+    output_dir: Path,
+    *,
+    name: str | None = ...,
+    spool: bool = ...,
+    engine: str,
+) -> DataFrame: ...
 def lazy_multiindex(
     manifest: Manifest,
     output_dir: Path,
     *,
     name: str | None = None,
     spool: bool = True,
-) -> pd.DataFrame:
+    engine: str = "pandas",
+) -> DataFrame:
     """Assemble the ``(run_id, time)``-indexed report DataFrame from a sweep's outputs.
 
     Iterates ``manifest.entries`` in order. For each ``ok`` entry the
@@ -122,19 +183,29 @@ def lazy_multiindex(
         ``True`` (default) streams each run's record batches into pandas
         one batch at a time. ``False`` reads each run's Parquet eagerly
         in one shot — simpler control flow, higher peak memory.
+    engine
+        ``"pandas"`` (default) returns a ``(run_id, time)``-MultiIndexed
+        :class:`pandas.DataFrame`. ``"polars"`` returns a
+        :class:`polars.DataFrame` whose ``(run_id, time)`` MultiIndex is
+        flattened into two leading sorted columns; row count and the
+        non-index column set match the pandas-engine equivalent. Requires
+        the ``[polars]`` extra; an :class:`ImportError` with the install
+        hint is raised when polars is not importable.
 
     Raises
     ------
     SweepConfigError
         ``name=None`` was passed but the sweep produced more than one
-        report (the exception message lists the available names), or the
-        explicitly-named report does not appear in any ok run's outputs.
+        report (the exception message lists the available names), the
+        explicitly-named report does not appear in any ok run's outputs,
+        or ``engine`` is neither ``"pandas"`` nor ``"polars"``.
     ValueError
         An ``ok`` entry has no ``output_paths`` at all (a run that ran
         successfully must have produced something), or a per-run Parquet
         is missing the ``time`` column required for the index.
     """
-    return _aggregate(
+    _check_engine(engine)
+    df = _aggregate(
         manifest,
         output_dir,
         kind="report",
@@ -142,15 +213,44 @@ def lazy_multiindex(
         name=name,
         spool=spool,
     )
+    return _to_polars(df) if engine == "polars" else df
 
 
+@overload
+def lazy_ephemerides(
+    manifest: Manifest,
+    output_dir: Path,
+    *,
+    name: str | None = ...,
+    spool: bool = ...,
+    engine: Literal["pandas"] = ...,
+) -> pd.DataFrame: ...
+@overload
+def lazy_ephemerides(
+    manifest: Manifest,
+    output_dir: Path,
+    *,
+    name: str | None = ...,
+    spool: bool = ...,
+    engine: Literal["polars"],
+) -> pl.DataFrame: ...
+@overload
+def lazy_ephemerides(
+    manifest: Manifest,
+    output_dir: Path,
+    *,
+    name: str | None = ...,
+    spool: bool = ...,
+    engine: str,
+) -> DataFrame: ...
 def lazy_ephemerides(
     manifest: Manifest,
     output_dir: Path,
     *,
     name: str | None = None,
     spool: bool = True,
-) -> pd.DataFrame:
+    engine: str = "pandas",
+) -> DataFrame:
     """Assemble the ``(run_id, time)``-indexed ephemeris DataFrame from a sweep's outputs.
 
     Mirrors :func:`lazy_multiindex` but dispatches on ``ephemeris__<name>``
@@ -159,9 +259,11 @@ def lazy_ephemerides(
     SPK formats) to a column named ``time`` before writing Parquet, so
     the same ``(run_id, time)`` index machinery applies.
 
-    See :func:`lazy_multiindex` for parameter and exception semantics.
+    See :func:`lazy_multiindex` for parameter and exception semantics,
+    including the ``engine`` knob.
     """
-    return _aggregate(
+    _check_engine(engine)
+    df = _aggregate(
         manifest,
         output_dir,
         kind="ephemeris",
@@ -169,14 +271,40 @@ def lazy_ephemerides(
         name=name,
         spool=spool,
     )
+    return _to_polars(df) if engine == "polars" else df
 
 
+@overload
+def lazy_contacts(
+    manifest: Manifest,
+    output_dir: Path,
+    *,
+    name: str | None = ...,
+    engine: Literal["pandas"] = ...,
+) -> pd.DataFrame: ...
+@overload
+def lazy_contacts(
+    manifest: Manifest,
+    output_dir: Path,
+    *,
+    name: str | None = ...,
+    engine: Literal["polars"],
+) -> pl.DataFrame: ...
+@overload
+def lazy_contacts(
+    manifest: Manifest,
+    output_dir: Path,
+    *,
+    name: str | None = ...,
+    engine: str,
+) -> DataFrame: ...
 def lazy_contacts(
     manifest: Manifest,
     output_dir: Path,
     *,
     name: str | None = None,
-) -> pd.DataFrame:
+    engine: str = "pandas",
+) -> DataFrame:
     """Assemble the ``(run_id, interval_id)``-indexed contact DataFrame from a sweep's outputs.
 
     Mirrors :func:`lazy_multiindex` but dispatches on ``contact__<name>``
@@ -188,12 +316,15 @@ def lazy_contacts(
 
     Failed, skipped, and report-only ``ok`` runs materialise as one row
     with ``interval_id = pd.NA`` (cast as the nullable ``Int64`` dtype so
-    integer interval indices and missing values share one level).
+    integer interval indices and missing values share one level). Under
+    ``engine="polars"`` the nullable ``Int64`` round-trips into a polars
+    ``Int64`` column with ``null`` for the missing slots.
 
     See :func:`lazy_multiindex` for the rest of the parameter and
-    exception semantics.
+    exception semantics, including the ``engine`` knob.
     """
-    return _aggregate(
+    _check_engine(engine)
+    df = _aggregate(
         manifest,
         output_dir,
         kind="contact",
@@ -201,6 +332,7 @@ def lazy_contacts(
         name=name,
         spool=False,
     )
+    return _to_polars(df) if engine == "polars" else df
 
 
 def _aggregate(
@@ -727,12 +859,37 @@ def sweep_summary(
 _RUNNING_COLUMNS: tuple[str, ...] = ("running_mean", "running_std", "se_mean")
 
 
+@overload
+def mc_convergence(
+    df: pd.DataFrame,
+    metric: str | Callable[[pd.DataFrame], float],
+    *,
+    terminal_only: bool = ...,
+    engine: Literal["pandas"] = ...,
+) -> pd.DataFrame: ...
+@overload
+def mc_convergence(
+    df: pd.DataFrame,
+    metric: str | Callable[[pd.DataFrame], float],
+    *,
+    terminal_only: bool = ...,
+    engine: Literal["polars"],
+) -> pl.DataFrame: ...
+@overload
+def mc_convergence(
+    df: pd.DataFrame,
+    metric: str | Callable[[pd.DataFrame], float],
+    *,
+    terminal_only: bool = ...,
+    engine: str,
+) -> DataFrame: ...
 def mc_convergence(
     df: pd.DataFrame,
     metric: str | Callable[[pd.DataFrame], float],
     *,
     terminal_only: bool = False,
-) -> pd.DataFrame:
+    engine: str = "pandas",
+) -> DataFrame:
     """Diagnose Monte Carlo convergence: running mean / std / SE of the mean over run-id prefixes.
 
     Reduces ``df`` to a per-run scalar (or per-run-per-time scalar) under
@@ -763,10 +920,15 @@ def mc_convergence(
         the final state converge?" view. ``False`` (default) keeps every
         time step and emits one running curve per ``time``. Ignored for
         callable metrics, which already return one scalar per run.
+    engine
+        ``"pandas"`` (default) returns a :class:`pandas.DataFrame` with a
+        plain :class:`~pandas.RangeIndex`. ``"polars"`` returns the same
+        flat-column frame as a :class:`polars.DataFrame`. Requires the
+        ``[polars]`` extra; same semantics as :func:`lazy_multiindex`.
 
     Returns
     -------
-    pandas.DataFrame
+    pandas.DataFrame or polars.DataFrame
         Long-form frame with columns ``n``, ``running_mean``,
         ``running_std``, ``se_mean``. When ``terminal_only=False`` and
         ``metric`` is a column name, an additional leading ``time``
@@ -777,8 +939,9 @@ def mc_convergence(
     ------
     SweepConfigError
         ``df.index`` is not a MultiIndex with a ``run_id`` level; the
-        column-name ``metric`` is not in ``df``; or the callable
-        ``metric`` does not return a numeric scalar.
+        column-name ``metric`` is not in ``df``; the callable
+        ``metric`` does not return a numeric scalar; or ``engine`` is
+        neither ``"pandas"`` nor ``"polars"``.
 
     Examples
     --------
@@ -788,6 +951,7 @@ def mc_convergence(
             n  running_mean  running_std       se_mean
     995   996      ...           ...           ...
     """
+    _check_engine(engine)
     if df.index.nlevels < 2 or _RUN_ID_COL not in (df.index.names or []):
         raise SweepConfigError(
             f"mc_convergence: df.index must have a {_RUN_ID_COL!r} level "
@@ -801,18 +965,18 @@ def mc_convergence(
 
     if callable(metric):
         per_run = _reduce_callable_metric(working, metric)
-        return _running_stats(per_run.to_numpy(), n_offset=1)
-
-    if metric not in working.columns:
+        result = _running_stats(per_run.to_numpy(), n_offset=1)
+    elif metric not in working.columns:
         raise SweepConfigError(
             f"mc_convergence: metric={metric!r} is not a column of df and is not callable"
         )
-
-    if terminal_only:
+    elif terminal_only:
         per_run_series = working.groupby(level=_RUN_ID_COL)[metric].last().sort_index()
-        return _running_stats(per_run_series.to_numpy(), n_offset=1)
+        result = _running_stats(per_run_series.to_numpy(), n_offset=1)
+    else:
+        result = _running_stats_per_time(working[metric])
 
-    return _running_stats_per_time(working[metric])
+    return _to_polars(result) if engine == "polars" else result
 
 
 def _reduce_callable_metric(
@@ -869,6 +1033,36 @@ def _running_stats(values: Any, *, n_offset: int) -> pd.DataFrame:
     )
 
 
+@overload
+def sweep_diff(
+    df_a: pd.DataFrame,
+    df_b: pd.DataFrame,
+    *,
+    on: str | None = ...,
+    how: str = ...,
+    tolerance: float | Callable[[str], float] | None = ...,
+    engine: Literal["pandas"] = ...,
+) -> pd.DataFrame: ...
+@overload
+def sweep_diff(
+    df_a: pd.DataFrame,
+    df_b: pd.DataFrame,
+    *,
+    on: str | None = ...,
+    how: str = ...,
+    tolerance: float | Callable[[str], float] | None = ...,
+    engine: Literal["polars"],
+) -> pl.DataFrame: ...
+@overload
+def sweep_diff(
+    df_a: pd.DataFrame,
+    df_b: pd.DataFrame,
+    *,
+    on: str | None = ...,
+    how: str = ...,
+    tolerance: float | Callable[[str], float] | None = ...,
+    engine: str,
+) -> DataFrame: ...
 def sweep_diff(
     df_a: pd.DataFrame,
     df_b: pd.DataFrame,
@@ -876,7 +1070,8 @@ def sweep_diff(
     on: str | None = None,
     how: str = "both",
     tolerance: float | Callable[[str], float] | None = None,
-) -> pd.DataFrame:
+    engine: str = "pandas",
+) -> DataFrame:
     """Pairwise compare two same-shape sweep DataFrames into a diff frame.
 
     Aligns ``df_a`` and ``df_b`` on the intersection of their indexes,
@@ -911,11 +1106,18 @@ def sweep_diff(
         ``tolerance(col_name) -> float`` to produce a per-column cutoff,
         which is the right shape when the data columns carry mixed units
         (e.g. ``Sat.X`` in km vs. ``Sat.VX`` in km/s).
+    engine
+        ``"pandas"`` (default) returns a :class:`pandas.DataFrame` with
+        the same index shape as the inputs. ``"polars"`` returns a
+        :class:`polars.DataFrame` whose index levels are flattened into
+        leading columns. Requires the ``[polars]`` extra; same semantics
+        as :func:`lazy_multiindex`.
 
     Returns
     -------
-    pandas.DataFrame
-        Same index as the (aligned) inputs. One column per
+    pandas.DataFrame or polars.DataFrame
+        Same index as the (aligned) inputs (flattened to leading columns
+        under ``engine="polars"``). One column per
         ``(<source-column>, suffix)`` pair, where suffix is ``__diff`` or
         ``__rel`` per ``how``. When at least one side carries a
         ``__status`` column, an extra trailing ``__status_diff`` column
@@ -928,8 +1130,9 @@ def sweep_diff(
     SweepConfigError
         ``how`` is not one of ``"absolute"``, ``"relative"``, ``"both"``;
         ``on`` is neither ``None`` nor ``"run_id"``; ``df_a`` and ``df_b``
-        do not share the same index level names; or ``on="run_id"`` was
-        passed against a frame whose index has no ``run_id`` level.
+        do not share the same index level names; ``on="run_id"`` was
+        passed against a frame whose index has no ``run_id`` level; or
+        ``engine`` is neither ``"pandas"`` nor ``"polars"``.
 
     Examples
     --------
@@ -939,6 +1142,7 @@ def sweep_diff(
     >>> diff = sweep_diff(baseline, perturbed, on="run_id")  # doctest: +SKIP
     >>> diff[["Sat.SMA__diff", "Sat.SMA__rel"]]  # doctest: +SKIP
     """
+    _check_engine(engine)
     if how not in _VALID_HOW:
         raise SweepConfigError(
             f"sweep_diff: how={how!r} is not supported; pass one of {list(_VALID_HOW)}"
@@ -1037,7 +1241,8 @@ def sweep_diff(
         status_diff[both_ok] = "ok"
         result[_STATUS_DIFF_COL] = status_diff
 
-    return cast(pd.DataFrame, result.sort_index())
+    sorted_result = cast(pd.DataFrame, result.sort_index())
+    return _to_polars(sorted_result) if engine == "polars" else sorted_result
 
 
 def _running_stats_per_time(series: pd.Series[Any]) -> pd.DataFrame:

--- a/src/gmat_sweep/api.py
+++ b/src/gmat_sweep/api.py
@@ -7,7 +7,7 @@ import tempfile
 import weakref
 from collections.abc import Callable, Iterable, Iterator, Mapping
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 from gmat_sweep.backends.base import Pool
 from gmat_sweep.backends.joblib import LocalJoblibPool
@@ -24,6 +24,9 @@ from gmat_sweep.sweep import Sweep
 
 if TYPE_CHECKING:
     import pandas as pd
+    import polars as pl
+
+    from gmat_sweep.aggregate import DataFrame
 
 __all__ = [
     "latin_hypercube",
@@ -39,6 +42,42 @@ __all__ = [
 _MANIFEST_FILENAME = "manifest.jsonl"
 
 
+@overload
+def sweep(
+    mission: str | Path,
+    *,
+    grid: Mapping[str, Iterable[Any]] | None = ...,
+    samples: pd.DataFrame | None = ...,
+    backend: Pool | None = ...,
+    out: str | Path | None = ...,
+    seed: int | None = ...,
+    progress: bool = ...,
+    engine: Literal["pandas"] = ...,
+) -> pd.DataFrame: ...
+@overload
+def sweep(
+    mission: str | Path,
+    *,
+    grid: Mapping[str, Iterable[Any]] | None = ...,
+    samples: pd.DataFrame | None = ...,
+    backend: Pool | None = ...,
+    out: str | Path | None = ...,
+    seed: int | None = ...,
+    progress: bool = ...,
+    engine: Literal["polars"],
+) -> pl.DataFrame: ...
+@overload
+def sweep(
+    mission: str | Path,
+    *,
+    grid: Mapping[str, Iterable[Any]] | None = ...,
+    samples: pd.DataFrame | None = ...,
+    backend: Pool | None = ...,
+    out: str | Path | None = ...,
+    seed: int | None = ...,
+    progress: bool = ...,
+    engine: str,
+) -> DataFrame: ...
 def sweep(
     mission: str | Path,
     *,
@@ -48,7 +87,8 @@ def sweep(
     out: str | Path | None = None,
     seed: int | None = None,
     progress: bool = True,
-) -> pd.DataFrame:
+    engine: str = "pandas",
+) -> DataFrame:
     """Run a parameter sweep over a GMAT mission.
 
     Two mutually exclusive run-set shapes are accepted: pass ``grid=`` for a
@@ -105,20 +145,32 @@ def sweep(
         runs complete. Set to ``False`` for non-interactive use (CI logs,
         notebooks committed with outputs) where the progress bar would
         otherwise be captured as noisy stderr snapshots.
+    engine:
+        ``"pandas"`` (default) returns a ``(run_id, time)``-MultiIndexed
+        :class:`pandas.DataFrame`. ``"polars"`` returns a
+        :class:`polars.DataFrame` with the MultiIndex flattened into two
+        leading sorted columns; row count and the non-index column set
+        match the pandas-engine equivalent. Requires the ``[polars]``
+        extra; an :class:`ImportError` with the install hint is raised
+        when polars is not importable. See
+        :func:`gmat_sweep.aggregate.lazy_multiindex` for the full
+        engine-knob contract.
 
     Returns
     -------
-    pandas.DataFrame
+    pandas.DataFrame or polars.DataFrame
         ``(run_id, time)``-MultiIndexed frame produced by
-        :func:`gmat_sweep.aggregate.lazy_multiindex`. Failed and skipped runs
-        appear as one NaN-filled row with ``__status`` set accordingly — a
-        single bad run does not abort the sweep or raise from this call.
+        :func:`gmat_sweep.aggregate.lazy_multiindex` (or its polars-engine
+        equivalent). Failed and skipped runs appear as one NaN-filled row
+        with ``__status`` set accordingly — a single bad run does not
+        abort the sweep or raise from this call.
 
     Raises
     ------
     SweepConfigError
-        If both ``grid`` and ``samples`` are passed, if neither is passed, or
-        if either argument fails its own structural validation.
+        If both ``grid`` and ``samples`` are passed, if neither is passed,
+        if either argument fails its own structural validation, or if
+        ``engine`` is neither ``"pandas"`` nor ``"polars"``.
     """
     if grid is not None and samples is not None:
         raise SweepConfigError("sweep() accepts either grid= or samples=, not both")
@@ -164,9 +216,46 @@ def sweep(
         backend=backend,
         out=out,
         progress=progress,
+        engine=engine,
     )
 
 
+@overload
+def monte_carlo(
+    mission: str | Path,
+    *,
+    n: int,
+    perturb: Mapping[str, DistSpec],
+    seed: int | None = ...,
+    backend: Pool | None = ...,
+    out: str | Path | None = ...,
+    progress: bool = ...,
+    engine: Literal["pandas"] = ...,
+) -> pd.DataFrame: ...
+@overload
+def monte_carlo(
+    mission: str | Path,
+    *,
+    n: int,
+    perturb: Mapping[str, DistSpec],
+    seed: int | None = ...,
+    backend: Pool | None = ...,
+    out: str | Path | None = ...,
+    progress: bool = ...,
+    engine: Literal["polars"],
+) -> pl.DataFrame: ...
+@overload
+def monte_carlo(
+    mission: str | Path,
+    *,
+    n: int,
+    perturb: Mapping[str, DistSpec],
+    seed: int | None = ...,
+    backend: Pool | None = ...,
+    out: str | Path | None = ...,
+    progress: bool = ...,
+    engine: str,
+) -> DataFrame: ...
 def monte_carlo(
     mission: str | Path,
     *,
@@ -176,7 +265,8 @@ def monte_carlo(
     backend: Pool | None = None,
     out: str | Path | None = None,
     progress: bool = True,
-) -> pd.DataFrame:
+    engine: str = "pandas",
+) -> DataFrame:
     """Run a Monte Carlo dispersion sweep over a GMAT mission.
 
     Builds an explicit-row run set of ``n`` runs by independently sampling
@@ -209,19 +299,24 @@ def monte_carlo(
     progress:
         Whether to draw the :mod:`tqdm` progress bar; same semantics as
         :func:`sweep`.
+    engine:
+        Output engine; same semantics as :func:`sweep`.
 
     Returns
     -------
-    pandas.DataFrame
-        ``(run_id, time)``-MultiIndexed frame, one row per (run, time-step)
-        pair, with ``run_id`` cardinality ``n``. A failed run lands as one
-        NaN row with ``__status="failed"`` — same contract as :func:`sweep`.
+    pandas.DataFrame or polars.DataFrame
+        ``(run_id, time)``-MultiIndexed frame (or polars flat-key
+        equivalent under ``engine="polars"``), one row per (run,
+        time-step) pair, with ``run_id`` cardinality ``n``. A failed run
+        lands as one NaN row with ``__status="failed"`` — same contract
+        as :func:`sweep`.
 
     Raises
     ------
     SweepConfigError
-        If ``perturb`` is empty, ``n < 1``, or any parameter spec is
-        ill-formed.
+        If ``perturb`` is empty, ``n < 1``, any parameter spec is
+        ill-formed, or ``engine`` is neither ``"pandas"`` nor
+        ``"polars"``.
     """
     mission_path = Path(mission)
     parameter_spec: dict[str, Any] = {
@@ -244,9 +339,46 @@ def monte_carlo(
         backend=backend,
         out=out,
         progress=progress,
+        engine=engine,
     )
 
 
+@overload
+def latin_hypercube(
+    mission: str | Path,
+    *,
+    n: int,
+    perturb: Mapping[str, DistSpec],
+    seed: int | None = ...,
+    backend: Pool | None = ...,
+    out: str | Path | None = ...,
+    progress: bool = ...,
+    engine: Literal["pandas"] = ...,
+) -> pd.DataFrame: ...
+@overload
+def latin_hypercube(
+    mission: str | Path,
+    *,
+    n: int,
+    perturb: Mapping[str, DistSpec],
+    seed: int | None = ...,
+    backend: Pool | None = ...,
+    out: str | Path | None = ...,
+    progress: bool = ...,
+    engine: Literal["polars"],
+) -> pl.DataFrame: ...
+@overload
+def latin_hypercube(
+    mission: str | Path,
+    *,
+    n: int,
+    perturb: Mapping[str, DistSpec],
+    seed: int | None = ...,
+    backend: Pool | None = ...,
+    out: str | Path | None = ...,
+    progress: bool = ...,
+    engine: str,
+) -> DataFrame: ...
 def latin_hypercube(
     mission: str | Path,
     *,
@@ -256,7 +388,8 @@ def latin_hypercube(
     backend: Pool | None = None,
     out: str | Path | None = None,
     progress: bool = True,
-) -> pd.DataFrame:
+    engine: str = "pandas",
+) -> DataFrame:
     """Run a Latin hypercube sweep over a GMAT mission.
 
     Backed by :class:`scipy.stats.qmc.LatinHypercube`: draws ``n`` unit-cube
@@ -287,18 +420,22 @@ def latin_hypercube(
         Same semantics as :func:`sweep`.
     progress:
         Same semantics as :func:`sweep`.
+    engine:
+        Same semantics as :func:`sweep`.
 
     Returns
     -------
-    pandas.DataFrame
-        ``(run_id, time)``-MultiIndexed frame with ``run_id`` cardinality
+    pandas.DataFrame or polars.DataFrame
+        ``(run_id, time)``-MultiIndexed frame (or polars flat-key
+        equivalent under ``engine="polars"``) with ``run_id`` cardinality
         ``n``. Same failure-as-row contract as :func:`sweep`.
 
     Raises
     ------
     SweepConfigError
-        If ``perturb`` is empty, ``n < 1``, or any parameter spec is
-        ill-formed.
+        If ``perturb`` is empty, ``n < 1``, any parameter spec is
+        ill-formed, or ``engine`` is neither ``"pandas"`` nor
+        ``"polars"``.
     """
     mission_path = Path(mission)
     parameter_spec: dict[str, Any] = {
@@ -321,9 +458,43 @@ def latin_hypercube(
         backend=backend,
         out=out,
         progress=progress,
+        engine=engine,
     )
 
 
+@overload
+def monte_carlo_extend(
+    manifest: str | Path,
+    script: str | Path,
+    *,
+    n: int,
+    backend: Pool | None = ...,
+    allow_script_drift: bool = ...,
+    progress: bool = ...,
+    engine: Literal["pandas"] = ...,
+) -> pd.DataFrame: ...
+@overload
+def monte_carlo_extend(
+    manifest: str | Path,
+    script: str | Path,
+    *,
+    n: int,
+    backend: Pool | None = ...,
+    allow_script_drift: bool = ...,
+    progress: bool = ...,
+    engine: Literal["polars"],
+) -> pl.DataFrame: ...
+@overload
+def monte_carlo_extend(
+    manifest: str | Path,
+    script: str | Path,
+    *,
+    n: int,
+    backend: Pool | None = ...,
+    allow_script_drift: bool = ...,
+    progress: bool = ...,
+    engine: str,
+) -> DataFrame: ...
 def monte_carlo_extend(
     manifest: str | Path,
     script: str | Path,
@@ -332,7 +503,8 @@ def monte_carlo_extend(
     backend: Pool | None = None,
     allow_script_drift: bool = False,
     progress: bool = True,
-) -> pd.DataFrame:
+    engine: str = "pandas",
+) -> DataFrame:
     """Append ``n`` more bit-deterministic Monte Carlo runs to an existing sweep.
 
     Loads the manifest written by a prior :func:`monte_carlo` call,
@@ -374,11 +546,14 @@ def monte_carlo_extend(
         :meth:`gmat_sweep.Sweep.from_manifest`.
     progress:
         Whether to draw the :mod:`tqdm` progress bar over the new runs.
+    engine:
+        Output engine; same semantics as :func:`sweep`.
 
     Returns
     -------
-    pandas.DataFrame
-        ``(run_id, time)``-MultiIndexed frame whose ``run_id``
+    pandas.DataFrame or polars.DataFrame
+        ``(run_id, time)``-MultiIndexed frame (or polars flat-key
+        equivalent under ``engine="polars"``) whose ``run_id``
         cardinality is ``old_n + n``.
 
     Raises
@@ -386,8 +561,9 @@ def monte_carlo_extend(
     SweepConfigError
         If the manifest's ``parameter_spec._kind`` is not
         ``"monte_carlo"``, ``n < 1``, the script hash drifted with
-        ``allow_script_drift=False``, or the base sweep is incomplete
-        (any ``run_id`` in ``[0, old_n)`` is failed or missing).
+        ``allow_script_drift=False``, the base sweep is incomplete
+        (any ``run_id`` in ``[0, old_n)`` is failed or missing), or
+        ``engine`` is neither ``"pandas"`` nor ``"polars"``.
     """
     # Local import to avoid a Sweep ↔ api import cycle at module load.
     from gmat_sweep.sweep import Sweep
@@ -400,7 +576,7 @@ def monte_carlo_extend(
             allow_script_drift=allow_script_drift,
             progress=progress,
         ).extend(n=n)
-        return sweep_obj.to_dataframe()
+        return sweep_obj.to_dataframe(engine=engine)
 
 
 def latin_hypercube_extend(
@@ -457,7 +633,8 @@ def _run_sweep(
     backend: Pool | None,
     out: str | Path | None,
     progress: bool,
-) -> pd.DataFrame:
+    engine: str,
+) -> DataFrame:
     """Shared orchestration for the public entry points.
 
     Resolves the output directory (creating a sweep-scoped temp dir when
@@ -499,7 +676,7 @@ def _run_sweep(
                 progress=progress,
             )
             .run()
-            .to_dataframe()
+            .to_dataframe(engine=engine)
         )
 
     if tempdir is not None:

--- a/src/gmat_sweep/sweep.py
+++ b/src/gmat_sweep/sweep.py
@@ -19,7 +19,7 @@ import warnings
 from collections.abc import Mapping, Sequence
 from concurrent.futures import Future
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 from tqdm.auto import tqdm
 
@@ -34,7 +34,9 @@ from gmat_sweep.manifest import Manifest, ManifestEntry, canonical_script_sha256
 
 if TYPE_CHECKING:
     import pandas as pd
+    import polars as pl
 
+    from gmat_sweep.aggregate import DataFrame
     from gmat_sweep.backends.base import Pool
     from gmat_sweep.spec import RunOutcome, RunSpec
 
@@ -453,29 +455,72 @@ class Sweep:
             sweep_version=sweep_version,
         )
 
-    def to_dataframe(self, name: str | None = None) -> pd.DataFrame:
+    @overload
+    def to_dataframe(
+        self, name: str | None = ..., *, engine: Literal["pandas"] = ...
+    ) -> pd.DataFrame: ...
+    @overload
+    def to_dataframe(
+        self, name: str | None = ..., *, engine: Literal["polars"]
+    ) -> pl.DataFrame: ...
+    @overload
+    def to_dataframe(self, name: str | None = ..., *, engine: str) -> DataFrame: ...
+    def to_dataframe(self, name: str | None = None, *, engine: str = "pandas") -> DataFrame:
         """Aggregate the sweep's ``ReportFile`` outputs into one DataFrame.
 
         ``name`` selects which report to aggregate when the sweep produced
         multiple ``ReportFile`` resources per run; ``None`` (default) picks
-        the sole report when exactly one was produced. See
+        the sole report when exactly one was produced. ``engine="polars"``
+        returns a :class:`polars.DataFrame` with the ``(run_id, time)``
+        MultiIndex flattened into two leading columns; the default
+        ``engine="pandas"`` preserves the MultiIndex. See
         :func:`gmat_sweep.aggregate.lazy_multiindex` for the full contract.
         """
-        return lazy_multiindex(self.to_manifest(), self._output_dir, name=name)
+        return lazy_multiindex(self.to_manifest(), self._output_dir, name=name, engine=engine)
 
-    def to_ephemerides(self, name: str | None = None) -> pd.DataFrame:
+    @overload
+    def to_ephemerides(
+        self, name: str | None = ..., *, engine: Literal["pandas"] = ...
+    ) -> pd.DataFrame: ...
+    @overload
+    def to_ephemerides(
+        self, name: str | None = ..., *, engine: Literal["polars"]
+    ) -> pl.DataFrame: ...
+    @overload
+    def to_ephemerides(self, name: str | None = ..., *, engine: str) -> DataFrame: ...
+    def to_ephemerides(self, name: str | None = None, *, engine: str = "pandas") -> DataFrame:
         """Aggregate the sweep's ``EphemerisFile`` outputs into one DataFrame.
 
-        See :func:`gmat_sweep.aggregate.lazy_ephemerides` for the contract.
+        See :func:`gmat_sweep.aggregate.lazy_ephemerides` for the contract,
+        including the ``engine`` knob.
         """
-        return lazy_ephemerides(self.to_manifest(), self._output_dir, name=name)
+        return lazy_ephemerides(self.to_manifest(), self._output_dir, name=name, engine=engine)
 
-    def to_contacts(self, name: str | None = None) -> pd.DataFrame:
+    @overload
+    def to_contacts(
+        self, name: str | None = ..., *, engine: Literal["pandas"] = ...
+    ) -> pd.DataFrame: ...
+    @overload
+    def to_contacts(self, name: str | None = ..., *, engine: Literal["polars"]) -> pl.DataFrame: ...
+    @overload
+    def to_contacts(self, name: str | None = ..., *, engine: str) -> DataFrame: ...
+    def to_contacts(self, name: str | None = None, *, engine: str = "pandas") -> DataFrame:
         """Aggregate the sweep's ``ContactLocator`` outputs into one DataFrame.
 
-        See :func:`gmat_sweep.aggregate.lazy_contacts` for the contract.
+        See :func:`gmat_sweep.aggregate.lazy_contacts` for the contract,
+        including the ``engine`` knob.
         """
-        return lazy_contacts(self.to_manifest(), self._output_dir, name=name)
+        return lazy_contacts(self.to_manifest(), self._output_dir, name=name, engine=engine)
+
+    def to_polars(self, name: str | None = None) -> pl.DataFrame:
+        """Aggregate the sweep's ``ReportFile`` outputs into a polars DataFrame.
+
+        Shortcut for :meth:`to_dataframe` with ``engine="polars"``: returns
+        a :class:`polars.DataFrame` whose ``(run_id, time)`` MultiIndex is
+        flattened into two leading sorted columns. Requires the ``[polars]``
+        extra; raises :class:`ImportError` with the install hint otherwise.
+        """
+        return self.to_dataframe(name, engine="polars")
 
     def to_fused_reports(
         self,

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 import pandas as pd
@@ -1230,3 +1230,173 @@ def test_sweep_diff_rejects_on_run_id_when_index_has_no_run_id_level() -> None:
     df = _diff_df(n_runs=2, n_steps=2).reset_index().set_index("time")
     with pytest.raises(SweepConfigError, match=r"requires a 'run_id' index level"):
         sweep_diff(df, df.copy(), on="run_id")
+
+
+# ---------------------------------------------------------------------------
+# engine="polars" — opt-in polars output across the DataFrame-returning surface
+# ---------------------------------------------------------------------------
+
+# pytest.importorskip skips this section's tests when the [polars] extra is not
+# installed; the TYPE_CHECKING import gives mypy something to resolve when the
+# typecheck CI cell runs without the extra (the polars override in pyproject
+# treats the symbol as Any).
+if TYPE_CHECKING:
+    import polars as pl
+else:
+    pl = pytest.importorskip("polars")
+
+
+def _assert_polars_matches_pandas_flat(
+    pdf: pd.DataFrame,
+    plf: pl.DataFrame,
+    *,
+    numeric_check_col: str,
+) -> None:
+    """Assert a polars-engine result matches its pandas-engine equivalent.
+
+    The MultiIndex (if any) is flattened to leading columns under the polars
+    engine, so we compare row count, column set (after the flatten), and at
+    least one numeric column to text precision — the issue's stated DoD.
+    Pandas ``NaN``/``NaT``/``pd.NA`` and polars ``null`` all collapse to
+    ``None`` for the per-element comparison.
+    """
+    import math
+
+    def _normalise(v: Any) -> Any:
+        if v is None or v is pd.NaT or v is pd.NA:
+            return None
+        if isinstance(v, float) and math.isnan(v):
+            return None
+        return v
+
+    flat = pdf.reset_index() if pdf.index.nlevels > 1 or pdf.index.name else pdf
+    assert plf.height == len(flat)
+    assert set(plf.columns) == set(flat.columns)
+    pl_col = [_normalise(v) for v in plf.get_column(numeric_check_col).to_list()]
+    pd_col = [_normalise(v) for v in flat[numeric_check_col].tolist()]
+    assert pl_col == pd_col
+
+
+def test_lazy_multiindex_engine_polars_flattens_index_and_matches_pandas(
+    tmp_path: Path,
+) -> None:
+    paths = [_write_run_parquet(tmp_path, i, n_rows=2) for i in range(4)]
+    entries: list[ManifestEntry] = [_ok_entry(i, p) for i, p in enumerate(paths)]
+    entries.append(_nonok_entry(4, "failed"))
+    manifest = _make_manifest(entries)
+
+    pdf = lazy_multiindex(manifest, tmp_path)
+    plf = lazy_multiindex(manifest, tmp_path, engine="polars")
+
+    assert isinstance(plf, pl.DataFrame)
+    assert plf.columns[:2] == ["run_id", "time"]
+    _assert_polars_matches_pandas_flat(pdf, plf, numeric_check_col="x")
+
+
+def test_lazy_ephemerides_engine_polars_matches_pandas(tmp_path: Path) -> None:
+    paths = [
+        _write_run_parquet(tmp_path, i, n_rows=2, basename="ephemeris__Eph1") for i in range(3)
+    ]
+    manifest = _make_manifest([_ok_entry(i, p, key="ephemeris__Eph1") for i, p in enumerate(paths)])
+
+    pdf = lazy_ephemerides(manifest, tmp_path)
+    plf = lazy_ephemerides(manifest, tmp_path, engine="polars")
+
+    assert isinstance(plf, pl.DataFrame)
+    _assert_polars_matches_pandas_flat(pdf, plf, numeric_check_col="y")
+
+
+def test_lazy_contacts_engine_polars_preserves_int64_nullable_interval_id(
+    tmp_path: Path,
+) -> None:
+    p0 = _write_contact_parquet(tmp_path, 0, n_intervals=2)
+    p1 = _write_contact_parquet(tmp_path, 1, n_intervals=1)
+    entries: list[ManifestEntry] = [
+        _ok_entry(0, p0, key="contact__GroundContact"),
+        _ok_entry(1, p1, key="contact__GroundContact"),
+        _nonok_entry(2, "failed"),
+    ]
+    manifest = _make_manifest(entries)
+
+    pdf = lazy_contacts(manifest, tmp_path)
+    plf = lazy_contacts(manifest, tmp_path, engine="polars")
+
+    assert isinstance(plf, pl.DataFrame)
+    assert plf.columns[:2] == ["run_id", "interval_id"]
+    # The failed run's interval_id must be null in polars (round-tripped from
+    # pandas Int64 + pd.NA), not 0 or some other sentinel.
+    failed_row = plf.filter(pl.col("run_id") == 2)
+    assert failed_row.height == 1
+    assert failed_row["interval_id"][0] is None
+    _assert_polars_matches_pandas_flat(pdf, plf, numeric_check_col="Duration")
+
+
+def test_mc_convergence_engine_polars_matches_pandas() -> None:
+    df = _conv_df(n_runs=12)
+    pdf = mc_convergence(df, "miss", terminal_only=True)
+    plf = mc_convergence(df, "miss", terminal_only=True, engine="polars")
+
+    assert isinstance(plf, pl.DataFrame)
+    _assert_polars_matches_pandas_flat(pdf, plf, numeric_check_col="running_mean")
+
+
+def test_sweep_diff_engine_polars_matches_pandas() -> None:
+    a = _diff_df(n_runs=3, n_steps=2)
+    b = _diff_df(n_runs=3, n_steps=2, sma_offset=50.0)
+    pdf = sweep_diff(a, b)
+    plf = sweep_diff(a, b, engine="polars")
+
+    assert isinstance(plf, pl.DataFrame)
+    assert plf.columns[:2] == ["run_id", "time"]
+    _assert_polars_matches_pandas_flat(pdf, plf, numeric_check_col="Sat.SMA__diff")
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda m, d: lazy_multiindex(m, d, engine="bogus"),
+        lambda m, d: lazy_ephemerides(m, d, engine="bogus"),
+        lambda m, d: lazy_contacts(m, d, engine="bogus"),
+    ],
+)
+def test_lazy_aggregators_reject_unknown_engine(
+    tmp_path: Path,
+    call: Any,
+) -> None:
+    manifest = _make_manifest([])
+    with pytest.raises(SweepConfigError, match=r"engine='bogus' is not supported"):
+        call(manifest, tmp_path)
+
+
+def test_mc_convergence_rejects_unknown_engine() -> None:
+    df = _conv_df(n_runs=2)
+    with pytest.raises(SweepConfigError, match=r"engine='bogus' is not supported"):
+        mc_convergence(df, "miss", engine="bogus")
+
+
+def test_sweep_diff_rejects_unknown_engine() -> None:
+    a = _diff_df(n_runs=2, n_steps=2)
+    with pytest.raises(SweepConfigError, match=r"engine='bogus' is not supported"):
+        sweep_diff(a, a.copy(), engine="bogus")
+
+
+def test_polars_missing_extra_raises_install_hint(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When polars is not importable, the ImportError carries the install hint."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "polars":
+            raise ImportError("No module named 'polars'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    p = _write_run_parquet(tmp_path, 0, n_rows=1)
+    manifest = _make_manifest([_ok_entry(0, p)])
+    with pytest.raises(ImportError, match=r"pip install gmat-sweep\[polars\]"):
+        lazy_multiindex(manifest, tmp_path, engine="polars")

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -245,6 +245,44 @@ def test_sweep_to_dataframe_returns_multiindexed_frame(
     assert (df["__status"] == "ok").all()
 
 
+def test_sweep_to_dataframe_engine_polars_returns_polars_frame(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    """Smoke-test the engine="polars" plumbing through Sweep.to_dataframe and to_polars."""
+    pl = pytest.importorskip("polars")
+
+    script = _write_script(tmp_path)
+    output_dir = tmp_path / "out"
+    runs = _make_runs(script, output_dir, n=3)
+
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook(rows=2))
+
+    with LocalJoblibPool(workers=1) as pool:
+        sweep = Sweep(
+            runs=runs,
+            backend=pool,
+            manifest_path=output_dir / "manifest.jsonl",
+            output_dir=output_dir,
+            script_path=script,
+            parameter_spec={"Sat.SMA": [7000.0, 7001.0, 7002.0]},
+            progress=False,
+        ).run()
+
+    pdf = sweep.to_dataframe()
+    plf = sweep.to_dataframe(engine="polars")
+    plf_shortcut = sweep.to_polars()
+
+    assert isinstance(plf, pl.DataFrame)
+    assert isinstance(plf_shortcut, pl.DataFrame)
+    # Both polars paths agree.
+    assert plf.equals(plf_shortcut)
+    # Index becomes two leading columns; row count and the non-index column
+    # set match the pandas-engine equivalent.
+    assert plf.columns[:2] == ["run_id", "time"]
+    assert plf.height == len(pdf)
+    assert set(plf.columns) == set(pdf.reset_index().columns)
+
+
 def test_sweep_to_dataframe_marks_failed_run(tmp_path: Path, fake_gmat_run: FakeGmatRun) -> None:
     script = _write_script(tmp_path)
     output_dir = tmp_path / "out"

--- a/uv.lock
+++ b/uv.lock
@@ -1281,6 +1281,9 @@ mpi = [
 plot = [
     { name = "matplotlib" },
 ]
+polars = [
+    { name = "polars" },
+]
 ray = [
     { name = "ray", extra = ["default"] },
 ]
@@ -1314,13 +1317,14 @@ requires-dist = [
     { name = "mpi4py", marker = "extra == 'mpi'", specifier = ">=3.1" },
     { name = "numpy", specifier = ">=1.24" },
     { name = "pandas", specifier = ">=2.0" },
+    { name = "polars", marker = "extra == 'polars'", specifier = ">=1.0" },
     { name = "pyarrow", specifier = ">=14" },
     { name = "ray", extras = ["default"], marker = "extra == 'examples'", specifier = ">=2.10" },
     { name = "ray", extras = ["default"], marker = "extra == 'ray'", specifier = ">=2.10" },
     { name = "scipy", specifier = ">=1.11" },
     { name = "tqdm", specifier = ">=4.66" },
 ]
-provides-extras = ["dask", "ray", "k8s", "mpi", "plot", "examples"]
+provides-extras = ["dask", "ray", "k8s", "mpi", "plot", "polars", "examples"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3346,6 +3350,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "polars"
+version = "1.40.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "polars-runtime-32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/8c/bc9bc948058348ed43117cecc3007cd608f395915dae8a00974579a5dab1/polars-1.40.1.tar.gz", hash = "sha256:ab2694134b137596b5a59bfd7b4c54ebbc9b59f9403127f18e32d363777552e8", size = 733574, upload-time = "2026-04-22T19:15:55.507Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/91/74fc60d94488685a92ac9d49d7ec55f3e91fe9b77942a6235a5fa7f249c3/polars-1.40.1-py3-none-any.whl", hash = "sha256:c0f861219d1319cdea45c4ce4d30355a47176b8f98dcedf95ea8269f131b8abd", size = 828723, upload-time = "2026-04-22T19:14:25.452Z" },
+]
+
+[[package]]
+name = "polars-runtime-32"
+version = "1.40.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ba/26d40f039be9f552b5fd7365a621bdfc0f8e912ef77094ae4693491b0bae/polars_runtime_32-1.40.1.tar.gz", hash = "sha256:37f3065615d1bf90d03b5326222df4c5c1f8a5d33e50470aa588e3465e6eb814", size = 2935843, upload-time = "2026-04-22T19:15:57.26Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/46/22c8af5eed68ac2eeb556e0fa3ca8a7b798e984ceff4450888f3b5ac61fd/polars_runtime_32-1.40.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:b748ef652270cc49e9e69f99a035e0eb4d5f856d42bcd6ac4d9d80a40142aa1e", size = 52098755, upload-time = "2026-04-22T19:14:28.555Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/3e/48599a38009ca60ff82a6f38c8a621ce3c0286aa7397c7d79e741bd9060e/polars_runtime_32-1.40.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:d249b3743e05986060cec0a7aaa542d020df6c6b876e556023a310efd581f9be", size = 46367542, upload-time = "2026-04-22T19:14:32.433Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e9/384bc069367a1a36ee31c13782c178dbd039b2b873b772d4a0fc23a2373d/polars_runtime_32-1.40.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5987b30e7aa1059d069498496e8dda35afd592b0ac3d46ed87e3ff8df1ad652c", size = 50252104, upload-time = "2026-04-22T19:14:35.945Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ef/7d57ceb0651af74194e97ed6583e148d352f03d696090221b8059cdfc90b/polars_runtime_32-1.40.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d7f42a8b3f16fc66002cc0f6516f7dd7653396886ae0ed362ab95c0b3408b59", size = 56250788, upload-time = "2026-04-22T19:14:39.743Z" },
+    { url = "https://files.pythonhosted.org/packages/10/0f/e4b3ffc748827a14a474ec9c42e45c066050e440fec57e914091d9adda75/polars_runtime_32-1.40.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e5f7becc237a7ec9d9a10878dc8e54b73bbf4e2d94a2991c37d7a0b38590d8f9", size = 50432590, upload-time = "2026-04-22T19:14:43.388Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/0b/b8d95fbed869fa4caabe9c400e4210374913b376e925e96fdcfa9be6416b/polars_runtime_32-1.40.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:992d14cf191dde043d36fbdbc98a65e43fbc7e9a5024cecd45f838ac4988c1ee", size = 54155564, upload-time = "2026-04-22T19:14:47.239Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d9/d091d8fb5cbed5e9536adfed955c4c89987a4cc3b8e73ae4532402b91c74/polars_runtime_32-1.40.1-cp310-abi3-win_amd64.whl", hash = "sha256:f78bb2abd00101cbb23cc0cb068f7e36e081057a15d2ec2dde3dda280709f030", size = 51829755, upload-time = "2026-04-22T19:14:50.85Z" },
+    { url = "https://files.pythonhosted.org/packages/65/ad/b33c3022a394f3eb55c3310597cec615412a8a33880055eee191d154a628/polars_runtime_32-1.40.1-cp310-abi3-win_arm64.whl", hash = "sha256:b5cbfaf6b085b420b4bfcbe24e8f665076d1cccfdb80c0484c02a023ce205537", size = 45822104, upload-time = "2026-04-22T19:14:54.192Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds an opt-in `engine="polars"` kwarg across the DataFrame-returning surface (`sweep` / `monte_carlo` / `latin_hypercube` / `monte_carlo_extend`, `Sweep.to_dataframe` / `to_ephemerides` / `to_contacts` plus a `Sweep.to_polars()` shortcut, and the standalone `lazy_multiindex` / `lazy_ephemerides` / `lazy_contacts` / `sweep_diff` / `mc_convergence`). Pandas remains the default; the `(run_id, time)` MultiIndex flattens to two leading sorted columns under polars.
- New `[polars]` optional extra pinning `polars>=1.0`. Polars is lazy-imported in `gmat_sweep.aggregate`; missing the extra fails fast with `pip install gmat-sweep[polars]`.
- `lazy_fused_reports` / `Sweep.to_fused_reports` and `sweep_summary` stay pandas-only — their column-level MultiIndex has no polars equivalent without a flattening contract decision; explicitly noted in the docs as a follow-up.
- Each entry point gets `Literal["pandas"]` / `Literal["polars"]` / `str` overload stubs so existing pandas-typed callers keep their narrowed return type.

## Test plan

- [ ] Per-aggregator polars parity: row count, column set, and one numeric column match pandas-engine output to text precision (DoD criterion).
- [ ] `Sweep.to_dataframe(engine="polars")` and `Sweep.to_polars()` smoke test through a fake-GMAT fixture.
- [ ] Missing-`[polars]`-extra raises `ImportError` with the install hint.
- [ ] Invalid engine string raises `SweepConfigError` on every entry point.
- [ ] CI: ruff, mypy, pytest, aggregate.py coverage stays ≥95%.

Closes #97