### PR TITLE
k8s: per-Job deadline, close() deletes in-flight Jobs, spec cleanup

### DIFF
--- a/docs/backends.md
+++ b/docs/backends.md
@@ -161,7 +161,12 @@ outcome through a shared `PersistentVolumeClaim` mounted at the same
 path on the driver and the workers. `parallelism=` caps the in-flight
 Job count so a 10000-run sweep doesn't stampede the API server. Per-run
 resource overrides are supported via the `resources=` kwarg in either
-mapping or callable form.
+mapping or callable form. A Job that has not reached a terminal status
+within `job_deadline_seconds` (default 1 h) is deleted by the driver
+and folded into a synthetic `RunOutcome.failed` rather than hanging the
+sweep on a stuck-`Pending` Pod; closing the pool mid-sweep deletes any
+remaining in-flight Jobs so they don't orphan against the namespace
+quota.
 
 See the [`KubernetesJobPool` recipe](recipes/kubernetes-jobpool.md) for
 the full setup: image build, PVC layout, in-cluster vs.

--- a/docs/recipes/kubernetes-jobpool.md
+++ b/docs/recipes/kubernetes-jobpool.md
@@ -258,6 +258,29 @@ Completed Jobs auto-GC after 5 minutes. Long enough for a kubectl
 inspection window, short enough to not leak Job objects across long
 sweeps. Override via `ttl_seconds_after_finished=` if you need more.
 
+### `job_deadline_seconds=3600`
+
+Driver-side wall-clock deadline per Job. A Job that has not reached a
+terminal status (`succeeded` or `failed`) within this many seconds is
+deleted (`propagationPolicy=Background`) and folded into a synthetic
+`RunOutcome.failed`. The check exists to break the otherwise-silent
+hang on Pods stuck in `Pending` / `ImagePullBackOff` / `Unschedulable`,
+which never produce a status event and so never satisfy the watch
+loop. Granularity is bounded by the watch reconnect cadence (~60 s);
+the deadline is a hang preventer, not a tight SLA. Override via
+`job_deadline_seconds=` for shorter (test) or longer (multi-hour
+solver) runs.
+
+### `close()` deletes in-flight Jobs
+
+Calling `close()` (whether from a `with` block exit, a `Ctrl-C`, or
+explicitly mid-sweep) issues a background-propagation delete for
+every Job still in flight at close time. Without this, an aborted
+sweep would leave Pods running until the TTL kicked in *after* they
+finished — burning your namespace quota and your bill. `ApiException`
+on a per-Job delete is swallowed so a Job already reaped by the TTL
+controller (or by a concurrent kubectl) doesn't propagate out.
+
 ### Pod failure modes
 
 A Pod that finished but didn't write outcome JSON (OOMKill, eviction,

--- a/src/gmat_sweep/backends/kubernetes.py
+++ b/src/gmat_sweep/backends/kubernetes.py
@@ -41,8 +41,19 @@ Job lifecycle
 Each Job is created with ``backoffLimit=0`` so a Pod failure maps 1:1 to a
 ``RunOutcome.failed`` (silent retries break determinism), and
 ``ttlSecondsAfterFinished=300`` so completed Jobs auto-GC after 5 minutes.
-:meth:`close` cancels parked futures but does not delete in-flight Jobs —
-the TTL is what reaps them.
+
+A Job that exceeds ``job_deadline_seconds`` (default 1 hour) without
+producing a terminal status is deleted by the driver and folded into a
+synthetic :meth:`RunOutcome.failed`. The check fires between watch
+reconnects, so deadline granularity is roughly the watch timeout
+(~60 s) — fine for hour-scale defaults, intended as a hang preventer
+rather than a tight SLA.
+
+:meth:`close` cancels parked futures and deletes every Job still
+in-flight at close time (``propagationPolicy=Background``), so a
+sweep aborted mid-drain does not orphan Jobs against the namespace
+quota. ``ApiException`` from a per-Job delete is swallowed so a Job
+already reaped by the TTL controller does not propagate out of close.
 """
 
 from __future__ import annotations
@@ -77,6 +88,7 @@ _WATCH_TIMEOUT_SECONDS = 60
 _DEFAULT_PARALLELISM = 64
 _DEFAULT_BACKOFF_LIMIT = 0
 _DEFAULT_TTL_SECONDS = 300
+_DEFAULT_JOB_DEADLINE_SECONDS = 3600
 _INCLUSTER_TOKEN_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
 
@@ -126,6 +138,16 @@ class KubernetesJobPool(Pool):
         Forwarded to ``V1JobSpec.ttl_seconds_after_finished``. Defaults
         to ``300`` (5 min) — enough for a kubectl-window for inspection
         before the cluster GCs.
+    job_deadline_seconds:
+        Driver-side wall-clock deadline per Job. A Job that has not
+        reached a terminal status (``succeeded`` or ``failed``) within
+        this many seconds is deleted (``propagationPolicy=Background``)
+        and folded into a synthetic :meth:`RunOutcome.failed`, instead
+        of letting the driver hang forever on Pods stuck in
+        ``Pending`` / ``ImagePullBackOff`` / ``Unschedulable``.
+        Granularity is bounded by the watch reconnect cadence
+        (~60 s); the deadline is a hang preventer, not a hard SLA.
+        Defaults to ``3600`` (1 h). Must be a positive integer.
     resources:
         Per-run resource overrides keyed by ``RunSpec.run_id``, or a
         callable taking the spec and returning a resources dict. The
@@ -164,6 +186,7 @@ class KubernetesJobPool(Pool):
         parallelism: int | None = _DEFAULT_PARALLELISM,
         backoff_limit: int = _DEFAULT_BACKOFF_LIMIT,
         ttl_seconds_after_finished: int = _DEFAULT_TTL_SECONDS,
+        job_deadline_seconds: int = _DEFAULT_JOB_DEADLINE_SECONDS,
         resources: _ResourcesArg = None,
         default_resources: Mapping[str, Any] | None = None,
         kubeconfig: str | Path | None = None,
@@ -185,6 +208,10 @@ class KubernetesJobPool(Pool):
             raise BackendError(
                 f"parallelism must be a positive integer or None, got {parallelism!r}"
             )
+        if job_deadline_seconds < 1:
+            raise BackendError(
+                f"job_deadline_seconds must be a positive integer, got {job_deadline_seconds!r}"
+            )
         if not image:
             raise BackendError("image is required")
         if not pvc_name:
@@ -201,6 +228,7 @@ class KubernetesJobPool(Pool):
         self._parallelism = parallelism
         self._backoff_limit = backoff_limit
         self._ttl_seconds_after_finished = ttl_seconds_after_finished
+        self._job_deadline_seconds = job_deadline_seconds
         self._resources = resources
         self._default_resources = dict(default_resources) if default_resources is not None else None
         self._reuse_gmat_context = reuse_gmat_context
@@ -211,6 +239,11 @@ class KubernetesJobPool(Pool):
         self._core_api = _kubernetes.client.CoreV1Api()
 
         self._pending: dict[Future[RunOutcome], RunSpec] = {}
+        # Job names that have been created on the API server but have not yet
+        # produced an outcome (or had one synthesised by the deadline scan or
+        # transport-failure path). `close()` deletes whatever is left here so
+        # an aborted sweep does not orphan Jobs against the namespace quota.
+        self._in_flight_jobs: set[str] = set()
         self._closed = False
 
     def _load_kube_config(self, *, in_cluster: bool | None, kubeconfig: str | Path | None) -> None:
@@ -266,7 +299,11 @@ class KubernetesJobPool(Pool):
 
         self._ensure_io_dirs()
 
-        in_flight: dict[str, tuple[RunSpec, datetime]] = {}
+        # `started_mono` (third tuple element) is `time.monotonic()` at submit
+        # time, used by the deadline scan so an NTP step does not move the
+        # cutoff. `started_wall` is kept separately so the audit-trail
+        # `started_at` on the resulting `RunOutcome` is wall-clock.
+        in_flight: dict[str, tuple[RunSpec, datetime, float]] = {}
         submit_iter = iter(specs)
         cap = self._parallelism if self._parallelism is not None else len(specs)
 
@@ -277,21 +314,35 @@ class KubernetesJobPool(Pool):
 
         completion_stream = self._iter_completions(label_selector)
         while in_flight:
-            completed_name = next(completion_stream, None)
-            if completed_name is None:
-                # stream exhausted unexpectedly; surface remaining as transport failures
-                for stuck_name, (stuck_spec, started) in list(in_flight.items()):
-                    outcome = self._fold_unknown_failure(stuck_spec, stuck_name, started)
-                    future_by_run_id[stuck_spec.run_id].set_result(outcome)
-                    yield outcome
-                    in_flight.pop(stuck_name)
-                break
+            event = next(completion_stream, None)
 
+            # Deadline scan runs on every iteration — both real completions
+            # and natural-reconnect ticks. Granularity is bounded by the
+            # watch reconnect cadence (~_WATCH_TIMEOUT_SECONDS), but a Job
+            # exceeding the deadline is the failure mode the scan exists
+            # to break; ~60 s tail latency is acceptable.
+            for stuck_name in self._collect_expired(in_flight):
+                stuck_spec, stuck_wall, _ = in_flight.pop(stuck_name)
+                self._delete_job_best_effort(stuck_name)
+                outcome = self._fold_deadline_failure(stuck_spec, stuck_name, stuck_wall)
+                self._in_flight_jobs.discard(stuck_name)
+                future_by_run_id[stuck_spec.run_id].set_result(outcome)
+                yield outcome
+                # Keep the cap full when a deadline expiry frees a slot.
+                self._submit_next(submit_iter, in_flight, sweep_id)
+
+            if event is None:
+                # Natural watch reconnect tick — deadline scan above was the
+                # work; loop back and resume waiting for completions.
+                continue
+
+            completed_name = event
             entry = in_flight.pop(completed_name, None)
             if entry is None:
                 continue
-            spec, started = entry
-            outcome = self._read_outcome(spec, completed_name, started_at=started)
+            spec, started_wall, _ = entry
+            outcome = self._read_outcome(spec, completed_name, started_at=started_wall)
+            self._in_flight_jobs.discard(completed_name)
             future_by_run_id[spec.run_id].set_result(outcome)
             yield outcome
 
@@ -304,6 +355,13 @@ class KubernetesJobPool(Pool):
         for f in self._pending:
             f.cancel()
         self._pending.clear()
+        # Delete any Job we created that has not yet produced an outcome.
+        # Best-effort per Job — an ApiException (already reaped by TTL,
+        # 403 from RBAC, transient network blip) is swallowed so a
+        # single delete failure doesn't leave the rest orphaned.
+        for job_name in list(self._in_flight_jobs):
+            self._delete_job_best_effort(job_name)
+        self._in_flight_jobs.clear()
 
     def _ensure_io_dirs(self) -> None:
         (self._driver_mount_path / _SPEC_SUBDIR).mkdir(parents=True, exist_ok=True)
@@ -312,14 +370,15 @@ class KubernetesJobPool(Pool):
     def _submit_next(
         self,
         submit_iter: Iterator[RunSpec],
-        in_flight: dict[str, tuple[RunSpec, datetime]],
+        in_flight: dict[str, tuple[RunSpec, datetime, float]],
         sweep_id: str,
     ) -> bool:
         spec = next(submit_iter, None)
         if spec is None:
             return False
         job_name = self._submit_job(spec, sweep_id)
-        in_flight[job_name] = (spec, datetime.now(timezone.utc))
+        in_flight[job_name] = (spec, datetime.now(timezone.utc), time.monotonic())
+        self._in_flight_jobs.add(job_name)
         return True
 
     def _submit_job(self, spec: RunSpec, sweep_id: str) -> str:
@@ -379,7 +438,18 @@ class KubernetesJobPool(Pool):
             spec=job_spec,
         )
 
-        self._batch_api.create_namespaced_job(namespace=self._namespace, body=job)
+        # If `create_namespaced_job` doesn't succeed, the spec file we wrote
+        # above is orphaned on the PVC. Clean it up on every failure path
+        # (typed `ApiException`, network/transport errors, KeyboardInterrupt,
+        # …) via a `finally` guarded on a success flag — `try/except` would
+        # have to enumerate every reachable exception type to be correct.
+        job_created = False
+        try:
+            self._batch_api.create_namespaced_job(namespace=self._namespace, body=job)
+            job_created = True
+        finally:
+            if not job_created:
+                spec_path_driver.unlink(missing_ok=True)
         return job_name
 
     def _job_name(self, sweep_id: str, run_id: int) -> str:
@@ -412,11 +482,20 @@ class KubernetesJobPool(Pool):
             return resolved
         return self._default_resources
 
-    def _iter_completions(self, label_selector: str) -> Iterator[str]:
+    def _iter_completions(self, label_selector: str) -> Iterator[str | None]:
+        """Yield Job names for terminally-completed Jobs; ``None`` on each reconnect.
+
+        ``None`` is a tick the drain loop in :meth:`as_completed` uses to run
+        its deadline scan even when no Job has produced a status event for
+        the full ``_WATCH_TIMEOUT_SECONDS``. Tick fires after both natural
+        watch ends and ApiException reconnects, so the deadline check
+        runs once per reconnect cycle regardless of which path we took.
+        """
         watch_module = self._kubernetes.watch
         rest_exc = self._kubernetes.client.exceptions.ApiException
         while True:
             watch = watch_module.Watch()
+            saw_api_exception = False
             try:
                 for event in watch.stream(
                     self._batch_api.list_namespaced_job,
@@ -433,13 +512,55 @@ class KubernetesJobPool(Pool):
                     if succeeded >= 1 or failed >= 1:
                         yield job.metadata.name
             except rest_exc:
-                # transient API failure: brief backoff and reconnect
-                time.sleep(0.5)
-                continue
+                saw_api_exception = True
             finally:
                 with contextlib.suppress(Exception):
                     watch.stop()
-            # Natural end of stream is a server-side timeout — reconnect.
+            if saw_api_exception:
+                # transient API failure: brief backoff before reconnecting
+                time.sleep(0.5)
+            yield None
+            # loop reconnects on the next iteration
+
+    def _collect_expired(self, in_flight: dict[str, tuple[RunSpec, datetime, float]]) -> list[str]:
+        deadline = self._job_deadline_seconds
+        now = time.monotonic()
+        return [
+            name
+            for name, (_spec, _wall, started_mono) in in_flight.items()
+            if (now - started_mono) >= deadline
+        ]
+
+    def _delete_job_best_effort(self, job_name: str) -> None:
+        """Delete a Job with background propagation, swallowing ApiException.
+
+        Used by the deadline scan and by :meth:`close`. A delete may race
+        the TTL controller (Job already reaped) or hit a transient RBAC /
+        network error; in either case the right move is to drop the entry
+        and continue rather than abort the rest of the sweep teardown.
+        """
+        rest_exc = self._kubernetes.client.exceptions.ApiException
+        with contextlib.suppress(rest_exc):
+            self._batch_api.delete_namespaced_job(
+                name=job_name,
+                namespace=self._namespace,
+                propagation_policy="Background",
+            )
+
+    def _fold_deadline_failure(
+        self, spec: RunSpec, job_name: str, started_at: datetime
+    ) -> RunOutcome:
+        ended_at = datetime.now(timezone.utc)
+        return RunOutcome.failed(
+            run_id=spec.run_id,
+            stderr=(
+                f"Job {job_name} exceeded job_deadline_seconds="
+                f"{self._job_deadline_seconds} without producing a terminal "
+                f"status; deleted by the driver before it could hang the sweep."
+            ),
+            started_at=started_at,
+            ended_at=ended_at,
+        )
 
     def _read_outcome(self, spec: RunSpec, job_name: str, *, started_at: datetime) -> RunOutcome:
         outcome_path = self._driver_mount_path / _OUTCOME_SUBDIR / f"{spec.run_id}.json"

--- a/tests/test_backends_kubernetes.py
+++ b/tests/test_backends_kubernetes.py
@@ -57,14 +57,31 @@ def _ok_outcome_dict(run_id: int) -> dict[str, Any]:
 
 
 class _BatchStub:
-    """Records every Job submission. Real V1Job objects round-trip through it."""
+    """Records every Job submission and deletion. Real V1Job objects round-trip through it."""
 
     def __init__(self) -> None:
         self.created: list[tuple[str, Any]] = []
+        self.deleted: list[dict[str, Any]] = []
+        # If non-None, ``create_namespaced_job`` raises this on every call.
+        self.create_raises: BaseException | None = None
+        # If non-None, ``delete_namespaced_job`` raises this on every call.
+        self.delete_raises: BaseException | None = None
 
     def create_namespaced_job(self, *, namespace: str, body: Any) -> Any:
+        if self.create_raises is not None:
+            raise self.create_raises
         self.created.append((namespace, body))
         return body
+
+    def delete_namespaced_job(
+        self, *, name: str, namespace: str, propagation_policy: str = "Background"
+    ) -> Any:
+        if self.delete_raises is not None:
+            raise self.delete_raises
+        self.deleted.append(
+            {"name": name, "namespace": namespace, "propagation_policy": propagation_policy}
+        )
+        return None
 
     def list_namespaced_job(self, **_kw: Any) -> Any:
         # Reference handed to ``Watch.stream`` — the watch stub never calls it,
@@ -213,6 +230,13 @@ def test_init_rejects_zero_or_negative_parallelism(patch_kube: _BatchStub, tmp_p
         _make_pool(tmp_path=tmp_path, parallelism=0)
     with pytest.raises(BackendError, match="parallelism"):
         _make_pool(tmp_path=tmp_path, parallelism=-2)
+
+
+def test_init_rejects_zero_or_negative_job_deadline(patch_kube: _BatchStub, tmp_path: Path) -> None:
+    with pytest.raises(BackendError, match="job_deadline_seconds"):
+        _make_pool(tmp_path=tmp_path, job_deadline_seconds=0)
+    with pytest.raises(BackendError, match="job_deadline_seconds"):
+        _make_pool(tmp_path=tmp_path, job_deadline_seconds=-1)
 
 
 def test_init_rejects_in_cluster_with_kubeconfig(patch_kube: _BatchStub, tmp_path: Path) -> None:
@@ -701,7 +725,9 @@ def test_iter_completions_yields_completed_job_names(
     monkeypatch.setattr(kubernetes.watch, "Watch", _Stub)
 
     pool = _make_pool(tmp_path=tmp_path)
-    gen = cast(Generator[str, None, None], pool._iter_completions("gmat-sweep/sweep-id=test"))
+    gen = cast(
+        Generator[str | None, None, None], pool._iter_completions("gmat-sweep/sweep-id=test")
+    )
     try:
         assert next(gen) == "job-a"
         assert next(gen) == "job-b"
@@ -709,10 +735,45 @@ def test_iter_completions_yields_completed_job_names(
         gen.close()
 
 
+def test_iter_completions_yields_none_on_natural_reconnect(
+    patch_kube: _BatchStub, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A clean ``Watch.stream()`` end (server-side timeout) yields a ``None`` tick.
+
+    The drain loop in :meth:`as_completed` uses the tick to run its
+    deadline scan even when no Job has produced a status event.
+    """
+
+    class _Stub(_WatchStub):
+        @classmethod
+        def _events_for_call(cls, call_n: int) -> list[dict[str, Any]]:
+            if call_n == 1:
+                # Empty stream — natural end (server-side timeout)
+                return []
+            raise AssertionError(f"unexpected Watch reconnect (call_n={call_n})")
+
+    _Stub.instances = []
+    _Stub.call_n = 0
+    monkeypatch.setattr(kubernetes.watch, "Watch", _Stub)
+
+    pool = _make_pool(tmp_path=tmp_path)
+    gen = cast(
+        Generator[str | None, None, None], pool._iter_completions("gmat-sweep/sweep-id=test")
+    )
+    try:
+        assert next(gen) is None
+    finally:
+        gen.close()
+
+
 def test_iter_completions_reconnects_after_api_exception(
     patch_kube: _BatchStub, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Transient ApiException during stream() triggers a Watch() reconnect."""
+    """Transient ApiException during stream() triggers a Watch() reconnect.
+
+    The reconnect path also yields a ``None`` tick before the next
+    Watch — same contract as the natural-end path.
+    """
 
     class _Stub(_WatchStub):
         @classmethod
@@ -729,13 +790,153 @@ def test_iter_completions_reconnects_after_api_exception(
     monkeypatch.setattr("gmat_sweep.backends.kubernetes.time.sleep", lambda _s: None)
 
     pool = _make_pool(tmp_path=tmp_path)
-    gen = cast(Generator[str, None, None], pool._iter_completions("gmat-sweep/sweep-id=test"))
+    gen = cast(
+        Generator[str | None, None, None], pool._iter_completions("gmat-sweep/sweep-id=test")
+    )
     try:
+        # First yield is the post-ApiException tick
+        assert next(gen) is None
+        # Second yield is the completion from the reconnected stream
         assert next(gen) == "job-x"
         # Two Watch instances — proves a reconnect happened
         assert len(_Stub.instances) >= 2
     finally:
         gen.close()
+
+
+# ---------------------------------------------------------------------------
+# Deadline-driven hang prevention + close()-deletes-in-flight + spec cleanup
+# ---------------------------------------------------------------------------
+
+
+def test_job_exceeding_deadline_folded_into_failed_run(
+    patch_kube: _BatchStub, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A Job that never reaches a terminal status before ``job_deadline_seconds``
+    is deleted by the driver and folded into a synthetic ``RunOutcome.failed``
+    rather than hanging the sweep.
+    """
+
+    # Drive the watch to deliver a single None tick — no completion events
+    # ever arrive, so the only way the drain loop progresses is via the
+    # deadline scan.
+    def _fake_iter(self: KubernetesJobPool, _label_selector: str) -> Iterator[str | None]:
+        yield None
+
+    monkeypatch.setattr(KubernetesJobPool, "_iter_completions", _fake_iter, raising=True)
+
+    # Step monotonic time past the deadline on the second read (after the
+    # spec is recorded in `in_flight`).
+    times = iter([0.0, 1_000_000.0])
+    monkeypatch.setattr(
+        "gmat_sweep.backends.kubernetes.time.monotonic", lambda: next(times, 1_000_000.0)
+    )
+
+    pool = _make_pool(tmp_path=tmp_path, job_deadline_seconds=60)
+    spec = _make_spec(output_dir=tmp_path / "run_0", run_id=0)
+    f = pool.submit(spec)
+
+    outcomes = list(pool.as_completed([f]))
+    assert len(outcomes) == 1
+    assert outcomes[0].status == "failed"
+    assert outcomes[0].stderr is not None
+    assert "job_deadline_seconds=60" in outcomes[0].stderr
+
+    # The driver must have deleted the stuck Job with background propagation.
+    assert len(patch_kube.deleted) == 1
+    deleted_call = patch_kube.deleted[0]
+    assert deleted_call["propagation_policy"] == "Background"
+    # The deleted Job name matches the one we created.
+    expected_name = patch_kube.created[0][1].metadata.name
+    assert deleted_call["name"] == expected_name
+
+
+def test_close_deletes_in_flight_jobs(patch_kube: _BatchStub, tmp_path: Path) -> None:
+    """``close()`` issues a background-propagation delete for every Job
+    still in :attr:`_in_flight_jobs` at close time, so a sweep aborted
+    mid-drain does not orphan Jobs against the namespace quota.
+    Completed Jobs (already removed from the set by the drain loop) are
+    left alone — the TTL controller reaps them.
+    """
+    pool = _make_pool(tmp_path=tmp_path)
+    pool._ensure_io_dirs()
+
+    # Get two Jobs onto the API server (and onto `_in_flight_jobs`) via
+    # direct `_submit_next` — bypasses `as_completed`, so this test can
+    # exercise the close-time delete invariant in isolation.
+    pool._submit_next(
+        iter([_make_spec(output_dir=tmp_path / "run_0", run_id=0)]),
+        {},
+        sweep_id="abcdef12",
+    )
+    pool._submit_next(
+        iter([_make_spec(output_dir=tmp_path / "run_1", run_id=1)]),
+        {},
+        sweep_id="abcdef12",
+    )
+    in_flight_before_close = sorted(pool._in_flight_jobs)
+    assert len(in_flight_before_close) == 2
+
+    # Simulate run_0 having completed during the drain — `as_completed`
+    # is the only place that removes from the set, so we model it here.
+    completed = in_flight_before_close[0]
+    still_in_flight = in_flight_before_close[1]
+    pool._in_flight_jobs.discard(completed)
+
+    pool.close()
+
+    # Exactly one delete — for the Job still in-flight at close time.
+    assert len(patch_kube.deleted) == 1
+    deleted_call = patch_kube.deleted[0]
+    assert deleted_call["name"] == still_in_flight
+    assert deleted_call["propagation_policy"] == "Background"
+
+
+def test_close_swallows_api_exception_on_delete(patch_kube: _BatchStub, tmp_path: Path) -> None:
+    """An ApiException from ``delete_namespaced_job`` (already reaped by TTL,
+    RBAC denied, transient network error) is swallowed per-Job so a single
+    delete failure doesn't propagate out of close.
+    """
+    pool = _make_pool(tmp_path=tmp_path)
+    pool._ensure_io_dirs()
+    # Get two Jobs onto the API server (and onto `_in_flight_jobs`)
+    # without driving as_completed — direct `_submit_next` calls do that.
+    pool._submit_next(
+        iter([_make_spec(output_dir=tmp_path / "run_0", run_id=0)]),
+        {},
+        sweep_id="abcdef12",
+    )
+    pool._submit_next(
+        iter([_make_spec(output_dir=tmp_path / "run_1", run_id=1)]),
+        {},
+        sweep_id="abcdef12",
+    )
+    assert len(pool._in_flight_jobs) == 2
+
+    patch_kube.delete_raises = kubernetes.client.exceptions.ApiException("gone")
+
+    # Must not raise — every per-Job delete failure is swallowed.
+    pool.close()
+    assert pool._in_flight_jobs == set()
+
+
+def test_spec_file_cleaned_up_when_create_namespaced_job_fails(
+    patch_kube: _BatchStub, tmp_path: Path
+) -> None:
+    """If ``create_namespaced_job`` raises, the spec JSON we wrote to the
+    PVC is unlinked before the exception propagates so a retry doesn't
+    see stale data and the disk doesn't accumulate orphaned specs.
+    """
+    pool = _make_pool(tmp_path=tmp_path)
+    patch_kube.create_raises = kubernetes.client.exceptions.ApiException("nope")
+
+    pool._ensure_io_dirs()
+    spec = _make_spec(output_dir=tmp_path / "run_3", run_id=3)
+    with pytest.raises(kubernetes.client.exceptions.ApiException):
+        pool._submit_job(spec, sweep_id="cafef00d")
+
+    spec_path = tmp_path / "_specs" / "3.json"
+    assert not spec_path.exists()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the two real-world failure modes in \`KubernetesJobPool\` the v0.4 review surfaced:

- **Per-Job deadline.** New constructor kwarg \`job_deadline_seconds: int = 3600\` (validated \`>= 1\`). The drain loop in \`as_completed\` checks each in-flight Job's elapsed monotonic time against the deadline on every iteration; an expired Job is deleted (\`propagation_policy=\"Background\"\`) and folded into a synthetic \`RunOutcome.failed\`. \`_iter_completions\` now yields \`str | None\` — a \`None\` after each natural watch end and each \`ApiException\` reconnect — so the deadline scan runs once per reconnect cycle even when no Job is producing status events. Deadline granularity is bounded by \`_WATCH_TIMEOUT_SECONDS\` (~60 s); the deadline is a hang preventer, not a tight SLA, and that's documented in the class docstring.

- **\`close()\` deletes in-flight Jobs.** New \`self._in_flight_jobs: set[str]\` tracks every Job created on the API server until it produces an outcome (real, deadline-synthetic, or transport-failure-synthetic). \`close()\` iterates the set and issues a background-propagation delete for each, swallowing per-Job \`ApiException\` so a single delete failure (TTL race, RBAC, transient network) doesn't leave the rest orphaned. Module / class docstrings updated.

- **Spec-file cleanup on Job-create failure.** \`_submit_job\` wraps \`create_namespaced_job\` in a \`try/finally\` guarded on a success flag so the spec JSON we wrote to the PVC is unlinked on every Job-create failure path (typed \`ApiException\`, network errors, KeyboardInterrupt) rather than orphaning on disk.

## Test plan

- [x] \`uv run ruff check\` — clean.
- [x] \`uv run ruff format --check\` — 81 files already formatted.
- [x] \`uv run mypy\` — clean across 71 source files.
- [x] \`uv run pytest tests/test_backends_kubernetes.py\` — 39 passed (was 35 pre-PR; 5 new tests, two existing watch-loop tests updated for the \`str | None\` contract change).
- [x] \`uv run pytest -m \"not integration\"\` — 593 passed / 10 skipped (optional extras) / 28 deselected.
- [x] \`uv run mkdocs build --strict\` — class docstring is consumed by mkdocstrings; clean.
- [ ] Real-cluster \`backend-k8s\` cell in \`integration.yml\` is not exercisable locally; runs against \`kind\` on push-to-main. The new mock tests pin the failure-mode contract.

## New tests

- \`test_init_rejects_zero_or_negative_job_deadline\` — validates the new kwarg rejects \`0\` and negatives.
- \`test_iter_completions_yields_none_on_natural_reconnect\` — empty stream yields a \`None\` tick directly.
- \`test_job_exceeding_deadline_folded_into_failed_run\` — drives a stuck Job past the deadline (monkeypatched \`time.monotonic\`) and asserts the outcome is \`failed\`, the stderr cites \`job_deadline_seconds\`, and \`delete_namespaced_job\` was called with \`propagation_policy=\"Background\"\`.
- \`test_close_deletes_in_flight_jobs\` — \`close()\` deletes only the Jobs still in \`_in_flight_jobs\` (the test simulates one as completed and removed from the set; the other is asserted to be the only one deleted).
- \`test_close_swallows_api_exception_on_delete\` — a mocked \`delete_namespaced_job\` that raises \`ApiException\` does not propagate out of \`close\`.
- \`test_spec_file_cleaned_up_when_create_namespaced_job_fails\` — a failing \`create_namespaced_job\` leaves no spec JSON on disk.

## Out of scope

- Other backends' similar uniform-failure-folding work — issue #132.
- The version-pegged \`v0.4\` docstring on the \`image:\` parameter — already fixed on the v0.4 cut PR (#128).
- Adding a real-cluster integration test that targets a deliberately stuck Job — defer; the new mock tests pin the contract, and the existing kind-side cell continues to exercise the happy path.

Closes #129