### PR TITLE
Docs cleanup: align cli/api references, drop version-pegged copy

### DIFF
--- a/docs/aggregation.md
+++ b/docs/aggregation.md
@@ -389,12 +389,3 @@ plf_summary = pl.from_pandas(flat.reset_index())
 ```
 
 [polars-df]: https://docs.pola.rs/api/python/stable/reference/dataframe/index.html
-
-## Migrating from v0.1
-
-v0.1 used a bare `<name>.parquet` per-run layout and keyed
-`output_paths` by `<name>`; v0.2 prepends the kind prefix
-(`report__<name>.parquet`, key `report__<name>`). v0.1 manifests are not
-readable by v0.2 aggregators — the aggregator dispatch is keyed on the
-prefix and v0.1 entries lack one. Re-run any sweep you need to
-re-aggregate under v0.2.

--- a/docs/api.md
+++ b/docs/api.md
@@ -34,6 +34,8 @@ auto-generated from docstrings via
 
 ::: gmat_sweep.backends.ProcessPoolExecutorPool
 
+::: gmat_sweep.backends.DebugPool
+
 ## Specs and outcomes
 
 ::: gmat_sweep.RunSpec
@@ -47,6 +49,16 @@ auto-generated from docstrings via
 ::: gmat_sweep.full_factorial
 
 ::: gmat_sweep.expand_grid_to_run_specs
+
+::: gmat_sweep.expand_samples_to_run_specs
+
+::: gmat_sweep.expand_monte_carlo_to_run_specs
+
+::: gmat_sweep.expand_monte_carlo_extension_to_run_specs
+
+::: gmat_sweep.expand_latin_hypercube_to_run_specs
+
+::: gmat_sweep.latin_hypercube_samples
 
 ## Manifest
 
@@ -85,6 +97,10 @@ auto-generated from docstrings via
 ::: gmat_sweep.plotting.sweep_band_plot
 
 ::: gmat_sweep.plotting.mc_convergence_plot
+
+::: gmat_sweep.plotting.sweep_corner
+
+::: gmat_sweep.plotting.sweep_heatmap
 
 ## Exceptions
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -19,6 +19,8 @@ The subcommands:
 - [`extend`](#extend) — append more bit-deterministic Monte Carlo runs to an
   existing sweep.
 - [`show`](#show) — print a one-line summary of a manifest.
+- [`archive`](#archive) — pack a finished sweep into a portable `.zip` for
+  archival deposit.
 
 `gmat-sweep --help` lists them. Each subcommand has its own `--help`.
 
@@ -308,3 +310,41 @@ manifest` message on stderr.
 
 A missing or unparseable manifest, or a `--run N` for an `N` not in the
 manifest, exits with code `3`.
+
+## `archive`
+
+Pack a finished sweep — script, manifest, per-run Parquet outputs — into a
+single self-describing `.zip` suitable for archival deposit (Zenodo, JOSS
+supplementary material) or internal handoff.
+
+```bash
+gmat-sweep archive ./sweep-out/manifest.jsonl \
+    --script mission.script \
+    --out ./sma-scan-2026q2.zip
+```
+
+Required positional: `MANIFEST` — the existing `manifest.jsonl`.
+
+Required flags:
+
+- `--script PATH` — the same GMAT `.script` the sweep loaded. Its canonical
+  SHA-256 must equal the manifest's `script_sha256`; same hash-drift contract
+  as `resume` and `extend`. Add `--allow-script-drift` to proceed past a
+  mismatch — the bundle still records the manifest's original hash so a
+  downstream verifier can spot the drift.
+- `--out PATH` — destination `.zip` path. Parent directories are created on
+  demand.
+
+`--include-logs` bundles every per-run `worker.log` and keeps the manifest's
+`log_path` field pointing at it (rewritten to bundle-relative form). The
+default drops the logs and sets `log_path` to `null` in the bundled manifest,
+keeping the archive small.
+
+The bundled manifest's `output_paths` are rewritten to be bundle-relative
+(`runs/run-<id>/<basename>`), and the bundle is byte-deterministic — two
+archives of the same manifest produce identical bytes. See
+[Cookbook § Pattern 4 — Archival deposit](cookbook.md#pattern-4-archival-deposit-zenodo-joss)
+for the full layout and the reproduce-from-bundle recipe.
+
+A missing `MANIFEST` exits with code `3`; a missing `--script`, or a hash
+mismatch without `--allow-script-drift`, exits with code `2`.

--- a/docs/manifest-schema.md
+++ b/docs/manifest-schema.md
@@ -119,7 +119,7 @@ checked out under different line-ending settings produce identical hashes.
 |----------------|--------------------------------------------------------------------------------------------------------------|
 | `run_id`       | Sequential integer assigned at grid-expansion time, starting at `0`. Unique within a sweep.                  |
 | `overrides`    | The override dict applied for this run — exactly the slice of the grid that produced it.                     |
-| `status`       | One of `"ok"`, `"failed"`, `"skipped"`. v0.1 only emits `"ok"` and `"failed"`.                                |
+| `status`       | One of `"ok"`, `"failed"`, `"skipped"`.                                                                      |
 | `output_paths` | Map from the prefixed output basename (`report__<name>`, `ephemeris__<name>`, `contact__<name>`) to the per-run Parquet path. Empty `{}` for non-`ok` runs. The prefix encodes the GMAT output kind so [`lazy_multiindex`][gmat_sweep.lazy_multiindex] / [`lazy_ephemerides`][gmat_sweep.lazy_ephemerides] / [`lazy_contacts`][gmat_sweep.lazy_contacts] can dispatch without reading the file. |
 | `started_at`   | UTC `datetime` the worker began this run, ISO-8601 with tz offset.                                           |
 | `ended_at`     | UTC `datetime` the worker returned its outcome, ISO-8601.                                                    |

--- a/docs/recipes/kubernetes-jobpool.md
+++ b/docs/recipes/kubernetes-jobpool.md
@@ -27,7 +27,7 @@ the Kubernetes API directly.
 
 ## Image
 
-`KubernetesJobPool` requires `image=` because v0.4 ships no default. The
+`KubernetesJobPool` requires `image=` — the pool ships no default. The
 canonical image at `ghcr.io/astro-tools/gmat:<tag>` carries GMAT and
 `gmatpy` but **not** `gmat-sweep` itself — downstream consumers add
 their own packages on top:


### PR DESCRIPTION
## Summary
- Add the `archive` subcommand to `cli.md` (it was wired in `cli.py` and used in `cookbook.md` but missing from the CLI reference).
- Backfill `api.md` with the public exports the auto-generated reference was missing — the four `expand_*_to_run_specs` helpers, `latin_hypercube_samples`, `sweep_corner` / `sweep_heatmap`, and `DebugPool`.
- Drop version-pegged copy from `manifest-schema.md`, `recipes/kubernetes-jobpool.md`, and `aggregation.md` (the "Migrating from v0.1" section).

Other pages under `docs/` were read end-to-end and left untouched — they already reflect the current implementation.

## Test plan
- [x] `uv run mkdocs build --strict` is clean.
- [ ] Skim the rendered `cli.md` archive section and api.md additions in CI's docs preview / locally.

Closes #122