### PR TITLE
Extend benchmarks docs to cover all six backends

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,8 +1,11 @@
 # Benchmarks
 
-Wall-clock and throughput numbers for the three execution backends on a
-1000-run reference sweep, plus the in-CI throughput regression that catches
-per-PR slowdowns before release.
+Wall-clock and throughput numbers on a 1000-run reference sweep for every
+backend that fits the single-machine rig — `LocalJoblibPool`,
+`DaskPool`, `RayPool`, `ProcessPoolExecutorPool`, and `MPIPool` — plus
+the in-CI throughput regression that catches per-PR slowdowns before
+release. `KubernetesJobPool` and `DebugPool` aren't reported here for
+reasons noted under [Excluded backends](#excluded-backends).
 
 ## Setup
 
@@ -20,10 +23,11 @@ stock-sample support files.
 | Sweep parameter | `Sat.SMA` ∈ `np.linspace(7000, 8000, 1000)` |
 | Workers per backend | 8 |
 | GMAT version | R2026a |
-| `gmat-sweep` version | [`110d4be`](https://github.com/astro-tools/gmat-sweep/commit/110d4be) (post-0.2.0 `main`) |
+| `gmat-sweep` version | [`3193e55`](https://github.com/astro-tools/gmat-sweep/commit/3193e55) (post-0.4 `main`) |
 | CPU | Intel® Core™ i7-10700 @ 2.90 GHz (8 cores / 16 threads) |
 | RAM | 16 GB |
-| OS | Linux 6.6.87 (WSL2, x86_64) |
+| OS | Linux 6.6.114.1 (WSL2, x86_64) |
+| Filesystem | ext4 (WSL2 native, under `/home`) |
 
 The benchmark fixture is committed at
 [`tests/data/benchmark_sweep.py`][benchmark-script]; the docs reproduce-command
@@ -39,28 +43,72 @@ Wall-clock seconds, median of three runs, min–max range in parentheses.
 
 | Backend | Median (s) | Min (s) | Max (s) |
 | --- | --- | --- | --- |
-| `LocalJoblibPool(workers=8)` | 12.10 | 11.85 | 12.51 |
-| `DaskPool(n_workers=8)` (LocalCluster) | 14.32 | 14.22 | 14.73 |
-| `RayPool(num_cpus=8)` (local) | 14.61 | 14.52 | 14.73 |
+| `LocalJoblibPool(workers=8)` | 11.93 | 11.02 | 12.37 |
+| `DaskPool(n_workers=8)` (LocalCluster) | 13.55 | 13.30 | 14.48 |
+| `RayPool(num_cpus=8)` (local) | 14.06 | 13.71 | 14.68 |
+| `MPIPool(max_workers=8)` (`mpi4py.futures`, 9 ranks) | 12.64 | 12.54 | 13.01 |
+| `ProcessPoolExecutorPool(max_workers=8)` (Python ≥ 3.11) | 269.86 | 268.37 | 270.34 |
 
 ## Throughput
 
 | Backend | Runs/sec | Per-worker runs/sec |
 | --- | --- | --- |
-| `LocalJoblibPool(workers=8)` | 82.62 | 10.33 |
-| `DaskPool(n_workers=8)` | 69.85 | 8.73 |
-| `RayPool(num_cpus=8)` | 68.46 | 8.56 |
+| `LocalJoblibPool(workers=8)` | 83.83 | 10.48 |
+| `DaskPool(n_workers=8)` | 73.80 | 9.23 |
+| `RayPool(num_cpus=8)` | 71.11 | 8.89 |
+| `MPIPool(max_workers=8)` | 79.14 | 9.89 |
+| `ProcessPoolExecutorPool(max_workers=8)` | 3.71 | 0.46 |
+
+## Excluded backends
+
+Two pools that ship with `gmat-sweep` aren't represented in the table
+above. Their numbers don't belong on a single-machine reference setup:
+
+- **`KubernetesJobPool`** — every run becomes a separate `Job` / Pod, so
+  wall-clock is dominated by per-Pod scheduling, image pull, and PVC
+  mount, not by GMAT propagation. A single-machine kind cluster would
+  measure something other than what production deployments care about.
+  The authoritative single-machine kind numbers live in the
+  `backend-k8s` CI cell — it runs the same 50-run scaled fixture under
+  `tests/test_backend_throughput.py` against a kind-provisioned cluster
+  and asserts the floor in
+  [`tests/data/throughput_floor.json`][floor-json] (`"k8s"` key). For
+  multi-host production sizing, measure on the target cluster against
+  the same `tests/data/benchmark_sweep.py` fixture.
+- **`DebugPool`** — the in-process, single-spec backend for
+  `breakpoint()`-driven debugging. It refuses to dispatch more than one
+  spec by construction (raising `BackendError`), so "throughput" isn't a
+  defined metric for it. See
+  [`gmat_sweep.backends.debug.DebugPool`][debugpool] for the design and
+  the two-flag opt-in required to use it.
+
+[debugpool]: https://github.com/astro-tools/gmat-sweep/blob/main/src/gmat_sweep/backends/debug.py
 
 ## Discussion
 
-On this 8-worker / single-machine setup the local joblib pool turns in
-roughly 82.6 runs/sec, with Dask at 69.9 and Ray at 68.5 — about 15–17 %
-below local. Per-worker throughput tracks the same gap (10.3 vs 8.7 vs 8.6
-runs/sec). Dask and Ray are within ~2 % of each other; the gap to local is
-the dispatch-layer overhead each of them pays per task that joblib's loky
-backend avoids on a single host. Per-run GMAT load is amortised identically
-across all three backends because `reuse_gmat_context=True` keeps a single
-gmatpy import alive in each worker for the lifetime of the sweep.
+On this 8-worker / single-machine setup the local joblib pool tops the
+table at roughly 83.8 runs/sec. `MPIPool` lands within ~6 % of it
+(79.1 runs/sec) — `mpi4py.futures` with pre-allocated ranks reuses worker
+processes the same way joblib's loky backend does, so the per-task
+dispatch is lean once the gmatpy bootstrap is amortised. `DaskPool` and
+`RayPool` follow at 73.8 and 71.1 runs/sec — about 12–15 % below local
+because each of their dispatch layers pays per-task scheduling overhead
+that loky avoids on a single host. Per-worker throughput tracks the same
+ordering (10.5 / 9.9 / 9.2 / 8.9 runs/sec). Across all four of these
+backends the per-run GMAT load is amortised identically because
+`reuse_gmat_context=True` (the default) keeps a single gmatpy import
+alive in each worker for the lifetime of the sweep.
+
+`ProcessPoolExecutorPool` is the outlier at 3.7 runs/sec — about 22×
+below local. That gap is structural, not a regression: the pool is
+constructed with `max_tasks_per_child=1`, so every task runs in a fresh
+worker interpreter and pays the gmatpy bootstrap cost individually. The
+guarantee — one fresh interpreter per task, no joblib runtime
+dependency, no shared state — is what the backend trades wall-clock for.
+For sweeps where many runs share the same script, `LocalJoblibPool` is
+the right choice; reach for `ProcessPoolExecutorPool` when the
+fresh-interpreter contract or the stdlib-only dependency surface
+matters.
 
 The picture changes once the sweep spans more than one machine; see
 [Backends](backends.md) for when each backend is worth its overhead.
@@ -79,6 +127,15 @@ python -m tests.data.benchmark_sweep --scale 1000 --backend dask --workers 8
 
 # Same on Ray (local runtime)
 python -m tests.data.benchmark_sweep --scale 1000 --backend ray --workers 8
+
+# ProcessPoolExecutorPool — stdlib, Python 3.11+
+python -m tests.data.benchmark_sweep --scale 1000 --backend process --workers 8
+
+# MPIPool — pre-allocated ranks under mpi4py.futures.
+# `-n 9` provisions 1 driver rank + 8 worker ranks for `--workers 8`.
+# `--oversubscribe` is needed because 9 > the rig's 8 cores.
+mpirun -n 9 --oversubscribe \
+  python -m mpi4py.futures -m tests.data.benchmark_sweep --scale 1000 --backend mpi --workers 8
 ```
 
 Each invocation prints a JSON record with `wall_seconds` and
@@ -91,11 +148,24 @@ python -m tests.data.benchmark_sweep --scale 50 --backend local --workers 4
 
 ## CI regression gate
 
-The `backend-throughput` CI job runs the 50-run sweep on each of the three
-backends and asserts a per-backend throughput floor. The floor JSON lives at
-[`tests/data/throughput_floor.json`][floor-json]; updates show as deliberate
-diffs in PRs, so a tightening or relaxation is reviewable rather than
-accidental. A regression below the floor fails CI with a message naming the
-backend, the measured rate, and the floor.
+The 50-run scaled fixture runs across three CI cells that together cover
+every shipping backend:
+
+- `backend-throughput` covers `LocalJoblibPool`, `DaskPool`, `RayPool`,
+  and `ProcessPoolExecutorPool` (Python 3.12 in the cell, so the
+  ≥ 3.11 gate passes).
+- `backend-mpi` covers `MPIPool` under
+  `mpirun -n K --oversubscribe python -m mpi4py.futures -m pytest …`,
+  filtered by `-k mpi` to the MPI parametrize rows only.
+- `backend-k8s` covers `KubernetesJobPool` against a kind-provisioned
+  cluster, filtered by `-k k8s`.
+
+Each cell asserts a per-backend throughput floor. The floor JSON lives
+at [`tests/data/throughput_floor.json`][floor-json] and carries an entry
+for every backend `tests.data.benchmark_sweep.BACKENDS` enumerates;
+updates show as deliberate diffs in PRs, so a tightening or relaxation
+is reviewable rather than accidental. A regression below the floor
+fails CI with a message naming the backend, the measured rate, and the
+floor.
 
 [floor-json]: https://github.com/astro-tools/gmat-sweep/blob/main/tests/data/throughput_floor.json


### PR DESCRIPTION
## Summary

- `docs/benchmarks.md` now reports `ProcessPoolExecutorPool` and `MPIPool` alongside the existing `LocalJoblibPool` / `DaskPool` / `RayPool` rows; `KubernetesJobPool` and `DebugPool` are noted under a new "Excluded backends" section with rationale (k8s = per-Pod scheduling dominates wall-clock; Debug = single-spec by construction) and pointers to where their numbers actually live (`throughput_floor.json` + `backend-k8s` CI cell for k8s; `gmat_sweep.backends.debug.DebugPool` source for Debug).
- All five measured rows were re-run at `scale=1000`, `workers=8` against `3193e55` on a single native ext4 WSL2 clone, so the rig metadata now points at one filesystem and one kernel (6.6.114.1) for every row.
- "How to reproduce" gains `--backend process` and the full `mpirun -n 9 --oversubscribe python -m mpi4py.futures -m tests.data.benchmark_sweep …` form for MPI.
- "CI regression gate" paragraph rewritten to enumerate the three cells (`backend-throughput`, `backend-mpi`, `backend-k8s`) that together cover every backend in `tests/data/throughput_floor.json`.
- Discussion extended with the MPI-vs-joblib observation and the structural reason `ProcessPoolExecutorPool` is ~22× slower than local (`max_tasks_per_child=1` → fresh interpreter + gmatpy bootstrap per task).

No code or test changes; no `CHANGELOG.md` edit (per the release-cut convention).

## Test plan

- [ ] `mkdocs build --strict` passes locally (verified: rc=0, no warnings beyond the mkdocs-material team's MkDocs 2.0 advisory banner).
- [ ] Rendered `Benchmarks` page shows five rows in both tables (local / dask / ray / mpi / process) and an `Excluded backends` section listing k8s and Debug.
- [ ] Reproduce-block invocations match the args `tests/data/benchmark_sweep.py` actually accepts (`--scale`, `--backend`, `--workers`).
- [ ] Internal anchor `[Excluded backends](#excluded-backends)` resolves under the Material theme's slug rules.

Closes #123