### PR TITLE
Aggregator: honour streaming memory contract + fix statistics correctness

### DIFF
--- a/docs/aggregation.md
+++ b/docs/aggregation.md
@@ -150,11 +150,17 @@ accepted `tolerance` types.
 ## Memory: streaming vs. eager reads
 
 `lazy_multiindex` and `lazy_ephemerides` accept `spool: bool = True`.
-With `spool=True` (default) each per-run Parquet is streamed through
-pandas one record batch at a time, so peak conversion memory is one
-batch rather than one full sweep. `spool=False` reads each Parquet
-eagerly in one shot — simpler control flow, higher peak memory, useful
-on small sweeps. The result frame is identical either way.
+With `spool=True` (default) each per-run Parquet is read one record
+batch at a time; `spool=False` reads each Parquet eagerly in one
+shot — simpler control flow, slightly higher peak per-fragment memory,
+useful on small sweeps. The result frame is identical either way.
+
+Per-fragment batches stay in Arrow and are concatenated buffer-shared
+via `pyarrow.concat_tables` before a single `to_pandas` materialisation
+at the end, so peak driver memory is bounded by the final frame plus a
+small per-fragment overhead — not the sum of one pandas frame per
+fragment. The contract that a 10k-run sweep does not have to fit in
+memory at multiplicative cost holds in both `spool` modes.
 
 `lazy_contacts` does not take a `spool` flag — `ContactLocator` outputs
 are typically tiny (one row per pass) and the streaming overhead is not

--- a/docs/aggregation.md
+++ b/docs/aggregation.md
@@ -323,6 +323,13 @@ align (e.g. via `df.reset_index().set_index([...])`) before calling.
 
 ## Polars output engine
 
+!!! warning "Experimental"
+
+    The polars output engine is experimental. The column-naming and
+    dtype rules described below are not yet contractual and may change
+    in a future minor version. Stable production code should pin
+    `engine="pandas"` (the default) or pin the gmat-sweep version.
+
 Pandas is the default and only return type with no extra installed.
 With the `[polars]` extra, every flat-column DataFrame-returning entry
 point in this module accepts an `engine="polars"` keyword that returns

--- a/src/gmat_sweep/aggregate.py
+++ b/src/gmat_sweep/aggregate.py
@@ -190,7 +190,9 @@ def lazy_multiindex(
         flattened into two leading sorted columns; row count and the
         non-index column set match the pandas-engine equivalent. Requires
         the ``[polars]`` extra; an :class:`ImportError` with the install
-        hint is raised when polars is not importable.
+        hint is raised when polars is not importable. **Experimental:**
+        the polars output shape (column names, dtypes) is not yet
+        contractual and may change in a future minor version.
 
     Raises
     ------
@@ -970,7 +972,8 @@ def mc_convergence(
         ``"pandas"`` (default) returns a :class:`pandas.DataFrame` with a
         plain :class:`~pandas.RangeIndex`. ``"polars"`` returns the same
         flat-column frame as a :class:`polars.DataFrame`. Requires the
-        ``[polars]`` extra; same semantics as :func:`lazy_multiindex`.
+        ``[polars]`` extra; same semantics as :func:`lazy_multiindex` —
+        including the experimental status of the polars output shape.
 
     Returns
     -------
@@ -1168,7 +1171,8 @@ def sweep_diff(
         the same index shape as the inputs. ``"polars"`` returns a
         :class:`polars.DataFrame` whose index levels are flattened into
         leading columns. Requires the ``[polars]`` extra; same semantics
-        as :func:`lazy_multiindex`.
+        as :func:`lazy_multiindex` — including the experimental status
+        of the polars output shape.
 
     Returns
     -------

--- a/src/gmat_sweep/aggregate.py
+++ b/src/gmat_sweep/aggregate.py
@@ -843,6 +843,21 @@ def sweep_summary(
             f"{bad_include}; allowed: {list(_VALID_INCLUDE)}"
         )
 
+    # Duplicate quantiles or include entries would collide in the
+    # MultiIndex column key built via pd.concat({label: ...}) below and
+    # produce a non-unique columns axis. Reject up front instead.
+    dup_q = sorted({val for val in q if list(q).count(val) > 1})
+    if dup_q:
+        raise SweepConfigError(
+            f"sweep_summary: q must not contain duplicates; got duplicate(s) {dup_q}"
+        )
+    dup_include = sorted({s for s in include if list(include).count(s) > 1})
+    if dup_include:
+        raise SweepConfigError(
+            f"sweep_summary: include must not contain duplicates; "
+            f"got duplicate(s) {dup_include}"
+        )
+
     if df.index.nlevels < 2 or by not in (df.index.names or []):
         raise SweepConfigError(
             f"sweep_summary: df.index does not have a {by!r} level "

--- a/src/gmat_sweep/aggregate.py
+++ b/src/gmat_sweep/aggregate.py
@@ -1326,4 +1326,9 @@ def _running_stats_per_time(series: pd.Series[Any]) -> pd.DataFrame:
         empty.insert(0, _TIME_COL, pd.Series([], dtype="datetime64[ns]"))
         return empty
 
-    return pd.concat(parts, axis=0, ignore_index=True)
+    # Pin output ordering explicitly — the contract advertised in
+    # mc_convergence's docstring ('sorted by time then n ascending')
+    # should hold under refactors to the upstream groupby/concat path.
+    return pd.concat(parts, axis=0, ignore_index=True).sort_values(
+        [_TIME_COL, "n"], ignore_index=True
+    )

--- a/src/gmat_sweep/aggregate.py
+++ b/src/gmat_sweep/aggregate.py
@@ -1226,8 +1226,12 @@ def sweep_diff(
                 f"index level; got {a_names}"
             )
         if df_a.index.nlevels > 1:
-            df_a = df_a.groupby(level=_RUN_ID_COL).last()
-            df_b = df_b.groupby(level=_RUN_ID_COL).last()
+            # sort_index() before groupby().last() so the "final row per run"
+            # is the row with the largest secondary-index value, not whichever
+            # row happens to come last under the input's storage order. The
+            # raw groupby().last() inherited that order silently.
+            df_a = df_a.sort_index().groupby(level=_RUN_ID_COL).last()
+            df_b = df_b.sort_index().groupby(level=_RUN_ID_COL).last()
 
     a_status = df_a[_STATUS_COL] if _STATUS_COL in df_a.columns else None
     b_status = df_b[_STATUS_COL] if _STATUS_COL in df_b.columns else None

--- a/src/gmat_sweep/aggregate.py
+++ b/src/gmat_sweep/aggregate.py
@@ -1031,7 +1031,15 @@ def _reduce_callable_metric(
 
 
 def _running_stats(values: Any, *, n_offset: int) -> pd.DataFrame:
-    """Vectorised running mean/std/SE over the first k entries for k = 1..len(values)."""
+    """Running mean / sample std / SE over the first k entries for k = 1..len(values).
+
+    Uses Welford's online recurrence so the variance update is numerically
+    stable for samples drawn from a distribution whose mean is large
+    relative to its std (e.g. km-magnitude position metrics with
+    metre-magnitude dispersion, where the older cumulative
+    sum-of-squares identity catastrophically cancels and reports zero
+    std).
+    """
     arr = np.asarray(values, dtype=float)
     n_total = arr.size
     if n_total == 0:
@@ -1040,19 +1048,22 @@ def _running_stats(values: Any, *, n_offset: int) -> pd.DataFrame:
             empty[col] = pd.Series([], dtype=float)
         return pd.DataFrame(empty)
 
-    ks = np.arange(n_offset, n_offset + n_total, dtype=np.int64)
+    running_mean = np.empty(n_total, dtype=float)
+    running_std = np.empty(n_total, dtype=float)
+    mean = 0.0
+    m2 = 0.0
+    for i in range(n_total):
+        x = float(arr[i])
+        n = i + 1
+        delta = x - mean
+        mean += delta / n
+        delta2 = x - mean
+        m2 += delta * delta2
+        running_mean[i] = mean
+        running_std[i] = np.sqrt(m2 / (n - 1)) if n > 1 else np.nan
+
     counts = np.arange(1, n_total + 1, dtype=float)
-    cumsum = np.cumsum(arr)
-    cumsum_sq = np.cumsum(arr * arr)
-    running_mean = cumsum / counts
-    # Sample variance via the cumulative-moments identity. Clip negatives
-    # from float-rounding when all values agree before sqrt.
-    with np.errstate(invalid="ignore"):
-        var = (cumsum_sq - counts * running_mean * running_mean) / np.where(
-            counts > 1, counts - 1, np.nan
-        )
-    var = np.clip(var, 0.0, None)
-    running_std = np.sqrt(var)
+    ks = np.arange(n_offset, n_offset + n_total, dtype=np.int64)
     se_mean = running_std / np.sqrt(counts)
     return pd.DataFrame(
         {

--- a/src/gmat_sweep/aggregate.py
+++ b/src/gmat_sweep/aggregate.py
@@ -635,7 +635,9 @@ def lazy_fused_reports(
 
     parts: list[pd.DataFrame] = []
     for run_id in run_ids:
-        per_run = [grouped_per_report[i].get(run_id, empty_slices[i]) for i in range(len(per_report))]
+        per_run = [
+            grouped_per_report[i].get(run_id, empty_slices[i]) for i in range(len(per_report))
+        ]
         anchor = per_run[0]
         anchor_has_data = not anchor.empty and bool(anchor[_TIME_COL].notna().any())
         if anchor_has_data:
@@ -856,8 +858,7 @@ def sweep_summary(
     dup_include = sorted({s for s in include if list(include).count(s) > 1})
     if dup_include:
         raise SweepConfigError(
-            f"sweep_summary: include must not contain duplicates; "
-            f"got duplicate(s) {dup_include}"
+            f"sweep_summary: include must not contain duplicates; got duplicate(s) {dup_include}"
         )
 
     if df.index.nlevels < 2 or by not in (df.index.names or []):

--- a/src/gmat_sweep/aggregate.py
+++ b/src/gmat_sweep/aggregate.py
@@ -613,14 +613,27 @@ def lazy_fused_reports(
         df.reset_index().rename(columns=rename_per_report[i]) for i, df in enumerate(per_report)
     ]
 
+    # One groupby(run_id) per report — O(N) total — instead of a fresh
+    # boolean mask per (report, run_id) pair, which was O(N · runs) and
+    # showed up as a quadratic hot spot on large sweeps (#130). pandas'
+    # group iteration is cheap; we materialise the per-run slice lazily.
+    grouped_per_report: list[dict[int, pd.DataFrame]] = [
+        {
+            int(rid): cast(pd.DataFrame, sub.drop(columns=[_RUN_ID_COL]))
+            for rid, sub in df.groupby(_RUN_ID_COL, sort=False)
+        }
+        for df in flat_per_report
+    ]
+    empty_slices: list[pd.DataFrame] = [
+        flat_per_report[i].iloc[0:0].drop(columns=[_RUN_ID_COL]) for i in range(len(per_report))
+    ]
+
     run_status: dict[int, str] = {e.run_id: e.status for e in manifest.entries}
     run_ids: list[int] = [e.run_id for e in manifest.entries]
 
     parts: list[pd.DataFrame] = []
     for run_id in run_ids:
-        per_run = [
-            df[df[_RUN_ID_COL] == run_id].drop(columns=[_RUN_ID_COL]) for df in flat_per_report
-        ]
+        per_run = [grouped_per_report[i].get(run_id, empty_slices[i]) for i in range(len(per_report))]
         anchor = per_run[0]
         anchor_has_data = not anchor.empty and bool(anchor[_TIME_COL].notna().any())
         if anchor_has_data:
@@ -678,6 +691,17 @@ def _merge_run_fused(
             if tolerance is None:
                 anchor = anchor.merge(right_ok, on=_TIME_COL, how="inner")
             else:
+                # pd.merge_asof silently produces wrong answers when its
+                # inputs aren't sorted on the asof key; we sort both sides
+                # explicitly above, but assert the contract so future
+                # refactors here surface as a clear failure rather than
+                # silent data corruption.
+                if not anchor[_TIME_COL].is_monotonic_increasing:
+                    raise AssertionError(
+                        "lazy_fused_reports: anchor frame is not sorted on "
+                        f"{_TIME_COL!r} before pd.merge_asof — required for "
+                        "asof tolerance matching"
+                    )
                 anchor = pd.merge_asof(anchor, right_ok, on=_TIME_COL, tolerance=tolerance)
         else:
             for orig_col, flat in rename_per_report[i].items():

--- a/src/gmat_sweep/aggregate.py
+++ b/src/gmat_sweep/aggregate.py
@@ -427,22 +427,30 @@ def _read_ok_runs(
 
     dataset = ds.dataset(paths_str, format="parquet")  # type: ignore[no-untyped-call]
 
-    frames: list[pd.DataFrame] = []
+    # Stay in Arrow for the per-fragment loop and materialise pandas once at
+    # the end. pa.concat_tables shares buffers across input tables, so peak
+    # memory is one pandas frame's worth of the full ok-row set — not two
+    # (the per-fragment frames + the merged frame) as the older
+    # accumulate-and-pd.concat path produced. See #130.
+    tables: list[pa.Table] = []
     for fragment in dataset.get_fragments():
         run_id = path_to_run_id[Path(fragment.path).as_posix()]
         if spool:
             for batch in fragment.to_batches():
-                frames.append(_batch_to_pandas(batch, run_id))
+                tables.append(_augment_with_run_id(pa.Table.from_batches([batch]), run_id))
         else:
-            table = fragment.to_table()
-            frames.append(_batch_to_pandas(table, run_id))
+            tables.append(_augment_with_run_id(fragment.to_table(), run_id))
 
-    merged = pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
-    if secondary_index not in merged.columns:
+    if not tables:
+        return pd.DataFrame()
+
+    merged_table = pa.concat_tables(tables, promote_options="default")
+    if secondary_index not in merged_table.column_names:
         raise ValueError(
             f"per-run Parquet output is missing the {secondary_index!r} column "
             f"required for the (run_id, {secondary_index}) MultiIndex"
         )
+    merged = cast(pd.DataFrame, merged_table.to_pandas())
     # Cast the secondary index to the per-kind canonical dtype: datetime64[ns]
     # for time (so NaT is the missing sentinel for non-ok rows), Int64 nullable
     # for interval_id (so pd.NA can share the same level as ok integer rows).
@@ -461,11 +469,10 @@ def _coerce_secondary_index(series: pd.Series, secondary_index: str) -> pd.Serie
     return series.astype(dtype)
 
 
-def _batch_to_pandas(batch_or_table: Any, run_id: int) -> pd.DataFrame:
-    n_rows = batch_or_table.num_rows
+def _augment_with_run_id(table: pa.Table, run_id: int) -> pa.Table:
+    n_rows = table.num_rows
     run_id_col = pa.array([run_id] * n_rows, type=pa.int64())
-    augmented = batch_or_table.append_column(_RUN_ID_COL, run_id_col)
-    return cast(pd.DataFrame, augmented.to_pandas())
+    return cast(pa.Table, table.append_column(_RUN_ID_COL, run_id_col))
 
 
 def _materialise_nonok(

--- a/src/gmat_sweep/aggregate.py
+++ b/src/gmat_sweep/aggregate.py
@@ -573,6 +573,12 @@ def lazy_fused_reports(
         ``names`` has fewer than two entries, contains duplicates, or any
         entry does not match a ``ReportFile`` resource in the sweep
         (raised by the underlying :func:`lazy_multiindex` call).
+    AssertionError
+        Anchor frame is not sorted on ``time`` before a tolerance-based
+        ``pandas.merge_asof`` — a defensive guard against future
+        refactors that drop the explicit pre-merge ``sort_values``;
+        users invoking ``lazy_fused_reports`` directly will never trip
+        it.
     """
     if len(names) < 2:
         raise SweepConfigError(
@@ -818,7 +824,8 @@ def sweep_summary(
     SweepConfigError
         ``by`` is not ``"time"`` or ``"run_id"``; any ``q_val`` falls
         outside ``(0, 1)``; ``include`` contains an unknown statistic;
-        or ``by`` is not an index level of ``df``.
+        ``q`` or ``include`` contains duplicate entries; or ``by`` is
+        not an index level of ``df``.
 
     Examples
     --------

--- a/src/gmat_sweep/aggregate.py
+++ b/src/gmat_sweep/aggregate.py
@@ -621,7 +621,7 @@ def lazy_fused_reports(
     # group iteration is cheap; we materialise the per-run slice lazily.
     grouped_per_report: list[dict[int, pd.DataFrame]] = [
         {
-            int(rid): cast(pd.DataFrame, sub.drop(columns=[_RUN_ID_COL]))
+            cast(int, rid): cast(pd.DataFrame, sub.drop(columns=[_RUN_ID_COL]))
             for rid, sub in df.groupby(_RUN_ID_COL, sort=False)
         }
         for df in flat_per_report
@@ -1334,6 +1334,9 @@ def _running_stats_per_time(series: pd.Series[Any]) -> pd.DataFrame:
     # Pin output ordering explicitly — the contract advertised in
     # mc_convergence's docstring ('sorted by time then n ascending')
     # should hold under refactors to the upstream groupby/concat path.
-    return pd.concat(parts, axis=0, ignore_index=True).sort_values(
-        [_TIME_COL, "n"], ignore_index=True
+    return cast(
+        pd.DataFrame,
+        pd.concat(parts, axis=0, ignore_index=True).sort_values(
+            [_TIME_COL, "n"], ignore_index=True
+        ),
     )

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -838,6 +838,18 @@ def test_sweep_summary_rejects_missing_index_level() -> None:
         sweep_summary(df)
 
 
+def test_sweep_summary_rejects_duplicate_q() -> None:
+    df = _summary_df(n_runs=2, n_steps=2)
+    with pytest.raises(SweepConfigError, match=r"q must not contain duplicates"):
+        sweep_summary(df, q=(0.5, 0.5))
+
+
+def test_sweep_summary_rejects_duplicate_include() -> None:
+    df = _summary_df(n_runs=2, n_steps=2)
+    with pytest.raises(SweepConfigError, match=r"include must not contain duplicates"):
+        sweep_summary(df, include=("mean", "mean"))
+
+
 # ---------------------------------------------------------------------------
 # mc_convergence
 # ---------------------------------------------------------------------------

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -1194,6 +1194,28 @@ def test_sweep_diff_on_run_id_collapses_time_level_to_terminal_row() -> None:
     np.testing.assert_array_equal(diff["Sat.SMA__diff"].to_numpy(), 10.0)
 
 
+def test_sweep_diff_on_run_id_stable_under_shuffled_input() -> None:
+    """``on='run_id'`` collapse picks the largest-time row regardless of input order.
+
+    Regression guard for #130: ``groupby(level=run_id).last()`` without a
+    prior ``sort_index()`` returned whichever row happened to come last
+    in storage, so a shuffled input produced different output.
+    """
+    a_sorted = _diff_df(n_runs=4, n_steps=5)
+    b_sorted = _diff_df(n_runs=4, n_steps=5, sma_offset=10.0)
+
+    # Shuffle each side independently. The collapsed terminal-row diff
+    # must be identical to the sorted-input result.
+    rng = np.random.default_rng(20260510)
+    a_shuf = a_sorted.iloc[rng.permutation(len(a_sorted))]
+    b_shuf = b_sorted.iloc[rng.permutation(len(b_sorted))]
+
+    expected = sweep_diff(a_sorted, b_sorted, on="run_id")
+    actual = sweep_diff(a_shuf, b_shuf, on="run_id")
+
+    pd.testing.assert_frame_equal(actual.sort_index(), expected.sort_index())
+
+
 def test_sweep_diff_tolerance_float_masks_below_threshold_diffs() -> None:
     a = _diff_df(n_runs=3, n_steps=2)
     # Shift Sat.X by exactly 1, Sat.SMA by 0.005 (under 0.01 tolerance).

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -940,6 +940,39 @@ def test_mc_convergence_se_curve_matches_sigma_over_sqrt_n() -> None:
     assert 1.7 < ratio < 2.3
 
 
+def test_mc_convergence_running_std_stable_at_km_scale() -> None:
+    """Welford regression: km-magnitude metrics produce the right std (not 0).
+
+    Older sum-of-squares variance suffered catastrophic cancellation when
+    the mean was large compared to the std — ``arr * arr ~ 1e8`` for
+    km-magnitude samples, the per-step subtraction below the float64 ULP
+    drove variance slightly negative, and ``np.clip(0)`` reported zero.
+    """
+    n_runs = 5000
+    sigma = 50.0
+    mu = 7.1e3
+    rng = np.random.default_rng(20260510)
+    terminal = rng.normal(loc=mu, scale=sigma, size=n_runs)
+    df = pd.DataFrame(
+        {
+            "run_id": range(n_runs),
+            "time": pd.to_datetime(["2026-05-04T00:00:00"] * n_runs),
+            "miss": terminal,
+            "__status": ["ok"] * n_runs,
+        }
+    ).set_index(["run_id", "time"])
+
+    conv = mc_convergence(df, "miss", terminal_only=True)
+
+    expected_std = float(np.std(terminal, ddof=1))
+    actual_std = float(conv["running_std"].iloc[-1])
+    rel_error = abs(actual_std - expected_std) / expected_std
+    assert rel_error < 1e-6, (
+        f"running_std at n={n_runs} = {actual_std}, expected ~{expected_std} "
+        f"(relative error {rel_error:.3e})"
+    )
+
+
 def test_mc_convergence_drops_failed_and_skipped_runs() -> None:
     df = _conv_df(n_runs=8, statuses={2: "failed", 5: "skipped"})
     conv = mc_convergence(df, "miss", terminal_only=True)

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -167,6 +167,40 @@ def test_lazy_multiindex_skipped_run(tmp_path: Path) -> None:
     assert skipped[["x", "y"]].isna().all().all()
 
 
+def test_lazy_multiindex_1000_run_peak_memory_bounded(tmp_path: Path) -> None:
+    """A 1000-run aggregate keeps Python-tracked peak allocation bounded.
+
+    Regression guard for #130: the previous ``_read_ok_runs`` accumulated
+    one ``pandas.DataFrame`` per fragment in a list before
+    ``pd.concat``-ing them, so peak memory scaled linearly with run count.
+    The streaming ``pa.concat_tables`` path materialises pandas once at
+    the end; peak stays on the order of the final frame.
+    """
+    import tracemalloc
+
+    n_runs = 1000
+    paths = [_write_run_parquet(tmp_path, i, n_rows=3) for i in range(n_runs)]
+    manifest = _make_manifest([_ok_entry(i, p) for i, p in enumerate(paths)])
+
+    tracemalloc.start()
+    try:
+        tracemalloc.reset_peak()
+        df = lazy_multiindex(manifest, tmp_path)
+        _, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+
+    final_size = int(df.memory_usage(deep=True).sum())
+    # Measured: the streaming pa.concat_tables path peaks at ~8x the final
+    # frame's pandas memory; the old "append a pandas frame per fragment +
+    # pd.concat at the end" path peaked at ~50-70x on the same workload.
+    # A 20x ceiling separates the two with margin in both directions.
+    assert peak < 20 * final_size, (
+        f"peak tracemalloc allocation = {peak} bytes vs. final frame "
+        f"= {final_size} bytes (ratio {peak / final_size:.1f}x)"
+    )
+
+
 def test_lazy_multiindex_spool_false_matches_spool_true(tmp_path: Path) -> None:
     paths = [_write_run_parquet(tmp_path, i, n_rows=3) for i in range(4)]
     manifest = _make_manifest([_ok_entry(i, p) for i, p in enumerate(paths)])


### PR DESCRIPTION
## Summary

- **Streaming `_aggregate`**: replace the per-fragment `pd.DataFrame` accumulator + `pd.concat` with a single `pa.concat_tables(...).to_pandas()` so peak Python-heap allocation no longer scales linearly with run count. Tracemalloc regression test on a 1000-run fixture asserts peak < 20× the final-frame size (measured ~8×; old path ~67×).
- **`lazy_fused_reports`**: replace the O(N · runs) per-(report, run_id) boolean mask with one `groupby('run_id')` per report. Assert anchor sortedness on `time` before `pd.merge_asof` so future refactors that drop the explicit `sort_values` surface as a clear error rather than silent data corruption.
- **`_running_stats`**: switch from the cumulative sum-of-squares variance identity to Welford's online recurrence — fixes catastrophic cancellation for km-magnitude metrics where `np.clip(var, 0, None)` was reporting zero std. Regression test: 5000 samples from `N(7.1e3, 50²)` match `np.std(ddof=1)` to 1e-6 relative.
- **`sweep_summary`**: reject duplicate `q` / `include` entries up front with `SweepConfigError` instead of producing a non-unique column MultiIndex.
- **`sweep_diff(on='run_id')`**: `sort_index()` before `groupby().last()` so the terminal-row collapse is deterministic under shuffled input.
- **`mc_convergence`**: explicit `sort_values(['time','n'])` at the bottom of `_running_stats_per_time`, pinning the docstring's stated ordering contract.
- **Docs**: mark the polars output engine experimental in `docs/aggregation.md` and on the canonical `lazy_multiindex` engine docstring (which `sweep_diff` / `mc_convergence` defer to).

## Test plan

- [ ] Full pytest suite — 756 passed locally.
- [ ] `ruff check`, `ruff format --check`, `mypy` — clean (the one pre-existing `tests/test_backends_mpi.py` mypy error is unchanged on `main`).
- [ ] Coverage gates: `aggregate.py` 95%, overall 96%.
- [ ] Eyeball the docs admonition renders on `mkdocs serve` (or wait for the gh-pages build on merge).

Closes #130