### PR TITLE
Add Sobol sensitivity indices via SALib (extra [sensitivity])

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,12 @@ jobs:
         # coverage gate — the real-cluster k8s integration tests still
         # live in the dedicated `backend-k8s` job below. `--extra polars`
         # so the engine="polars" tests under `tests/test_aggregate.py`
-        # contribute to the aggregate.py coverage gate. The lint,
-        # typecheck, and minimal-install jobs deliberately keep their
-        # syncs narrower.
-        run: uv sync --all-groups --extra dask --extra ray --extra plot --extra k8s --extra polars
+        # contribute to the aggregate.py coverage gate. `--extra sensitivity`
+        # so `tests/test_sensitivity.py` can import SALib and contribute to
+        # the overall coverage gate (it would otherwise skip via
+        # `pytest.importorskip("SALib")`). The lint, typecheck, and minimal-
+        # install jobs deliberately keep their syncs narrower.
+        run: uv sync --all-groups --extra dask --extra ray --extra plot --extra k8s --extra polars --extra sensitivity
 
       - name: Run pytest
         # `-m "(integration or not integration) and not slow"` overrides the

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Runnable example notebooks:
 | Release | Scope |
 |---|---|
 | **v0.3** *(current)* | `DaskPool` (extra `[dask]`) and `RayPool` (extra `[ray]`) join `LocalJoblibPool` behind a single `Pool` ABC. CLI `--backend {local,dask,ray}` flag and rich `gmat-sweep show --detail` / `--run` modes. Three cluster-recipe pages (Slurm with `srun`, Kubernetes pod-per-worker, Ray autoscaling). Benchmark page comparing backends on a 1000-run reference sweep, with a per-backend throughput floor enforced in CI. Manifest header gains a `backend` field; `reuse_gmat_context` exposes the bootstrap-amortisation choice on every pool. |
-| **v0.4** *(next)* | `KubernetesJobPool` (extra `[k8s]`) — every run becomes one `batch/v1` Job, no Dask or Ray middleware. Notebook-friendly `__repr_html__` for `Sweep` / `RunOutcome`. Optional plotting helpers (`sweep_corner`, `sweep_heatmap`) behind a `[plot]` extra pulling matplotlib. A docs cookbook page on integrating sweep outputs into downstream consumers. Smoke-canary cell against the canonical `ghcr.io/astro-tools/gmat` image. |
+| **v0.4** *(next)* | `KubernetesJobPool` (extra `[k8s]`) — every run becomes one `batch/v1` Job, no Dask or Ray middleware. Notebook-friendly `__repr_html__` for `Sweep` / `RunOutcome`. Optional plotting helpers (`sweep_corner`, `sweep_heatmap`) behind a `[plot]` extra pulling matplotlib. Sobol sensitivity indices via SALib (extra `[sensitivity]`) — `sobol_sample` builds the Saltelli design, `sobol_analyze` returns first/total/second-order indices with confidence intervals. A docs cookbook page on integrating sweep outputs into downstream consumers. Smoke-canary cell against the canonical `ghcr.io/astro-tools/gmat` image. |
 
 Past releases live in [`CHANGELOG.md`](CHANGELOG.md).
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -74,6 +74,12 @@ auto-generated from docstrings via
 
 ::: gmat_sweep.mc_convergence
 
+## Sensitivity
+
+::: gmat_sweep.sobol_sample
+
+::: gmat_sweep.sobol_analyze
+
 ## Plotting
 
 ::: gmat_sweep.plotting.sweep_band_plot

--- a/docs/sensitivity.md
+++ b/docs/sensitivity.md
@@ -1,0 +1,146 @@
+# Sensitivity analysis
+
+Sobol sensitivity indices answer the canonical *which input drives the
+output* question for a stochastic sweep. `gmat_sweep.sensitivity`
+([`sobol_sample`][gmat_sweep.sobol_sample] + [`sobol_analyze`][gmat_sweep.sobol_analyze])
+wraps [SALib](https://salib.readthedocs.io/) so you can produce a
+Saltelli sample design, run the sweep through the existing `sweep(samples=...)`
+path, and read the indices off without assembling SALib's `problem`
+dict by hand.
+
+## Install
+
+The dependency is gated behind an optional extra so the default install
+stays slim:
+
+```bash
+pip install gmat-sweep[sensitivity]
+```
+
+## Workflow
+
+The three steps are: build the sample design, run the sweep, analyse.
+
+```python
+from gmat_sweep import sweep, sobol_sample, sobol_analyze
+
+perturb = {
+    "CoastTime":    ("uniform", 0.0, 1200.0),
+    "Inj.Element1": ("normal", 1.0, 0.05),
+    "Inj.Element2": ("normal", 0.0, 0.05),
+    "Inj.Element3": ("normal", 0.0, 0.05),
+}
+
+# 1. Saltelli/Sobol sample design — n*(2D+2) rows for D=4, so n=128 → 1280 runs.
+samples = sobol_sample(perturb, n=128, seed=42)
+
+# 2. Run the sweep through the explicit-row entry point.
+df = sweep("injection_dispersion.script", samples=samples)
+
+# 3. Sobol indices on the metric of interest.
+indices = sobol_analyze(df, perturb, metric="Sat.X", seed=42)
+print(indices)
+```
+
+`sobol_analyze` returns a tidy long DataFrame with columns
+`kind` / `param_a` / `param_b` / `value` / `conf`:
+
+| kind | param_a       | param_b       | value | conf |
+|------|---------------|---------------|------:|-----:|
+| S1   | CoastTime     | NaN           | 0.41  | 0.03 |
+| S1   | Inj.Element1  | NaN           | 0.18  | 0.02 |
+| ...  |               |               |       |      |
+| ST   | CoastTime     | NaN           | 0.55  | 0.04 |
+| ...  |               |               |       |      |
+| S2   | CoastTime     | Inj.Element1  | 0.07  | 0.05 |
+
+`kind="S1"` is the first-order index (parameter alone), `"ST"` is the
+total-order index (parameter plus all its interactions), and `"S2"` is
+the pairwise second-order index. `conf` is SALib's 95 % bootstrap
+confidence half-width — interpret index values as `value ± conf`.
+
+## Sample size
+
+The Saltelli design generates `n * (2*D + 2)` runs at
+`calc_second_order=True` and `n * (D + 2)` runs at
+`calc_second_order=False`, where `D = len(perturb)`. Pick `n` as a
+power of two; SALib's authors recommend `n ≥ 1024` for stable estimates
+on most engineering problems.
+
+If the second-order pairwise indices aren't part of the question,
+trade them away to halve the run count:
+
+```python
+samples = sobol_sample(perturb, n=128, seed=42, calc_second_order=False)
+df = sweep("...", samples=samples)
+indices = sobol_analyze(df, perturb, metric="Sat.X", seed=42, calc_second_order=False)
+```
+
+The flag must match between the two calls — `sobol_analyze` doesn't
+re-derive it from the row count.
+
+## Reducing per-run output to a scalar
+
+`metric` collapses the `(run_id, time)`-MultiIndexed sweep result to one
+scalar per run:
+
+* `metric="Sat.X"` — convenience for *value of `Sat.X` at each run's
+  final time-step* (the typical end-of-mission state).
+* `metric=callable` — receives the full DataFrame, returns a
+  `pd.Series` indexed by `run_id`. Use this for derived quantities
+  like miss distance, total Δv, or any quantile across the run's
+  trajectory.
+
+```python
+import numpy as np
+
+def terminal_radius(df):
+    last = df.groupby(level="run_id").tail(1)
+    return np.sqrt(last["Sat.X"]**2 + last["Sat.Y"]**2 + last["Sat.Z"]**2)
+
+indices = sobol_analyze(df, perturb, metric=terminal_radius, seed=42)
+```
+
+## Distribution shapes
+
+`sobol_sample` accepts the same `perturb` mapping as
+[`monte_carlo`](monte-carlo.md): the three shorthand tuples
+(`("normal", mu, sigma)`, `("uniform", lo, hi)`, `("lognormal", mu, sigma)`)
+and any pre-frozen `scipy.stats.rv_frozen`. The unit-cube design from
+SALib is lifted into each parameter's marginal via the distribution's
+`ppf` — generalising past SALib's own `dists` knob to anything
+`scipy.stats` can freeze.
+
+## Failure modes
+
+`sobol_analyze` rejects a sweep result that contains any `__status != "ok"`
+rows: SALib cannot ingest the NaN-padded values that
+failed/skipped runs leave behind. Filter explicitly first:
+
+```python
+df_ok = df[df["__status"] == "ok"]
+indices = sobol_analyze(df_ok, perturb, metric="Sat.X", seed=42)
+```
+
+Be aware that filtering breaks the Saltelli design's row balance — if
+runs failed in the middle, the indices on the survivors are no longer
+unbiased estimates. For a clean answer, re-launch the failed rows
+(`gmat-sweep resume`) before analysing.
+
+## Determinism
+
+Two `sobol_sample(..., seed=K)` calls produce bit-equal DataFrames at
+the same `(perturb, n, seed, calc_second_order)`. Two
+`sobol_analyze(..., seed=K)` calls produce bit-equal indices and
+bootstrap confidence intervals against the same `Y` vector. Saltelli
+seeding is independent of [`monte_carlo`](monte-carlo.md)'s
+per-run-name seeding contract — they are separate samplers.
+
+## What SALib methods are wrapped
+
+`gmat_sweep.sensitivity` ships Sobol only. SALib also exposes Morris,
+FAST, RBD-FAST, and DGSM samplers and analyses; if your work needs one
+of those, the same recipe (`sobol_sample`'s unit-cube + `ppf` lift,
+applied to the SALib sampler, then handed to `sweep(samples=...)`)
+generalises in three lines — open an issue if you'd like the wrappers
+upstreamed.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
   - Parameter spec: parameter-spec.md
   - Backends: backends.md
   - Monte Carlo: monte-carlo.md
+  - Sensitivity: sensitivity.md
   - Aggregation: aggregation.md
   - Resume: resume.md
   - CLI reference: cli.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ k8s = ["kubernetes>=29,<33"]
 mpi = ["mpi4py>=3.1"]
 plot = ["matplotlib>=3.8"]
 polars = ["polars>=1.0"]
+sensitivity = ["salib>=1.5"]
 examples = ["matplotlib>=3.8", "distributed>=2024.1", "ray[default]>=2.10"]
 
 [project.scripts]
@@ -191,6 +192,15 @@ follow_imports = "skip"
 # does not install the extra.
 [[tool.mypy.overrides]]
 module = ["polars", "polars.*"]
+ignore_missing_imports = true
+follow_imports = "skip"
+
+# SALib is an optional [sensitivity]-extra dependency; sensitivity.py imports
+# SALib.sample.sobol / SALib.analyze.sobol lazily inside each function. SALib
+# ships partial type information that trips strict-mode rejection, so
+# `follow_imports = "skip"` accompanies the missing-imports tolerance.
+[[tool.mypy.overrides]]
+module = ["SALib", "SALib.*"]
 ignore_missing_imports = true
 follow_imports = "skip"
 

--- a/src/gmat_sweep/__init__.py
+++ b/src/gmat_sweep/__init__.py
@@ -42,6 +42,7 @@ from gmat_sweep.manifest import (
     ManifestEntry,
     canonical_script_sha256,
 )
+from gmat_sweep.sensitivity import sobol_analyze, sobol_sample
 from gmat_sweep.spec import RunOutcome, RunSpec, SweepSpec
 from gmat_sweep.sweep import Sweep
 
@@ -92,6 +93,8 @@ __all__ = [
     "mc_convergence",
     "monte_carlo",
     "monte_carlo_extend",
+    "sobol_analyze",
+    "sobol_sample",
     "sweep",
     "sweep_diff",
     "sweep_summary",

--- a/src/gmat_sweep/sensitivity.py
+++ b/src/gmat_sweep/sensitivity.py
@@ -1,0 +1,252 @@
+"""Sobol sensitivity indices via SALib (extra ``[sensitivity]``).
+
+Wraps :mod:`SALib.sample.sobol` and :mod:`SALib.analyze.sobol` so a
+gmat-sweep user can produce a Saltelli/Sobol sample design as an
+explicit-row DataFrame, hand it to :func:`gmat_sweep.sweep` via
+``samples=``, and run :func:`sobol_analyze` on the result without
+assembling SALib's ``problem`` dict by hand.
+
+SALib is imported lazily inside each function — a default
+``pip install gmat-sweep`` never touches SALib. Install the optional
+extra to enable the module::
+
+    pip install gmat-sweep[sensitivity]
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from gmat_sweep.distributions import DistSpec, to_rv_frozen
+from gmat_sweep.errors import SweepConfigError
+
+__all__ = [
+    "sobol_analyze",
+    "sobol_sample",
+]
+
+
+def sobol_sample(
+    perturb: Mapping[str, DistSpec],
+    n: int,
+    *,
+    seed: int | None = None,
+    calc_second_order: bool = True,
+) -> pd.DataFrame:
+    """Build a Saltelli/Sobol sample design as an explicit-row DataFrame.
+
+    The returned DataFrame has parameter columns in lexicographic order and
+    a default :class:`pandas.RangeIndex` — suitable input to
+    :func:`gmat_sweep.sweep` via ``samples=``. Row count is ``n * (2*D + 2)``
+    when ``calc_second_order=True`` (the default) and ``n * (D + 2)``
+    otherwise, where ``D = len(perturb)``.
+
+    The unit-cube design from :mod:`SALib.sample.sobol` is lifted into each
+    parameter's marginal via ``to_rv_frozen(perturb[k]).ppf(...)``, so any
+    distribution shape :data:`gmat_sweep.distributions.DistSpec` accepts is
+    supported — not just the uniform/normal/lognormal cases SALib's own
+    ``dists`` knob covers.
+
+    Two calls at the same ``(perturb, n, seed, calc_second_order)`` produce
+    bit-equal DataFrames. ``seed=None`` falls back to OS entropy and is
+    **not** reproducible.
+
+    Parameters
+    ----------
+    perturb:
+        Mapping from dotted-path field name to a distribution spec. Same
+        surface as :func:`gmat_sweep.monte_carlo`.
+    n:
+        Saltelli base sample size. Must be ``>= 1``. Total runs are
+        ``n * (2*D + 2)`` (or ``n * (D + 2)``); SALib's authors recommend
+        powers of two.
+    seed:
+        Optional integer seed forwarded to SALib's sampler.
+    calc_second_order:
+        Whether to expand the design for second-order indices. Match this
+        flag in :func:`sobol_analyze`.
+
+    Raises
+    ------
+    SweepConfigError
+        If ``perturb`` is empty, ``n < 1``, or any parameter spec fails
+        validation in :func:`gmat_sweep.distributions.to_rv_frozen`.
+    """
+    if not perturb:
+        raise SweepConfigError("sobol_sample requires a non-empty perturb mapping")
+    if n < 1:
+        raise SweepConfigError(f"sobol_sample requires n >= 1, got {n}")
+
+    from SALib.sample import sobol as _sobol_sample
+
+    sorted_keys = sorted(perturb)
+    rvs = [to_rv_frozen(perturb[k]) for k in sorted_keys]
+
+    problem = _build_problem(sorted_keys)
+    unit = _sobol_sample.sample(problem, n, calc_second_order=calc_second_order, seed=seed)
+
+    columns: dict[str, Any] = {
+        key: rvs[idx].ppf(unit[:, idx]) for idx, key in enumerate(sorted_keys)
+    }
+    return pd.DataFrame(columns)
+
+
+def sobol_analyze(
+    df: pd.DataFrame,
+    perturb: Mapping[str, DistSpec],
+    metric: str | Callable[[pd.DataFrame], pd.Series],
+    *,
+    calc_second_order: bool = True,
+    seed: int | None = None,
+) -> pd.DataFrame:
+    """Compute Sobol indices on a sweep result via :mod:`SALib.analyze.sobol`.
+
+    Reduces ``df`` to a per-run scalar Y vector via ``metric``, then runs
+    SALib's Sobol analysis and returns a tidy long DataFrame with columns
+    ``["kind", "param_a", "param_b", "value", "conf"]``:
+
+    * ``kind`` is ``"S1"`` (first-order), ``"ST"`` (total-order), or
+      ``"S2"`` (second-order, only present when ``calc_second_order=True``).
+    * ``param_a`` is the parameter name. ``param_b`` is the second parameter
+      for ``S2`` rows and :data:`pandas.NA` for ``S1`` / ``ST`` rows.
+    * ``value`` is the Sobol index. ``conf`` is SALib's 95 % bootstrap
+      confidence half-width.
+
+    Parameters
+    ----------
+    df:
+        Sweep result DataFrame. Must come from a sweep launched with the
+        DataFrame :func:`sobol_sample` produced — the row count and ordering
+        are part of the Saltelli design. Failed or skipped runs cannot be
+        ingested; filter them out beforehand (``df = df[df["__status"] == "ok"]``).
+    perturb:
+        Same mapping handed to :func:`sobol_sample`. Used to recover the
+        sorted parameter list.
+    metric:
+        Reduces the per-(run_id, time) input to one scalar per run.
+        ``str`` form takes the value of that column at each run's final
+        time-step (``df.groupby(level="run_id")[metric].last()``) — the
+        common end-of-mission state shape. Callable form receives ``df``
+        and must return a :class:`pandas.Series` of length ``n * (2*D + 2)``
+        (or ``n * (D + 2)`` when ``calc_second_order=False``).
+    calc_second_order:
+        Match the value passed to :func:`sobol_sample`.
+    seed:
+        Optional integer seed forwarded to SALib's bootstrap resampler.
+
+    Raises
+    ------
+    SweepConfigError
+        If ``perturb`` is empty, the input has any non-``ok`` status row,
+        the metric column is missing, the callable returns a non-Series,
+        or the reduction yields any NaN value.
+    """
+    if not perturb:
+        raise SweepConfigError("sobol_analyze requires a non-empty perturb mapping")
+
+    from SALib.analyze import sobol as _sobol_analyze
+
+    sorted_keys = sorted(perturb)
+
+    y = _reduce_to_y(df, metric)
+
+    problem = _build_problem(sorted_keys)
+    result = _sobol_analyze.analyze(
+        problem,
+        np.asarray(y, dtype=float),
+        calc_second_order=calc_second_order,
+        seed=seed,
+    )
+
+    return _pack_indices(result, sorted_keys, calc_second_order=calc_second_order)
+
+
+def _build_problem(sorted_keys: list[str]) -> dict[str, Any]:
+    # Bounds are unit-cube; the per-parameter ppf lift in sobol_sample handles
+    # the actual distributions, generalising beyond SALib's own `dists` knob.
+    return {
+        "num_vars": len(sorted_keys),
+        "names": list(sorted_keys),
+        "bounds": [[0.0, 1.0]] * len(sorted_keys),
+    }
+
+
+def _reduce_to_y(
+    df: pd.DataFrame,
+    metric: str | Callable[[pd.DataFrame], pd.Series],
+) -> pd.Series:
+    if "__status" in df.columns:
+        not_ok = df["__status"].astype(str).ne("ok")
+        if bool(not_ok.any()):
+            raise SweepConfigError(
+                "sobol_analyze rejects sweep results with non-ok status rows; "
+                "filter to passing runs first, e.g. df = df[df['__status'] == 'ok']"
+            )
+
+    if isinstance(metric, str):
+        if metric not in df.columns:
+            raise SweepConfigError(
+                f"sobol_analyze metric column {metric!r} not found in df.columns"
+            )
+        if "run_id" not in (df.index.names or ()):
+            raise SweepConfigError(
+                "sobol_analyze with a str metric requires df indexed by run_id "
+                "(the default sweep() output)"
+            )
+        y = df.groupby(level="run_id")[metric].last()
+    else:
+        y_raw = metric(df)
+        if not isinstance(y_raw, pd.Series):
+            raise SweepConfigError(
+                f"sobol_analyze metric callable must return a pandas.Series, "
+                f"got {type(y_raw).__name__}"
+            )
+        y = y_raw
+
+    if bool(y.isna().any()):
+        raise SweepConfigError(
+            "sobol_analyze metric reduction produced NaN values; "
+            "SALib's analyse step cannot ingest NaN"
+        )
+    return y
+
+
+def _pack_indices(
+    result: Mapping[str, np.ndarray],
+    sorted_keys: list[str],
+    *,
+    calc_second_order: bool,
+) -> pd.DataFrame:
+    rows: list[dict[str, Any]] = []
+    for kind in ("S1", "ST"):
+        values = result[kind]
+        confs = result[f"{kind}_conf"]
+        for i, name in enumerate(sorted_keys):
+            rows.append(
+                {
+                    "kind": kind,
+                    "param_a": name,
+                    "param_b": pd.NA,
+                    "value": float(values[i]),
+                    "conf": float(confs[i]),
+                }
+            )
+    if calc_second_order:
+        s2 = result["S2"]
+        s2_conf = result["S2_conf"]
+        for i in range(len(sorted_keys)):
+            for j in range(i + 1, len(sorted_keys)):
+                rows.append(
+                    {
+                        "kind": "S2",
+                        "param_a": sorted_keys[i],
+                        "param_b": sorted_keys[j],
+                        "value": float(s2[i, j]),
+                        "conf": float(s2_conf[i, j]),
+                    }
+                )
+    return pd.DataFrame(rows, columns=["kind", "param_a", "param_b", "value", "conf"])

--- a/tests/test_sensitivity.py
+++ b/tests/test_sensitivity.py
@@ -1,0 +1,283 @@
+"""Tests for ``gmat_sweep.sensitivity`` — Sobol sample design + analyse pipeline.
+
+The Ishigami contract test is the headline check: at the SALib-recommended
+``n=1024`` Saltelli base size, ``sobol_analyze`` must reproduce the published
+S1 / ST values for the Ishigami function within Monte Carlo noise. Everything
+else pins user-facing knobs (sample shape, determinism, the str / callable
+``metric`` forms) and the failure modes that should raise
+:class:`SweepConfigError` rather than degrade silently.
+
+The whole module is gated on the ``[sensitivity]`` extra via
+``pytest.importorskip("SALib")`` — the default install path never imports
+SALib, and CI installs the extra explicitly so these tests run on the
+coverage-gate cell.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, cast
+
+import numpy as np
+import pandas as pd
+import pytest
+
+pytest.importorskip("SALib")
+
+from gmat_sweep.errors import SweepConfigError
+from gmat_sweep.sensitivity import sobol_analyze, sobol_sample
+
+
+def _multiindex(n: int) -> pd.MultiIndex:
+    return cast(
+        pd.MultiIndex,
+        pd.MultiIndex.from_arrays(
+            [np.arange(n), np.zeros(n, dtype=int)],
+            names=("run_id", "time"),
+        ),
+    )
+
+
+def _ishigami(x: np.ndarray, a: float = 7.0, b: float = 0.1) -> Any:
+    """f(x1, x2, x3) = sin(x1) + a sin^2(x2) + b x3^4 sin(x1)."""
+    return np.sin(x[:, 0]) + a * np.sin(x[:, 1]) ** 2 + b * x[:, 2] ** 4 * np.sin(x[:, 0])
+
+
+def test_sobol_analyze_recovers_ishigami_indices_within_mc_noise() -> None:
+    """At the SALib-recommended ``n=1024`` base sample size the Saltelli
+    design lands ~8200 evaluations on the Ishigami function. The published
+    Sobol indices for ``a=7, b=0.1`` are
+    ``S1 ≈ [0.314, 0.442, 0.000]`` and ``ST ≈ [0.558, 0.442, 0.244]`` —
+    a 0.05 absolute tolerance comfortably brackets typical MC noise at
+    this sample size."""
+    perturb = {
+        "x1": ("uniform", -math.pi, math.pi),
+        "x2": ("uniform", -math.pi, math.pi),
+        "x3": ("uniform", -math.pi, math.pi),
+    }
+    n = 1024
+    samples = sobol_sample(perturb, n=n, seed=42, calc_second_order=True)
+
+    y = _ishigami(samples.to_numpy())
+    df = pd.DataFrame({"y": y}, index=_multiindex(len(samples)))
+
+    result = sobol_analyze(df, perturb, metric="y", seed=42, calc_second_order=True)
+
+    s1 = result[result["kind"] == "S1"].set_index("param_a")["value"]
+    st = result[result["kind"] == "ST"].set_index("param_a")["value"]
+
+    assert s1["x1"] == pytest.approx(0.314, abs=0.05)
+    assert s1["x2"] == pytest.approx(0.442, abs=0.05)
+    assert s1["x3"] == pytest.approx(0.000, abs=0.05)
+    assert st["x1"] == pytest.approx(0.558, abs=0.05)
+    assert st["x2"] == pytest.approx(0.442, abs=0.05)
+    assert st["x3"] == pytest.approx(0.244, abs=0.05)
+
+
+def test_sobol_sample_bit_equal_across_two_calls() -> None:
+    """``sobol_sample`` is deterministic in ``(perturb, n, seed,
+    calc_second_order)`` — required so a sweep can be re-launched against
+    a recorded design without re-saving the DataFrame."""
+    perturb = {
+        "Sat.SMA": ("normal", 7100.0, 50.0),
+        "Sat.INC": ("uniform", 0.0, 90.0),
+    }
+    a = sobol_sample(perturb, n=64, seed=42)
+    b = sobol_sample(perturb, n=64, seed=42)
+    pd.testing.assert_frame_equal(a, b)
+
+
+def test_sobol_sample_shape_with_calc_second_order_true() -> None:
+    """Saltelli design row count is ``n * (2*D + 2)`` when
+    ``calc_second_order=True`` — pinning this guards against a surprise
+    SALib behaviour change in the next release."""
+    perturb = {
+        "a": ("uniform", 0.0, 1.0),
+        "b": ("uniform", 0.0, 1.0),
+        "c": ("uniform", 0.0, 1.0),
+    }
+    n = 8
+    df = sobol_sample(perturb, n=n, seed=0, calc_second_order=True)
+    assert len(df) == n * (2 * 3 + 2)
+    assert list(df.columns) == ["a", "b", "c"]
+
+
+def test_sobol_sample_shape_with_calc_second_order_false() -> None:
+    """``calc_second_order=False`` collapses the design to ``n * (D + 2)``
+    rows — half-cost when the user does not need pairwise indices."""
+    perturb = {
+        "a": ("uniform", 0.0, 1.0),
+        "b": ("uniform", 0.0, 1.0),
+        "c": ("uniform", 0.0, 1.0),
+    }
+    n = 8
+    df = sobol_sample(perturb, n=n, seed=0, calc_second_order=False)
+    assert len(df) == n * (3 + 2)
+
+
+def test_sobol_sample_columns_sorted_lexicographically() -> None:
+    """Columns come out lexicographically regardless of ``perturb`` insertion
+    order — the same stability guarantee :func:`latin_hypercube_samples`
+    ships with."""
+    perturb = {
+        "Sat.SMA": ("uniform", 0.0, 1.0),
+        "Aaa.X": ("uniform", 0.0, 1.0),
+        "Mmm.Y": ("uniform", 0.0, 1.0),
+    }
+    df = sobol_sample(perturb, n=4, seed=0)
+    assert list(df.columns) == ["Aaa.X", "Mmm.Y", "Sat.SMA"]
+
+
+def test_sobol_sample_lifts_unit_cube_via_distribution_ppf() -> None:
+    """The unit-cube SALib design must be lifted into the configured
+    marginal — a normal-distributed parameter should land outside the
+    [0, 1] range typical of the raw Saltelli samples."""
+    perturb = {"x": ("normal", 100.0, 10.0)}
+    df = sobol_sample(perturb, n=64, seed=0)
+    # The mean is 100 with sigma 10; samples should mostly fall in [70, 130].
+    assert df["x"].between(70.0, 130.0).all()
+    # And clearly not on [0, 1].
+    assert not df["x"].between(0.0, 1.0).any()
+
+
+def test_sobol_analyze_with_callable_metric_recovers_linear_variance_split() -> None:
+    """For ``Y = x1 + 2 * x2`` the variance-ratio decomposition gives
+    ``S1[x1] = 1/5`` and ``S1[x2] = 4/5``. Use the callable ``metric`` form
+    to perform the per-run reduction explicitly; the 0.05 tolerance again
+    brackets MC noise at moderate sample size."""
+    perturb = {
+        "x1": ("uniform", 0.0, 1.0),
+        "x2": ("uniform", 0.0, 1.0),
+    }
+    samples = sobol_sample(perturb, n=512, seed=0)
+    y = samples["x1"].to_numpy() + 2.0 * samples["x2"].to_numpy()
+    df = pd.DataFrame({"y": y}, index=_multiindex(len(samples)))
+
+    result = sobol_analyze(
+        df,
+        perturb,
+        metric=lambda d: d.groupby(level="run_id")["y"].last(),
+        seed=0,
+    )
+
+    s1 = result[result["kind"] == "S1"].set_index("param_a")["value"]
+    assert s1["x1"] == pytest.approx(0.20, abs=0.05)
+    assert s1["x2"] == pytest.approx(0.80, abs=0.05)
+    # S2 row should also be populated (calc_second_order defaults to True).
+    s2 = result[result["kind"] == "S2"]
+    assert len(s2) == 1
+    assert s2.iloc[0]["param_a"] == "x1"
+    assert s2.iloc[0]["param_b"] == "x2"
+
+
+def test_sobol_analyze_calc_second_order_false_omits_s2_rows() -> None:
+    """``calc_second_order=False`` must drop the ``S2`` rows from the
+    output frame entirely — matching the trimmed sample design."""
+    perturb = {
+        "x1": ("uniform", 0.0, 1.0),
+        "x2": ("uniform", 0.0, 1.0),
+    }
+    samples = sobol_sample(perturb, n=64, seed=0, calc_second_order=False)
+    y = samples.to_numpy().sum(axis=1)
+    df = pd.DataFrame({"y": y}, index=_multiindex(len(samples)))
+
+    result = sobol_analyze(df, perturb, metric="y", seed=0, calc_second_order=False)
+
+    assert set(result["kind"].unique()) == {"S1", "ST"}
+
+
+def test_sobol_sample_raises_on_empty_perturb() -> None:
+    with pytest.raises(SweepConfigError, match="non-empty"):
+        sobol_sample({}, n=4)
+
+
+def test_sobol_sample_raises_on_n_lt_1() -> None:
+    with pytest.raises(SweepConfigError, match="n >= 1"):
+        sobol_sample({"x": ("uniform", 0.0, 1.0)}, n=0)
+
+
+def test_sobol_analyze_raises_on_empty_perturb() -> None:
+    df = pd.DataFrame({"y": [1.0]}, index=_multiindex(1))
+    with pytest.raises(SweepConfigError, match="non-empty"):
+        sobol_analyze(df, {}, metric="y")
+
+
+def test_sobol_analyze_raises_on_failed_runs() -> None:
+    """A sweep result with any ``__status != 'ok'`` row carries NaN-padded
+    values that would corrupt SALib's analysis. Forces the user to filter
+    explicitly rather than silently propagating noise."""
+    perturb = {"x": ("uniform", 0.0, 1.0)}
+    samples = sobol_sample(perturb, n=4, seed=0)
+    n_rows = len(samples)
+    statuses = ["ok"] * n_rows
+    statuses[2] = "failed"
+    df = pd.DataFrame(
+        {
+            "y": np.arange(n_rows, dtype=float),
+            "__status": statuses,
+        },
+        index=_multiindex(n_rows),
+    )
+    with pytest.raises(SweepConfigError, match="non-ok"):
+        sobol_analyze(df, perturb, metric="y")
+
+
+def test_sobol_analyze_raises_on_unknown_metric_column() -> None:
+    perturb = {"x": ("uniform", 0.0, 1.0)}
+    samples = sobol_sample(perturb, n=4, seed=0)
+    df = pd.DataFrame(
+        {"y": np.arange(len(samples), dtype=float)},
+        index=_multiindex(len(samples)),
+    )
+    with pytest.raises(SweepConfigError, match="not found"):
+        sobol_analyze(df, perturb, metric="missing")
+
+
+def test_sobol_analyze_raises_when_str_metric_df_lacks_run_id_index() -> None:
+    """A flat-RangeIndex df can't satisfy the str metric's per-run ``last``
+    reduction — surface that with a config error rather than letting
+    SALib raise a confusing length mismatch."""
+    perturb = {"x": ("uniform", 0.0, 1.0)}
+    samples = sobol_sample(perturb, n=4, seed=0)
+    df = pd.DataFrame({"y": np.arange(len(samples), dtype=float)})
+    with pytest.raises(SweepConfigError, match="run_id"):
+        sobol_analyze(df, perturb, metric="y")
+
+
+def test_sobol_analyze_raises_when_callable_returns_non_series() -> None:
+    perturb = {"x": ("uniform", 0.0, 1.0)}
+    samples = sobol_sample(perturb, n=4, seed=0)
+    df = pd.DataFrame(
+        {"y": np.arange(len(samples), dtype=float)},
+        index=_multiindex(len(samples)),
+    )
+    with pytest.raises(SweepConfigError, match=r"pandas\.Series"):
+        sobol_analyze(
+            df,
+            perturb,
+            metric=lambda _d: np.zeros(len(samples)),  # type: ignore[arg-type,return-value]
+        )
+
+
+def test_sobol_analyze_raises_when_callable_returns_nan() -> None:
+    perturb = {"x": ("uniform", 0.0, 1.0)}
+    samples = sobol_sample(perturb, n=4, seed=0)
+    df = pd.DataFrame(
+        {"y": np.arange(len(samples), dtype=float)},
+        index=_multiindex(len(samples)),
+    )
+
+    def bad(_d: pd.DataFrame) -> pd.Series:
+        return pd.Series([np.nan] * len(samples))
+
+    with pytest.raises(SweepConfigError, match="NaN"):
+        sobol_analyze(df, perturb, metric=bad)
+
+
+def test_sobol_sample_and_analyze_round_trip_via_top_level_imports() -> None:
+    """``sobol_sample`` and ``sobol_analyze`` must be importable from the
+    top-level ``gmat_sweep`` namespace — pins the public surface."""
+    import gmat_sweep
+
+    assert gmat_sweep.sobol_sample is sobol_sample
+    assert gmat_sweep.sobol_analyze is sobol_analyze

--- a/uv.lock
+++ b/uv.lock
@@ -941,6 +941,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dill"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1287,6 +1296,9 @@ polars = [
 ray = [
     { name = "ray", extra = ["default"] },
 ]
+sensitivity = [
+    { name = "salib" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -1321,10 +1333,11 @@ requires-dist = [
     { name = "pyarrow", specifier = ">=14" },
     { name = "ray", extras = ["default"], marker = "extra == 'examples'", specifier = ">=2.10" },
     { name = "ray", extras = ["default"], marker = "extra == 'ray'", specifier = ">=2.10" },
+    { name = "salib", marker = "extra == 'sensitivity'", specifier = ">=1.5" },
     { name = "scipy", specifier = ">=1.11" },
     { name = "tqdm", specifier = ">=4.66" },
 ]
-provides-extras = ["dask", "ray", "k8s", "mpi", "plot", "polars", "examples"]
+provides-extras = ["dask", "ray", "k8s", "mpi", "plot", "polars", "sensitivity", "examples"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2588,6 +2601,29 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/f7/addf1087b860ac60e6f382240f64fb99f8bfb532bb06f7c542b83c29ca61/multidict-6.7.1-cp314-cp314t-win_amd64.whl", hash = "sha256:497bde6223c212ba11d462853cfa4f0ae6ef97465033e7dc9940cdb3ab5b48e5", size = 53542, upload-time = "2026-01-26T02:46:08.809Z" },
     { url = "https://files.pythonhosted.org/packages/4c/81/4629d0aa32302ef7b2ec65c75a728cc5ff4fa410c50096174c1632e70b3e/multidict-6.7.1-cp314-cp314t-win_arm64.whl", hash = "sha256:2bbd113e0d4af5db41d5ebfe9ccaff89de2120578164f86a5d17d5a576d1e5b2", size = 44719, upload-time = "2026-01-26T02:46:11.146Z" },
     { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
+]
+
+[[package]]
+name = "multiprocess"
+version = "0.70.19"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dill" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/f2/e783ac7f2aeeed14e9e12801f22529cc7e6b7ab80928d6dcce4e9f00922d/multiprocess-0.70.19.tar.gz", hash = "sha256:952021e0e6c55a4a9fe4cd787895b86e239a40e76802a789d6305398d3975897", size = 2079989, upload-time = "2026-01-19T06:47:39.744Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/b6/10832f96b499690854e574360be342a282f5f7dba58eff791299ff6c0637/multiprocess-0.70.19-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:02e5c35d7d6cd2bdc89c1858867f7bde4012837411023a4696c148c1bdd7c80e", size = 135131, upload-time = "2026-01-19T06:47:20.479Z" },
+    { url = "https://files.pythonhosted.org/packages/99/50/faef2d8106534b0dc4a0b772668a1a99682696ebf17d3c0f13f2ed6a656a/multiprocess-0.70.19-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:79576c02d1207ec405b00cabf2c643c36070800cca433860e14539df7818b2aa", size = 135131, upload-time = "2026-01-19T06:47:21.879Z" },
+    { url = "https://files.pythonhosted.org/packages/94/b1/0b71d18b76bf423c2e8ee00b31db37d17297ab3b4db44e188692afdca628/multiprocess-0.70.19-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:c6b6d78d43a03b68014ca1f0b7937d965393a670c5de7c29026beb2258f2f896", size = 135134, upload-time = "2026-01-19T06:47:23.262Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/aa/714635c727dbfc251139226fa4eaf1b07f00dc12d9cd2eb25f931adaf873/multiprocess-0.70.19-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:1bbf1b69af1cf64cd05f65337d9215b88079ec819cd0ea7bac4dab84e162efe7", size = 144743, upload-time = "2026-01-19T06:47:24.562Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e1/155f6abf5e6b5d9cef29b6d0167c180846157a4aca9b9bee1a217f67c959/multiprocess-0.70.19-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:5be9ec7f0c1c49a4f4a6fd20d5dda4aeabc2d39a50f4ad53720f1cd02b3a7c2e", size = 144738, upload-time = "2026-01-19T06:47:26.636Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cb/f421c2869d75750a4f32301cc20c4b63fab6376e9a75c8e5e655bdeb3d9b/multiprocess-0.70.19-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:1c3dce098845a0db43b32a0b76a228ca059a668071cfeaa0f40c36c0b1585d45", size = 144741, upload-time = "2026-01-19T06:47:27.985Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/45/8004d1e6b9185c1a444d6b55ac5682acf9d98035e54386d967366035a03a/multiprocess-0.70.19-py310-none-any.whl", hash = "sha256:97404393419dcb2a8385910864eedf47a3cadf82c66345b44f036420eb0b5d87", size = 134948, upload-time = "2026-01-19T06:47:32.325Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c2/dec9722dc3474c164a0b6bcd9a7ed7da542c98af8cabce05374abab35edd/multiprocess-0.70.19-py311-none-any.whl", hash = "sha256:928851ae7973aea4ce0eaf330bbdafb2e01398a91518d5c8818802845564f45c", size = 144457, upload-time = "2026-01-19T06:47:33.711Z" },
+    { url = "https://files.pythonhosted.org/packages/71/70/38998b950a97ea279e6bd657575d22d1a2047256caf707d9a10fbce4f065/multiprocess-0.70.19-py312-none-any.whl", hash = "sha256:3a56c0e85dd5025161bac5ce138dcac1e49174c7d8e74596537e729fd5c53c28", size = 150281, upload-time = "2026-01-19T06:47:35.037Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/74/d2c27e03cb84251dfe7249b8e82923643c6d48fa4883b9476b025e7dc7eb/multiprocess-0.70.19-py313-none-any.whl", hash = "sha256:8d5eb4ec5017ba2fab4e34a747c6d2c2b6fecfe9e7236e77988db91580ada952", size = 156414, upload-time = "2026-01-19T06:47:35.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/61/af9115673a5870fd885247e2f1b68c4f1197737da315b520a91c757a861a/multiprocess-0.70.19-py314-none-any.whl", hash = "sha256:e8cc7fbdff15c0613f0a1f1f8744bef961b0a164c0ca29bdff53e9d2d93c5e5f", size = 160318, upload-time = "2026-01-19T06:47:37.497Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/82/69e539c4c2027f1e1697e09aaa2449243085a0edf81ae2c6341e84d769b6/multiprocess-0.70.19-py39-none-any.whl", hash = "sha256:0d4b4397ed669d371c81dcd1ef33fd384a44d6c3de1bd0ca7ac06d837720d3c5", size = 133477, upload-time = "2026-01-19T06:47:38.619Z" },
 ]
 
 [[package]]
@@ -4320,6 +4356,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
     { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
     { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+]
+
+[[package]]
+name = "salib"
+version = "1.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "matplotlib" },
+    { name = "multiprocess" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "3.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/63/bdde6c303e95e2c819c668076fb3255f4453ee2041103d0edd18a90b6839/salib-1.5.2.tar.gz", hash = "sha256:a8eeedc4e87cf070f7ef450b76cdecd120d1e5c602a9c35855ec7777591f949f", size = 725859, upload-time = "2025-10-12T02:38:50.303Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/e2/9fbf2d571c0d5360f9cf6656de6c94b273d08ede1b628f23f319fa1a910d/salib-1.5.2-py3-none-any.whl", hash = "sha256:6f4b6bebc1eeed1d081c8f951fa8c2ad7b0cd8a7159d206af48ef137cc806c43", size = 780059, upload-time = "2025-10-12T02:38:48.878Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- New `gmat_sweep.sensitivity` module behind a `[sensitivity]` extra (`salib>=1.5`). `sobol_sample(perturb, n, *, seed=None, calc_second_order=True)` builds a Saltelli/Sobol design as an explicit-row DataFrame; `sobol_analyze(df, perturb, metric, *, calc_second_order=True, seed=None)` returns first/total/second-order indices with confidence intervals.
- `metric` accepts a column name (convenience for "value at each run's final time-step") or a callable that reduces the per-(run_id, time) DataFrame to a Series indexed by `run_id`. Output is tidy long: `kind` / `param_a` / `param_b` / `value` / `conf`.
- New `docs/sensitivity.md`, mkdocs nav entry, README v0.4 roadmap bullet. SALib import is lazy inside each function — a default install never touches it. `--extra sensitivity` added to the main CI test cell so the new module clears the overall coverage gate.

## Test plan

- [x] `uv run pytest tests/test_sensitivity.py` — 17/17 pass; Ishigami contract reproduces published S1 ≈ [0.314, 0.442, 0.000] and ST ≈ [0.558, 0.442, 0.244] within 0.05 absolute at `n=1024`.
- [x] `uv run pytest` — full unit suite stays green (592 pass).
- [x] `uv run ruff check`, `uv run ruff format --check` — clean.
- [x] `uv run mypy` — strict-mode clean across 71 source files.
- [x] `sensitivity.py` line/branch coverage 99 % (one untaken branch in the all-`ok` `__status` fall-through).
- [ ] CI on Ubuntu / Windows / macOS × Python 3.10 / 3.11 / 3.12 × R2025a / R2026a.

Closes #98