### PR TITLE
Cut v0.4.0: bump version, drop README roadmap, add CHANGELOG

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -28,7 +28,7 @@ body:
     id: gmat_sweep_version
     attributes:
       label: gmat-sweep version
-      placeholder: "e.g. 0.1.0, or git sha"
+      placeholder: "e.g. 0.4.0, or git sha"
     validations:
       required: true
   - type: input
@@ -58,8 +58,12 @@ body:
       label: Backend
       options:
         - LocalJoblibPool (default)
+        - ProcessPoolExecutorPool
         - DaskPool
         - RayPool
+        - KubernetesJobPool
+        - MPIPool
+        - DebugPool
         - Other / unsure
     validations:
       required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,190 @@ All notable changes to gmat-sweep are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] — 2026-05-10
+
+The quality-of-life and ecosystem release: three new execution
+backends join `KubernetesJobPool` (`MPIPool`,
+`ProcessPoolExecutorPool`, `DebugPool`), six DataFrame helpers land
+on top of the aggregator (`sweep_summary`, `sweep_diff`,
+`mc_convergence`, `lazy_fused_reports`, plus `monte_carlo_extend` /
+`latin_hypercube_extend`), Sobol sensitivity and matplotlib plot
+helpers ship behind opt-in extras, an opt-in Polars output engine
+runs alongside the pandas default, `Sweep.archive` packs a finished
+sweep into a deterministic `.zip` for Zenodo / JOSS deposits, and
+notebook-friendly `_repr_html_` rendering lands on `Sweep` /
+`RunOutcome` / `ManifestEntry`. CI gains a smoke-canary cell against
+the canonical `ghcr.io/astro-tools/gmat` image; per-PR cells trim
+from 18 to 10 with the heavy integration work moving to a scheduled
+`integration.yml`. Coverage gate raises from ≥ 85% to ≥ 90%.
+
+### Added
+
+- `KubernetesJobPool` (`gmat-sweep[k8s]`) — every run becomes one
+  `batch/v1` Job; every Pod is a fresh interpreter; completions
+  drained via a `kubernetes.watch.Watch` loop. Spec/outcome handoff
+  via the same shared PVC the worker Pods mount. No changes to
+  `RunSpec` or the `Pool` ABC. New
+  [`recipes/kubernetes-jobpool.md`](docs/recipes/kubernetes-jobpool.md)
+  walks the pod-per-run wiring (#101).
+- `MPIPool` (`gmat-sweep[mpi]`) — wraps
+  `mpi4py.futures.MPIPoolExecutor` and works under both
+  dynamic-spawn (plain `python …`) and pre-allocated-rank
+  (`mpirun -n K python -m mpi4py.futures …`) launches without any
+  launcher detection on this side. CLI gains `--backend mpi` with
+  `--backend-arg max_workers=N` as the dynamic-spawn knob (#102).
+- `ProcessPoolExecutorPool` (stdlib, Python ≥ 3.11) — wraps
+  `concurrent.futures.ProcessPoolExecutor(max_tasks_per_child=1)`,
+  no `joblib` / `loky` dependency. Coexists with `LocalJoblibPool`
+  rather than replacing it (#104).
+- `DebugPool` — in-process, single-run dispatch so a `breakpoint()`
+  reached during a run drops into the driver's debugger. Two opt-in
+  flags (`subprocess_isolated="debug"` on the `Pool` ABC + an
+  explicit `debug=True` on the constructor) gate the deliberate
+  isolation violation (#105).
+- `gmat_sweep.plotting` module behind `gmat-sweep[plot]`.
+  `sweep_corner(df, params=..., metric=..., manifest=...)` is a pair
+  plot of perturbed dotted-paths coloured by a per-run scalar
+  metric; `sweep_heatmap(df, x=..., y=..., metric=...)` is a
+  contour-grade heatmap on a 2-axis grid sweep. `matplotlib` is
+  imported lazily inside each helper, so `import gmat_sweep.plotting`
+  succeeds without the extra (#109).
+- `gmat_sweep.sensitivity` module behind `gmat-sweep[sensitivity]`
+  (`salib>=1.5`). `sobol_sample(perturb, n, *, seed=None,
+  calc_second_order=True)` builds the Saltelli/Sobol design as an
+  explicit-row DataFrame; `sobol_analyze(df, perturb, metric, *,
+  calc_second_order=True, seed=None)` returns first/total/
+  second-order indices with bootstrap confidence intervals. New
+  [`docs/sensitivity.md`](docs/sensitivity.md) walks the design and
+  the metric-callable contract (#121).
+- `engine="polars"` kwarg across the DataFrame-returning surface —
+  [`sweep`][gmat_sweep.sweep], [`monte_carlo`][gmat_sweep.monte_carlo],
+  [`latin_hypercube`][gmat_sweep.latin_hypercube],
+  [`monte_carlo_extend`][gmat_sweep.monte_carlo_extend],
+  `Sweep.to_dataframe` / `to_ephemerides` / `to_contacts` plus a
+  `Sweep.to_polars()` shortcut, and the standalone
+  `lazy_multiindex` / `lazy_ephemerides` / `lazy_contacts` /
+  `sweep_diff` / `mc_convergence`. Pandas remains the default; the
+  `(run_id, time)` index translates to a column-pair on the polars
+  side. Behind `gmat-sweep[polars]` (#120).
+- [`Sweep.archive(out, *, include_logs=False) -> Path`][gmat_sweep.Sweep.archive]
+  and a matching `gmat-sweep archive MANIFEST --out bundle.zip
+  [--include-logs] [--allow-script-drift]` CLI subcommand pack a
+  finished sweep — script, manifest, per-run Parquet outputs, a
+  generated reproduce-recipe README, and a `sha256sum`-compatible
+  `MANIFEST.hash` — into one deterministic `.zip` ready for Zenodo
+  or a JOSS deposit. Bundled manifest `output_paths` /
+  `log_path` are rewritten to bundle-relative form (#111).
+- `Sweep` / [`RunOutcome`][gmat_sweep.RunOutcome] /
+  [`ManifestEntry`][gmat_sweep.ManifestEntry] gain `_repr_html_`
+  methods rendering as compact HTML key/value tables in Jupyter,
+  instead of the default `<gmat_sweep.sweep.Sweep object at 0x…>`
+  placeholder. `__repr__` is unchanged (#108).
+- [`lazy_fused_reports`][gmat_sweep.lazy_fused_reports] and
+  `Sweep.to_fused_reports` fuse N `ReportFile` outputs per run into
+  one DataFrame with column-level `MultiIndex` keyed by
+  `(report_name, column)`. Per-run merge anchors on the first name;
+  subsequent reports join via `pd.merge_asof` with a user-supplied
+  `tolerance`, or via inner join on `time` when `tolerance` is `None`
+  (#107).
+- [`sweep_summary(df, *, by="time", q=(0.05, 0.5, 0.95),
+  include=("mean", "std"), dropna=True)`][gmat_sweep.sweep_summary]
+  collapses a `(run_id, time)`-MultiIndexed sweep DataFrame into
+  per-`by` statistics with a 2-level `("statistic", "field")`
+  column MultiIndex. Default 5/50/95 quantiles plus mean/std feed
+  directly into the matching plot helper; `count_ok` reports the
+  per-group non-NaN run count (#114).
+- [`monte_carlo_extend(manifest, script, *, n, backend, ...)`][gmat_sweep.monte_carlo_extend]
+  and a sibling `latin_hypercube_extend` run only the new `n`
+  samples on top of an existing sweep; the original `run_id`s'
+  draws are bit-equal to the same indices of a fresh
+  `monte_carlo(n=old_n + n, seed=...)`. Per-run sub-seeds derive
+  from `numpy.random.SeedSequence.spawn`, so the determinism
+  contract holds across extensions (#115).
+- [`mc_convergence(df, metric, *, terminal_only=False)`][gmat_sweep.mc_convergence]
+  returns per-prefix running mean / std / SE-of-mean across
+  `run_id` prefixes — answers "did my Monte Carlo converge?" for
+  a chosen metric. `metric` accepts a column name (with
+  `terminal_only=True` for the per-run last value, or
+  `terminal_only=False` for one running curve per `time` step) or
+  a callable `(per_run_subframe) -> scalar` (#117).
+- [`sweep_diff(df_a, df_b, *, on=None, how="both",
+  tolerance=None)`][gmat_sweep.sweep_diff] for comparing two
+  same-shape sweep DataFrames into a `(run_id, time)`- (or
+  `run_id`-) indexed diff frame. Per shared numeric column emits
+  `<col>__diff = b - a` and/or `<col>__rel = (b - a) / a`;
+  `on="run_id"` first collapses each side to its per-run
+  final-step row (#119).
+- New [`docs/cookbook.md`](docs/cookbook.md) page documenting four
+  patterns for turning sweep outputs into downstream-consumer
+  inputs: visualisation export (CCSDS-OEM 502.0-B-3 KVN, CZML for
+  Cesium), cross-tool validation (manifest + multi-indexed frame
+  as harness inputs), external-tool wrapping (`out=` directory +
+  `manifest.jsonl` + per-run Parquets as today's portable bundle),
+  and archival deposit (Zenodo / JOSS via `Sweep.archive`) (#110).
+- New runnable example notebooks rendered into the docs site:
+  `08_sobol_sensitivity.ipynb` (Saltelli/Sobol design + first/
+  total-order indices with 95% CIs), `09_archive_bundle.ipynb`
+  (pack a sweep with `Sweep.archive()`, inspect + re-aggregate
+  from the unzipped bundle), `10_extending_monte_carlo.ipynb`
+  (100-run base + `monte_carlo_extend(n=200)` + bit-for-bit
+  determinism assertion on the original 100). `sweep_summary`,
+  `sweep_corner`, and `sweep_heatmap` cells appear inline across
+  the existing sweep / Monte Carlo notebooks (#124).
+- `docs/benchmarks.md` extended to report `ProcessPoolExecutorPool`
+  and `MPIPool` alongside the existing `LocalJoblibPool` /
+  `DaskPool` / `RayPool` rows. `KubernetesJobPool` and `DebugPool`
+  are noted under an "Excluded backends" section with rationale
+  (k8s = per-Pod scheduling dominates wall-clock; Debug =
+  single-spec by construction) (#125).
+- Smoke-canary CI cell (`smoke-canary-image`) under
+  `integration.yml` runs the four-line vision-snippet sweep and a
+  4-run Monte Carlo against the canonical
+  `ghcr.io/astro-tools/gmat:R2025a` and `:R2026a` images on every
+  push to `main`, nightly, and on demand (#112).
+- New `integration.yml` workflow consolidates
+  `backend-throughput`, `backend-equivalence`, `backend-k8s`, and
+  `smoke-canary-image (R2025a, R2026a)`. Runs on every push to
+  `main`, nightly at 07:00 UTC, and on `workflow_dispatch` (#126).
+- `CITATION.cff` at the repo root so GitHub's "Cite this
+  repository" UI and academic tooling resolve a canonical
+  citation for the project (#116).
+
+### Changed
+
+- Overall coverage gate on the Ubuntu / Python 3.12 / R2026a cell
+  raised from `>=85%` to `>=90%`, the v0.4 charter line. The four
+  per-file 95% gates on `grids.py`, `distributions.py`,
+  `manifest.py`, and `aggregate.py` are unchanged (#113).
+- Per-PR CI trimmed from 18 to 10 cells: R2026a × 3 OS × 3 Python
+  = 9, plus a single R2025a Linux/py3.12 sentinel. The full
+  3 × 3 × 2 = 18 matrix expands on `main` push. Heavy backend and
+  canary cells move to the new `integration.yml` (push:main +
+  nightly + on-demand). No coverage loss post-merge (#126).
+- Docs alignment pass: `cli.md` gains the `archive` subcommand
+  (it was wired in `cli.py` and used in `cookbook.md` but missing
+  from the CLI reference); `api.md` backfills the public exports
+  the auto-generated reference was missing — the four
+  `expand_*_to_run_specs` helpers, `latin_hypercube_samples`,
+  `sweep_corner` / `sweep_heatmap`, and `DebugPool`. Version-pegged
+  copy across `manifest-schema.md`, `parameter-spec.md`,
+  `supported-versions.md`, and a handful of source comments is
+  scrubbed (#127).
+
+### Fixed
+
+- `sweep()` / `monte_carlo()` / `latin_hypercube()` and
+  `Sweep.from_manifest` now resolve `out=` (or the manifest path)
+  to absolute before per-run directories are seeded. A relative
+  `out=` was forwarded into `gmat_run.Mission.run(working_dir=...)`
+  and on into the GMAT API, which resolves a relative `working_dir`
+  against its installed `OUTPUT_PATH` rather than the caller's
+  CWD — per-run Parquet files landed under the GMAT install
+  directory and the aggregator failed to find them. Existing
+  absolute-`out=` callers see no behavioural change (#112).
+
+[0.4.0]: https://github.com/astro-tools/gmat-sweep/releases/tag/v0.4.0
+
 ## [0.3.0] — 2026-05-07
 
 The cluster-backends release: `DaskPool` and `RayPool` join the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ the canonical `ghcr.io/astro-tools/gmat` image; per-PR cells trim
 from 18 to 10 with the heavy integration work moving to a scheduled
 `integration.yml`. Coverage gate raises from ≥ 85% to ≥ 90%.
 
+A late-cycle hardening pass closes the v0.4-review punch list across
+the manifest, aggregator, worker / orchestration, every backend
+pool, the CLI, and the plot helpers: streaming manifest scans, an
+fsync cadence knob, a streaming grid generator + `Pool.imap`,
+Welford's online variance, uniform `RunOutcome.failed` folding on
+worker-side transport failures, lazy `gmat-sweep.cli` cold start,
+and monotonic-clock `duration_s`.
+
 ### Added
 
 - `KubernetesJobPool` (`gmat-sweep[k8s]`) — every run becomes one
@@ -153,6 +161,62 @@ from 18 to 10 with the heavy integration work moving to a scheduled
 - `CITATION.cff` at the repo root so GitHub's "Cite this
   repository" UI and academic tooling resolve a canonical
   citation for the project (#116).
+- [`Pool.imap(specs, *, in_flight=None)`][gmat_sweep.Pool.imap]
+  ABC method with a chunked default bounded to
+  `4 * max_workers`; every backend overrides the new
+  `Pool.max_workers` property to expose its actual count.
+  `grids.iter_grid_run_specs` + `full_factorial_size` give lazy
+  grid expansion; `Sweep.__init__` accepts an `Iterable[RunSpec]`
+  plus `expected_run_count`; `api.sweep(grid=...)` streams the
+  cartesian product end-to-end. A 10⁵-row factorial no longer
+  pins 10⁵ specs + 10⁵ futures in driver memory (#140).
+- [`Manifest.iter_entries(path)`][gmat_sweep.Manifest.iter_entries]
+  lazily yields parsed entries from disk; `Manifest.find_failed`
+  and `Manifest.find_missing` become classmethods taking a `path`
+  and consume `iter_entries` so `gmat-sweep resume` on a 10k-run
+  manifest no longer pays 10k JSON parses against an entry list it
+  never reads. `Manifest.load` stays eager for the consumers that
+  need every entry (#137).
+- [`Manifest.fsync_each: bool = True`][gmat_sweep.Manifest] plus
+  `Manifest.fsync_batch: int = 50` — fsyncs amortise across
+  batches when `fsync_each=False`, with `Manifest.close()`
+  flushing the tail on successful sweep exit. Plumbed through
+  `Sweep`, the four public API entry points, and every
+  sweep-running CLI subcommand as `--fsync-each / --no-fsync-each`
+  and `--fsync-batch N`. The default preserves v0.3 strict-
+  per-entry durability; `KeyboardInterrupt` deliberately skips
+  `close()` so the resume flow picks up the lost-tail slice (#137).
+- [`Manifest.total_run_count`][gmat_sweep.Manifest.total_run_count]
+  property — live total derived from the entries
+  (`run_count + extension_run_count`). The header's `run_count`
+  field stays frozen on disk to preserve the documented append-
+  only / torn-tail tolerance (#140).
+- `Manifest._migrate_header(data, from_version, path)` schema-
+  migration shim — no-op for v1 → v1 today; the ladder gives a
+  future v2 bump a single place to hang per-version migration
+  steps (#137).
+- [`ManifestCorruptError.line_number: int | None`][gmat_sweep.ManifestCorruptError]
+  — 1-indexed line that failed to parse, `None` for whole-file
+  failures. `Manifest.load` and `iter_entries` set it on every
+  line-localised raise; the CLI's top-level error handler prints
+  `path:line` so the offending line is locatable without
+  re-grepping (#137).
+- `KubernetesJobPool` gains
+  `job_deadline_seconds: int = 3600` (validated `>= 1`) to hang-
+  protect stuck Jobs — the drain loop checks each in-flight Job's
+  elapsed monotonic time and folds an expired Job into a
+  synthetic `RunOutcome.failed` with a background-propagation
+  delete. `close()` now tracks `_in_flight_jobs: set[str]` and
+  issues a background-propagation delete for each on shutdown,
+  swallowing per-Job `ApiException` so one delete failure (TTL
+  race, RBAC, transient network) does not orphan the rest.
+  `_submit_job` wraps `create_namespaced_job` in a try/finally so
+  the spec JSON written to the PVC is unlinked on every create-
+  failure path (typed `ApiException`, network errors,
+  `KeyboardInterrupt`) (#135).
+- `sweep_corner` gains a `kind="scatter"|"hexbin"|"auto"` kwarg;
+  `"auto"` (the default) flips to hexbin past 2000 runs to avoid
+  silent overplot saturation (#139).
 
 ### Changed
 
@@ -174,6 +238,60 @@ from 18 to 10 with the heavy integration work moving to a scheduled
   copy across `manifest-schema.md`, `parameter-spec.md`,
   `supported-versions.md`, and a handful of source comments is
   scrubbed (#127).
+- Every backend pool now folds worker-side transport failures
+  (loky / `ProcessPoolExecutor` / Dask / MPI rank / Ray worker
+  death, `RayTaskError`, pickling fault, …) into a synthetic
+  `RunOutcome.failed` at the drain site instead of letting
+  `.result()` raise and abort the sweep. `LocalJoblibPool.close()`
+  cancels parked futures *before* exiting the `Parallel` context
+  (the old order let loky compute an outcome on the way out and
+  silently drop it). `RayPool` uses `ray.wait(..., fetch_local=True)`
+  so the per-ref `ray.get` is in-store, dropping the second network
+  trip per outcome. `DaskPool` switches to
+  `distributed.as_completed(..., with_results=True, raise_errors=False)`
+  so the completion event, the result, and worker-side exception
+  folding share one round-trip. `ProcessPoolExecutorPool` dispatches
+  `run_one` directly on both `reuse_gmat_context` values —
+  `max_tasks_per_child=1` already gives every task a fresh
+  interpreter, so the old `run_spec_in_subprocess` hop was
+  double-paying the subprocess cost (#138).
+- `LocalJoblibPool` deprecates `workers=` in favour of
+  `max_workers=` (kept as alias with `DeprecationWarning`). Docs,
+  README, notebooks, CLI, and internal callsites switched (#138).
+- `Manifest.find_failed()` / `Manifest.find_missing(...)` become
+  classmethods taking a `path` argument. Pre-1.0; the only
+  public doc snippet that called the old form has been updated (#137).
+- `_aggregate` replaces the per-fragment `pd.DataFrame`
+  accumulator + `pd.concat` with a single
+  `pa.concat_tables(...).to_pandas()` — peak Python-heap allocation
+  no longer scales linearly with run count (measured ~8× the
+  final-frame size on a 1000-run fixture; the old path was ~67×).
+  `lazy_fused_reports` replaces the O(N · runs) per-(report,
+  `run_id`) boolean mask with one `groupby('run_id')` per report,
+  and asserts anchor sortedness on `time` before
+  `pd.merge_asof` (#136).
+- `import gmat_sweep.cli` is now lazy — `pandas` / `pyarrow` /
+  `tqdm` / `joblib` are not pulled until first use.
+  `gmat-sweep --help` cold start drops from ~300–800 ms to ~120 ms
+  on a warm cache. Pinned by
+  `test_cold_start_does_not_load_heavy_dependencies` in
+  `tests/test_import.py` (#139).
+- `_parse_grid_value` / `_parse_backend_arg` reject `nan` / `inf`
+  / `-inf`; linspace bounds get the same check. `gmat-sweep show
+  --filter STATUS` rejects without `--detail` before stat'ing the
+  manifest. `--backend mpi` paired with a non-default `--workers`
+  exits 2 with a spelled-out MPI exception instead of silently
+  ignoring the flag. `monte-carlo --help` description mirrors the
+  actual determinism contract (#139).
+- `_gather_param_values` prefers `manifest.parameter_spec`
+  overrides (design values) over `df.columns` (measured values)
+  for params in the spec, warning on disagreement.
+  `sweep_heatmap` validates pivot-axis dtype before
+  `np.asarray(..., dtype=float)`; a string axis raises a typed
+  `SweepConfigError` pointing at `sweep_corner` (#139).
+- The polars output engine is marked **experimental** in
+  `docs/aggregation.md` and on the canonical `lazy_multiindex`
+  engine docstring (`sweep_diff` / `mc_convergence` defer to it) (#136).
 
 ### Fixed
 
@@ -186,6 +304,71 @@ from 18 to 10 with the heavy integration work moving to a scheduled
   CWD — per-run Parquet files landed under the GMAT install
   directory and the aggregator failed to find them. Existing
   absolute-`out=` callers see no behavioural change (#112).
+- Running-stats variance switches from the cumulative
+  sum-of-squares identity to Welford's online recurrence — fixes
+  catastrophic cancellation on km-magnitude metrics where
+  `np.clip(var, 0, None)` was reporting zero std. Regression test:
+  5000 samples from `N(7.1e3, 50²)` now match `np.std(ddof=1)` to
+  1e-6 relative (#136).
+- `sweep_summary` rejects duplicate `q` / `include` entries up
+  front with `SweepConfigError` instead of producing a non-unique
+  column MultiIndex. `sweep_diff(on='run_id')` sorts before
+  `groupby().last()` so the terminal-row collapse is deterministic
+  under shuffled input. `mc_convergence` adds an explicit
+  `sort_values(['time', 'n'])` at the bottom of
+  `_running_stats_per_time`, pinning the docstring's stated
+  ordering contract (#136).
+- `canonical_script_sha256` strips a leading UTF-8 BOM before
+  line-ending normalisation, so a `.script` saved from a
+  BOM-emitting Windows editor and the same script saved without
+  a BOM hash equal (#137).
+- `_run_subprocess` probes `--outcome` writability *before* the
+  `run_one` call, so a bad output path no longer burns a
+  30-minute GMAT run. On a post-run write failure the outcome is
+  printed to stdout; `backends._subprocess.run_spec_in_subprocess`
+  recovers it before falling back to a synthetic
+  `RunOutcome.failed`. `worker.run_one`'s `mkdir` / logger /
+  `FileHandler` setup now sits inside the `try` block, so a
+  `FileHandler` init failure folds into `RunOutcome.failed` instead
+  of escaping the worker (#140).
+- `duration_s` is now sourced from `time.monotonic()`; an NTP step
+  mid-run can no longer drive duration negative.
+  `RunOutcome.from_dict` validates `status in {ok, failed, skipped}`;
+  `RunSpec.from_dict` validates field types explicitly. Both raise
+  `ValueError` naming the bad field, which
+  `manifest._parse_entry_line` wraps to `ManifestCorruptError` and
+  `_run_subprocess.py` maps to `_EXIT_BAD_SPEC=3` (#140).
+- `Sweep._repr_html_`'s status counter buckets unknown statuses
+  under `"other"` instead of raising `KeyError`. `RunSpec.to_dict`
+  / `SweepSpec.to_dict` drop their per-call `dict(...)` defensive
+  copies — `json.dumps` doesn't mutate (#140).
+- `latin_hypercube_extend` is removed from `__all__` and
+  `docs/api.md`. The function is a typed-refusal sentinel —
+  raises `SweepConfigError` with a substantive explanation (LH
+  extension changes stratification of every existing sample, so
+  there is no bit-equal slice) — and remains importable from
+  `gmat_sweep.api` for generic wrappers that want the typed
+  error (#140).
+- Doc drift swept out by walking every page against the current
+  source and re-executing all ten example notebooks: two
+  `Sweep.from_manifest(Path(...))` examples in
+  [`docs/cookbook.md`](docs/cookbook.md) were missing the required
+  `script_path` positional and `backend=` keyword (would raise
+  `TypeError` as written); rewritten with `LocalJoblibPool`.
+  `docs/manifest-schema.md` described `duration_s` as
+  `(ended_at - started_at).total_seconds()`; rewritten to match
+  the actual `time.monotonic` bookend pair.
+  `docs/recipes/slurm.md` and `docs/recipes/ray-autoscaling.md`
+  referenced a non-existent `_worker_entrypoint`; rewritten to
+  point at `gmat_sweep.worker.run_one` (reuse path) and
+  `gmat_sweep.backends._subprocess.run_spec_in_subprocess`
+  (fresh-bootstrap path). Pool-inventory enumerations across
+  `docs/index.md`, `docs/getting-started.md`, `docs/faq.md`,
+  `docs/recipes/index.md`, `docs/backends.md`, and `docs/cli.md`
+  refreshed to the seven shipped pools; the missing `mpi` entry in
+  `cli.md`'s "Choosing a backend" table is back, and the deprecated
+  `LocalJoblibPool(workers=...)` snippet swapped for
+  `max_workers=...` (#141).
 
 [0.4.0]: https://github.com/astro-tools/gmat-sweep/releases/tag/v0.4.0
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ type: software
 authors:
   - given-names: Dimitrije
     family-names: Jankovic
-version: 0.3.0
-date-released: "2026-05-08"
+version: 0.4.0
+date-released: "2026-05-10"
 license: MIT
 repository-code: "https://github.com/astro-tools/gmat-sweep"
 url: "https://github.com/astro-tools/gmat-sweep"

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ gmat-sweep run         --grid Sat.SMA=7000:7200:3 --backend dask --workers 8 --o
 gmat-sweep monte-carlo --n 1000 --perturb 'Sat.SMA=normal:7100:50' --seed 42 --out ./mc mission.script
 gmat-sweep resume      --script mission.script --workers 8 ./mc/manifest.jsonl
 gmat-sweep show        ./sweep/manifest.jsonl
+gmat-sweep archive     --out ./sweep.zip ./sweep/manifest.jsonl
 ```
 
 See the [CLI reference in the docs](https://astro-tools.github.io/gmat-sweep/cli/)

--- a/README.md
+++ b/README.md
@@ -217,15 +217,6 @@ Runnable example notebooks:
   anchor a 100-run `monte_carlo`, append 200 more via `monte_carlo_extend(n=200)`,
   and assert that the original 100 `run_id`s are preserved bit-for-bit.
 
-## Roadmap
-
-| Release | Scope |
-|---|---|
-| **v0.3** *(current)* | `DaskPool` (extra `[dask]`) and `RayPool` (extra `[ray]`) join `LocalJoblibPool` behind a single `Pool` ABC. CLI `--backend {local,dask,ray}` flag and rich `gmat-sweep show --detail` / `--run` modes. Three cluster-recipe pages (Slurm with `srun`, Kubernetes pod-per-worker, Ray autoscaling). Benchmark page comparing backends on a 1000-run reference sweep, with a per-backend throughput floor enforced in CI. Manifest header gains a `backend` field; `reuse_gmat_context` exposes the bootstrap-amortisation choice on every pool. |
-| **v0.4** *(next)* | `KubernetesJobPool` (extra `[k8s]`) — every run becomes one `batch/v1` Job, no Dask or Ray middleware. Notebook-friendly `__repr_html__` for `Sweep` / `RunOutcome`. Optional plotting helpers (`sweep_corner`, `sweep_heatmap`) behind a `[plot]` extra pulling matplotlib. Sobol sensitivity indices via SALib (extra `[sensitivity]`) — `sobol_sample` builds the Saltelli design, `sobol_analyze` returns first/total/second-order indices with confidence intervals. A docs cookbook page on integrating sweep outputs into downstream consumers. Smoke-canary cell against the canonical `ghcr.io/astro-tools/gmat` image. |
-
-Past releases live in [`CHANGELOG.md`](CHANGELOG.md).
-
 ## Development
 
 To work on `gmat-sweep` itself:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -92,11 +92,13 @@ gmat-sweep run --grid Sat.SMA=7000:7200:3 --out ./sweep mission.script
   `DaskPool`, `RayPool`, `KubernetesJobPool`, `MPIPool`, `DebugPool`, and
   the `reuse_gmat_context` knob that picks how the GMAT bootstrap is
   amortised across runs.
-- [Cluster recipes](recipes/index.md) — Slurm, Kubernetes, and Ray
-  autoscaling wiring once the local sweep proves out and you need to
-  fan it across multiple machines.
+- [Cluster recipes](recipes/index.md) — Slurm, Kubernetes pod-per-worker,
+  Kubernetes Job-per-run, and Ray autoscaling wiring once the local
+  sweep proves out and you need to fan it across multiple machines.
 - [Benchmarks](benchmarks.md) — backend timing and throughput on a
   1000-run reference sweep.
+- [Sensitivity](sensitivity.md) — Sobol indices via SALib for global
+  sensitivity analysis on top of a sweep.
 - [Manifest schema](manifest-schema.md) — what's in `manifest.jsonl` and
   how to load it back.
 - [API reference](api.md) — every public symbol, auto-generated.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ missions in parallel from Python.
 different parameter overrides, in parallel subprocesses, then aggregates the
 per-run reports into a single multi-indexed `pandas.DataFrame`. The single
 public entry point is [`sweep()`][gmat_sweep.sweep]: pass it a script, a
-parameter grid, and (optionally) a worker count.
+parameter grid, and (optionally) an execution `backend`.
 
 ```python
 from gmat_sweep import sweep
@@ -60,6 +60,8 @@ order-independence contracts.
   contract, and the backend-equivalence guarantee.
 - **[Monte Carlo](monte-carlo.md)** — stochastic dispersion sweeps with
   named distributions and a determinism contract.
+- **[Sensitivity](sensitivity.md)** — Sobol first / total / second-order
+  indices via SALib, with bootstrap confidence intervals.
 - **[CLI reference](cli.md)** — the `gmat-sweep` console script: every
   Python entry point exposed as a subcommand.
 - **[Manifest schema](manifest-schema.md)** — the JSON Lines manifest each
@@ -69,7 +71,8 @@ order-independence contracts.
   single-machine backends on a 1000-run reference sweep.
 - **[Cookbook](cookbook.md)** — patterns for turning a sweep's outputs into
   the inputs downstream consumers need: visualisation export (CCSDS-OEM,
-  CZML), cross-tool validation, and external-tool wrapping.
+  CZML), cross-tool validation, external-tool wrapping, and archival
+  deposit (Zenodo / JOSS via `Sweep.archive`).
 - **[Cluster recipes](recipes/index.md)** — Slurm with `srun`, Kubernetes
   pod-per-worker, Kubernetes Job-per-run, and Ray autoscaling — wiring
   `DaskPool`, `KubernetesJobPool`, and `RayPool` into shared infrastructure.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gmat-sweep"
-version = "0.3.0"
+version = "0.4.0"
 description = "Run parameter sweeps and Monte Carlo dispersions over GMAT missions in parallel from Python."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/gmat_sweep/backends/kubernetes.py
+++ b/src/gmat_sweep/backends/kubernetes.py
@@ -103,8 +103,8 @@ class KubernetesJobPool(Pool):
     image:
         Fully-qualified container image with ``gmat-sweep[k8s]`` plus a
         working GMAT install. Pods run ``python -m
-        gmat_sweep._run_subprocess`` inside this image. **Required** in
-        v0.4 — a published default may follow in a later release.
+        gmat_sweep._run_subprocess`` inside this image. **Required** —
+        no published default image is shipped today.
     pvc_name:
         Name of an existing :class:`PersistentVolumeClaim` in
         ``namespace`` that the Pods will mount. Must be visible to the

--- a/uv.lock
+++ b/uv.lock
@@ -1257,7 +1257,7 @@ wheels = [
 
 [[package]]
 name = "gmat-sweep"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "gmat-run" },


### PR DESCRIPTION
## Summary

- Bump `version` from `0.3.0` to `0.4.0` in `pyproject.toml`; regenerate `uv.lock` so the editable entry resolves to `0.4.0`. Trove classifier stays at `Development Status :: 4 - Beta` (set in v0.3).
- Bump `CITATION.cff` to `0.4.0` / `2026-05-10` so GitHub's "Cite this repository" UI and academic tooling resolve the v0.4 metadata.
- Aggregate every v0.4 PR (#101, #102, #104, #105, #107–#117, #119–#121, #124–#127) into a `[0.4.0]` `CHANGELOG.md` section under Added / Changed / Fixed.
- Remove the README `## Roadmap` section entirely (per the issue scope). Past releases live in `CHANGELOG.md`; the next-version surface is tracked on the issue board.

This is the source-side of v0.4.0. After merge, the release is cut by pushing a `v0.4.0` tag, which fires `release.yml` (sdist + wheel build, PyPI trusted publishing, GitHub Release with auto-generated notes) and `docs.yml` (rebuild + deploy to Pages under the tag).

## Test plan

- [x] `uv run ruff check` — clean.
- [x] `uv run ruff format --check` — 81 files already formatted.
- [x] `uv run mypy` — no issues found in 71 source files.
- [x] `uv run pytest -m "not integration"` — 627 passed, 5 skipped (optional extras: polars, kubernetes, mpi4py), 52 deselected.
- [x] `uv build` — produces `gmat_sweep-0.4.0.tar.gz` and `gmat_sweep-0.4.0-py3-none-any.whl`.
- [x] `uv run mkdocs build --strict` — clean.
- [ ] Cross-OS CI (Ubuntu + Windows + macOS) green on this PR.
- [ ] After merge: tag `v0.4.0`, watch `release.yml` (PyPI) and `docs.yml` (Pages deploy).
- [ ] After publish: `pip install gmat-sweep==0.4.0` smoke-installs cleanly on Linux / Windows / macOS × Python 3.10 / 3.11 / 3.12.

## v0.4 Definition of Done — verification (issue #100)

- [ ] `pip install gmat-sweep==0.4.0` succeeds from PyPI on Python 3.10, 3.11, 3.12 — verifiable post-tag.
- [x] The four-line vision-snippet quick start runs against R2026a — covered by the `smoke-canary-image` cell in `integration.yml` against `ghcr.io/astro-tools/gmat:R2026a`.
- [x] CHANGELOG.md `[0.4.0]` section appended in the project convention.
- [x] README roadmap section completely removed.
- [ ] PyPI page, docs site, and README all reflect 0.4.0 — verifiable post-tag.
- [x] Per-issue CHANGELOG line items aggregated from the v0.4 milestone's merged PRs.

## Out of scope

- Per-PR CHANGELOG edits during the cycle — per project convention, CHANGELOG entries land at release-cut time.
- v0.5 scope decisions and milestone creation.
- Coverage gate adjustments — the bump from ≥85% to ≥90% landed in #113 during the cycle, not in this PR.

Closes #100