### PR TITLE
Manifest: fsync cadence knob, streaming load, BOM hash, migration shim, line-numbered errors

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -81,6 +81,27 @@ exit with code `4` and a "pip install gmat-sweep[…]" message on stderr.
 Unknown kwargs surface the same way — they reach the pool constructor and
 are rejected there.
 
+## Manifest fsync cadence
+
+Every sweep-running subcommand (`run`, `monte-carlo`, `latin-hypercube`,
+`explicit`, `extend`, `resume`) accepts two flags that control how often
+the manifest is fsynced:
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `--fsync-each` / `--no-fsync-each` | `--fsync-each` | When set, the manifest is fsynced after every appended entry — strict per-run durability. Pass `--no-fsync-each` to amortise the fsync cost across batches. |
+| `--fsync-batch N` | `50` | Fsync interval (in entries) when `--no-fsync-each` is set. Ignored otherwise. |
+
+`--no-fsync-each` is a measurable speedup for sub-second runs at large
+counts (Monte Carlo dispersion sweeps, parameter scans where each run
+takes <100 ms) where the per-entry fsync would otherwise dominate the
+driver thread. The tradeoff: a host crash between fsync boundaries can
+leave up to `--fsync-batch - 1` recently-completed entries missing from
+the on-disk manifest. The per-run Parquet outputs and the script hash
+are unaffected, and `gmat-sweep resume` re-runs only the missing slice.
+See [Manifest schema § Fsync cadence and durability](manifest-schema.md#fsync-cadence-and-durability)
+for the full contract.
+
 ## Exit codes
 
 | Code | Meaning                                                                        |
@@ -309,7 +330,12 @@ manifest` message on stderr.
 ### Exit codes
 
 A missing or unparseable manifest, or a `--run N` for an `N` not in the
-manifest, exits with code `3`.
+manifest, exits with code `3`. An unparseable manifest's error message
+includes the file path and the 1-indexed line number that failed to
+parse — e.g. `gmat-sweep: manifest entry on line 42 is malformed: ...
+(./sweep/manifest.jsonl:42)` — so the offending line can be located
+without re-parsing the file by hand. Whole-file failures (empty file,
+header-line truncation) print just the path.
 
 ## `archive`
 

--- a/docs/manifest-schema.md
+++ b/docs/manifest-schema.md
@@ -95,9 +95,11 @@ These keep loading: the dispatch in
 
 `script_sha256` is computed by
 [`canonical_script_sha256()`][gmat_sweep.canonical_script_sha256], which
-normalises line endings (`\r\n` and lone `\r` → `\n`) and trims trailing
-newlines to exactly one before hashing. Two clones of the same script
-checked out under different line-ending settings produce identical hashes.
+normalises a leading UTF-8 byte-order mark (`﻿`), line endings
+(`\r\n` and lone `\r` → `\n`), and trailing newlines (trimmed to exactly
+one) before hashing. The same `.script` saved from a BOM-emitting
+Windows editor and from a Linux editor without a BOM produces identical
+hashes; same for two clones with different `core.autocrlf` settings.
 
 ## Entry fields
 
@@ -146,16 +148,30 @@ against the sweep's `output_dir`.
 
 ## Loading a manifest back
 
+[`Manifest.load`][gmat_sweep.Manifest.load] materialises every entry
+into the returned manifest's `entries` list, deduplicated last-wins per
+`run_id`. For tail-only operations on large manifests
+(`gmat-sweep resume` against a 10k-run sweep, "what failed?" queries),
+prefer the streaming primitives — they parse the file lazily and never
+hold every entry in memory.
+
 ```python
 from pathlib import Path
 from gmat_sweep import Manifest
 
-manifest = Manifest.load(Path("./sweep/manifest.jsonl"))
+manifest_path = Path("./sweep/manifest.jsonl")
+
+# Eager load: full entries list, deduplicated.
+manifest = Manifest.load(manifest_path)
 print(manifest.script_sha256, manifest.run_count, len(manifest.entries))
 
-# Find runs that need attention:
-failed_ids = manifest.find_failed()                       # [list of run_id]
-missing_ids = manifest.find_missing(range(manifest.run_count))
+# Streaming tail-only scans (do not materialise the entry list):
+failed_ids = Manifest.find_failed(manifest_path)
+missing_ids = Manifest.find_missing(manifest_path, range(manifest.run_count))
+
+# Lazy iteration if you need each entry but not all at once:
+for entry in Manifest.iter_entries(manifest_path):
+    ...
 ```
 
 ## CLI summary
@@ -170,19 +186,49 @@ $ gmat-sweep show ./sweep/manifest.jsonl
 
 ## Append-only invariant
 
-The manifest is written **append-only with fsync after every entry**:
+The manifest is written **append-only**:
 
 - The header is written once, then never touched.
 - Each [`Manifest.append_entry()`][gmat_sweep.Manifest.append_entry] call
-  writes one line and `fsync`s the file (and, on POSIX, the parent
-  directory) before returning.
+  writes one line; whether the line is fsynced before the call returns
+  depends on the manifest's [fsync cadence](#fsync-cadence-and-durability).
 
-A `Ctrl-C`, OOM kill, or `kill -9` can lose only the in-flight write —
-every entry that returned successfully from `append_entry` is durable.
 [`Manifest.load()`][gmat_sweep.Manifest.load] silently tolerates a single
 torn last line; anything more corrupted raises
 [`ManifestCorruptError`][gmat_sweep.ManifestCorruptError] with the offending
-file's path attached.
+file's path attached, and a `line_number` attribute set to the 1-indexed
+line that failed to parse (or `None` for whole-file failures such as an
+empty file). `gmat-sweep show`'s error output surfaces both.
+
+## Fsync cadence and durability
+
+Two knobs on [`Manifest`][gmat_sweep.Manifest] (and forwarded by every
+sweep-running entry point) control how often the manifest is fsynced:
+
+| Knob | Default | Effect |
+|------|---------|--------|
+| `fsync_each` | `True` | Every appended entry is fsynced before `append_entry` returns. Strict per-run durability — a `Ctrl-C`, OOM kill, or `kill -9` can lose only the in-flight write. |
+| `fsync_batch` | `50` | When `fsync_each=False`, the manifest is fsynced only every Nth entry (and once on [`Manifest.close()`][gmat_sweep.Manifest.close], called at end-of-sweep). |
+
+The default (`fsync_each=True`) preserves the v0.3 strict-per-entry
+behaviour. Opt into `fsync_each=False` when sub-second runs at large
+counts make the per-entry fsync the dominant cost in the driver thread —
+typical for 1000+ Monte Carlo or grid sweeps with cheap per-run work.
+
+**Tradeoff.** With `fsync_each=False` and `fsync_batch=N`, a host crash
+between fsync boundaries (power loss, kernel panic) can leave up to
+`N - 1` recently-appended entries missing from the on-disk manifest.
+The per-run Parquet files and the script hash are unaffected — the
+[resume flow](resume.md) re-runs only the missing slice. `Ctrl-C`
+mid-sweep deliberately skips the end-of-sweep `close()` so the same
+recovery window applies; the resume flow handles the gap.
+
+The CLI exposes the knob on every sweep-running subcommand as
+`--fsync-each / --no-fsync-each` and `--fsync-batch N`. The Python API
+accepts `fsync_each=` and `fsync_batch=` on
+[`sweep`][gmat_sweep.sweep], [`monte_carlo`][gmat_sweep.monte_carlo],
+[`latin_hypercube`][gmat_sweep.latin_hypercube], and
+[`monte_carlo_extend`][gmat_sweep.monte_carlo_extend].
 
 ## Last-wins merge on load
 
@@ -255,3 +301,12 @@ A `schema_version` bump is a coordinated change: the writer side
 emits the new value and the reader side learns to interpret the new
 shape. Older `gmat-sweep` versions stop accepting bumped manifests
 on the read side, which is the point of the version field.
+
+**Migration ladder.** [`Manifest.load`][gmat_sweep.Manifest.load] routes
+every header through an internal `_migrate_header(data, from_version)`
+shim before constructing the in-memory manifest. Today the shim is a
+pass-through for `v1 → v1`; the ladder exists so that when v2 ships,
+the per-version migration step (renames, splits, default backfills)
+lands in one place and v1 manifests keep loading unchanged. Major bumps
+are one-shot migrations applied on read; minor additive fields do not
+go through the shim.

--- a/docs/resume.md
+++ b/docs/resume.md
@@ -60,10 +60,12 @@ one row per `(run, time-step)` pair, plus a `__status` column.
 
 ## Last-wins entry semantics
 
-The manifest is **append-only with `fsync` after every entry** (see
-[Manifest schema](manifest-schema.md#append-only-invariant)). A resumed
-run appends a new entry with the **same `run_id`** as the original
-failed entry. The on-disk file then carries two lines for that
+The manifest is **append-only** (see
+[Manifest schema](manifest-schema.md#append-only-invariant); fsync
+cadence is configurable, see
+[Fsync cadence and durability](manifest-schema.md#fsync-cadence-and-durability)).
+A resumed run appends a new entry with the **same `run_id`** as the
+original failed entry. The on-disk file then carries two lines for that
 `run_id` — one `failed`, one `ok`.
 
 [`Manifest.load`][gmat_sweep.Manifest.load] folds these last-wins:
@@ -76,6 +78,14 @@ content survives, kept in the position of the first occurrence. So:
 - The on-disk file remains append-only — older entries are never
   rewritten or deleted, so a `Ctrl-C` during resume still leaves a
   parseable file.
+
+Resume itself walks the manifest with
+[`Manifest.find_failed(path)`][gmat_sweep.Manifest.find_failed] and
+[`Manifest.find_missing(path, ...)`][gmat_sweep.Manifest.find_missing] —
+both are streaming classmethods that scan the file lazily, fold per-`run_id`
+last-wins state into a small dict, and never materialise the full entry
+list. A 10k-run resume's failed/missing scan therefore allocates
+proportional to the number of unique `run_id`s, not the file length.
 
 A manifest from a sweep that never resumed has unique `run_id`s per
 entry, so the dedup is a no-op there.
@@ -114,10 +124,11 @@ checkout.
 
 [`resume()`][gmat_sweep.Sweep.resume] submits the union of:
 
-- `manifest.find_failed()` — entries whose latest status is `failed`.
-- `manifest.find_missing(expected_run_ids)` — `run_id`s the rebuilt
-  run iterable carries that have no entry on disk yet (the tail of a
-  `Ctrl-C`'d sweep).
+- `Manifest.find_failed(manifest_path)` — entries whose latest status
+  is `failed`.
+- `Manifest.find_missing(manifest_path, expected_run_ids)` — `run_id`s
+  the rebuilt run iterable carries that have no entry on disk yet (the
+  tail of a `Ctrl-C`'d sweep).
 
 Successful runs are skipped; their Parquet outputs are reused from
 their original `output_paths`. `skipped` runs (worker contract: the

--- a/src/gmat_sweep/api.py
+++ b/src/gmat_sweep/api.py
@@ -52,6 +52,8 @@ def sweep(
     out: str | Path | None = ...,
     seed: int | None = ...,
     progress: bool = ...,
+    fsync_each: bool = ...,
+    fsync_batch: int = ...,
     engine: Literal["pandas"] = ...,
 ) -> pd.DataFrame: ...
 @overload
@@ -64,6 +66,8 @@ def sweep(
     out: str | Path | None = ...,
     seed: int | None = ...,
     progress: bool = ...,
+    fsync_each: bool = ...,
+    fsync_batch: int = ...,
     engine: Literal["polars"],
 ) -> pl.DataFrame: ...
 @overload
@@ -76,6 +80,8 @@ def sweep(
     out: str | Path | None = ...,
     seed: int | None = ...,
     progress: bool = ...,
+    fsync_each: bool = ...,
+    fsync_batch: int = ...,
     engine: str,
 ) -> DataFrame: ...
 def sweep(
@@ -87,6 +93,8 @@ def sweep(
     out: str | Path | None = None,
     seed: int | None = None,
     progress: bool = True,
+    fsync_each: bool = True,
+    fsync_batch: int = 50,
     engine: str = "pandas",
 ) -> DataFrame:
     """Run a parameter sweep over a GMAT mission.
@@ -145,6 +153,17 @@ def sweep(
         runs complete. Set to ``False`` for non-interactive use (CI logs,
         notebooks committed with outputs) where the progress bar would
         otherwise be captured as noisy stderr snapshots.
+    fsync_each:
+        ``True`` (default) fsyncs the manifest after every appended
+        entry — strict per-run durability, matching the v0.3 behaviour.
+        Set to ``False`` to amortise the fsync cost across batches of
+        ``fsync_batch`` entries; useful for sub-second runs at large
+        counts where the per-entry fsync would otherwise dominate the
+        driver thread. Forwarded verbatim to :class:`Sweep`; see
+        :class:`Sweep` for the full durability tradeoff.
+    fsync_batch:
+        Fsync interval (in entries) when ``fsync_each`` is ``False``.
+        Default ``50``. Ignored when ``fsync_each`` is ``True``.
     engine:
         ``"pandas"`` (default) returns a ``(run_id, time)``-MultiIndexed
         :class:`pandas.DataFrame`. ``"polars"`` returns a
@@ -217,6 +236,8 @@ def sweep(
         out=out,
         progress=progress,
         engine=engine,
+        fsync_each=fsync_each,
+        fsync_batch=fsync_batch,
     )
 
 
@@ -230,6 +251,8 @@ def monte_carlo(
     backend: Pool | None = ...,
     out: str | Path | None = ...,
     progress: bool = ...,
+    fsync_each: bool = ...,
+    fsync_batch: int = ...,
     engine: Literal["pandas"] = ...,
 ) -> pd.DataFrame: ...
 @overload
@@ -242,6 +265,8 @@ def monte_carlo(
     backend: Pool | None = ...,
     out: str | Path | None = ...,
     progress: bool = ...,
+    fsync_each: bool = ...,
+    fsync_batch: int = ...,
     engine: Literal["polars"],
 ) -> pl.DataFrame: ...
 @overload
@@ -254,6 +279,8 @@ def monte_carlo(
     backend: Pool | None = ...,
     out: str | Path | None = ...,
     progress: bool = ...,
+    fsync_each: bool = ...,
+    fsync_batch: int = ...,
     engine: str,
 ) -> DataFrame: ...
 def monte_carlo(
@@ -265,6 +292,8 @@ def monte_carlo(
     backend: Pool | None = None,
     out: str | Path | None = None,
     progress: bool = True,
+    fsync_each: bool = True,
+    fsync_batch: int = 50,
     engine: str = "pandas",
 ) -> DataFrame:
     """Run a Monte Carlo dispersion sweep over a GMAT mission.
@@ -340,6 +369,8 @@ def monte_carlo(
         out=out,
         progress=progress,
         engine=engine,
+        fsync_each=fsync_each,
+        fsync_batch=fsync_batch,
     )
 
 
@@ -353,6 +384,8 @@ def latin_hypercube(
     backend: Pool | None = ...,
     out: str | Path | None = ...,
     progress: bool = ...,
+    fsync_each: bool = ...,
+    fsync_batch: int = ...,
     engine: Literal["pandas"] = ...,
 ) -> pd.DataFrame: ...
 @overload
@@ -365,6 +398,8 @@ def latin_hypercube(
     backend: Pool | None = ...,
     out: str | Path | None = ...,
     progress: bool = ...,
+    fsync_each: bool = ...,
+    fsync_batch: int = ...,
     engine: Literal["polars"],
 ) -> pl.DataFrame: ...
 @overload
@@ -377,6 +412,8 @@ def latin_hypercube(
     backend: Pool | None = ...,
     out: str | Path | None = ...,
     progress: bool = ...,
+    fsync_each: bool = ...,
+    fsync_batch: int = ...,
     engine: str,
 ) -> DataFrame: ...
 def latin_hypercube(
@@ -388,6 +425,8 @@ def latin_hypercube(
     backend: Pool | None = None,
     out: str | Path | None = None,
     progress: bool = True,
+    fsync_each: bool = True,
+    fsync_batch: int = 50,
     engine: str = "pandas",
 ) -> DataFrame:
     """Run a Latin hypercube sweep over a GMAT mission.
@@ -459,6 +498,8 @@ def latin_hypercube(
         out=out,
         progress=progress,
         engine=engine,
+        fsync_each=fsync_each,
+        fsync_batch=fsync_batch,
     )
 
 
@@ -471,6 +512,8 @@ def monte_carlo_extend(
     backend: Pool | None = ...,
     allow_script_drift: bool = ...,
     progress: bool = ...,
+    fsync_each: bool = ...,
+    fsync_batch: int = ...,
     engine: Literal["pandas"] = ...,
 ) -> pd.DataFrame: ...
 @overload
@@ -482,6 +525,8 @@ def monte_carlo_extend(
     backend: Pool | None = ...,
     allow_script_drift: bool = ...,
     progress: bool = ...,
+    fsync_each: bool = ...,
+    fsync_batch: int = ...,
     engine: Literal["polars"],
 ) -> pl.DataFrame: ...
 @overload
@@ -493,6 +538,8 @@ def monte_carlo_extend(
     backend: Pool | None = ...,
     allow_script_drift: bool = ...,
     progress: bool = ...,
+    fsync_each: bool = ...,
+    fsync_batch: int = ...,
     engine: str,
 ) -> DataFrame: ...
 def monte_carlo_extend(
@@ -503,6 +550,8 @@ def monte_carlo_extend(
     backend: Pool | None = None,
     allow_script_drift: bool = False,
     progress: bool = True,
+    fsync_each: bool = True,
+    fsync_batch: int = 50,
     engine: str = "pandas",
 ) -> DataFrame:
     """Append ``n`` more bit-deterministic Monte Carlo runs to an existing sweep.
@@ -575,6 +624,8 @@ def monte_carlo_extend(
             backend=pool,
             allow_script_drift=allow_script_drift,
             progress=progress,
+            fsync_each=fsync_each,
+            fsync_batch=fsync_batch,
         ).extend(n=n)
         return sweep_obj.to_dataframe(engine=engine)
 
@@ -634,6 +685,8 @@ def _run_sweep(
     out: str | Path | None,
     progress: bool,
     engine: str,
+    fsync_each: bool = True,
+    fsync_batch: int = 50,
 ) -> DataFrame:
     """Shared orchestration for the public entry points.
 
@@ -674,6 +727,8 @@ def _run_sweep(
                 parameter_spec=parameter_spec,
                 sweep_seed=sweep_seed,
                 progress=progress,
+                fsync_each=fsync_each,
+                fsync_batch=fsync_batch,
             )
             .run()
             .to_dataframe(engine=engine)

--- a/src/gmat_sweep/cli.py
+++ b/src/gmat_sweep/cli.py
@@ -284,7 +284,14 @@ def _cmd_run(args: argparse.Namespace) -> int:
 
     out = Path(args.out)
     with _build_pool(args) as pool:
-        sweep(script, grid=grid, backend=pool, out=out)
+        sweep(
+            script,
+            grid=grid,
+            backend=pool,
+            out=out,
+            fsync_each=args.fsync_each,
+            fsync_batch=args.fsync_batch,
+        )
 
     manifest = Manifest.load(out / "manifest.jsonl")
     print(_format_summary(manifest, out))
@@ -437,6 +444,8 @@ def _cmd_monte_carlo(args: argparse.Namespace) -> int:
             seed=args.seed,
             backend=pool,
             out=out,
+            fsync_each=args.fsync_each,
+            fsync_batch=args.fsync_batch,
         )
 
     manifest = Manifest.load(out / "manifest.jsonl")
@@ -460,6 +469,8 @@ def _cmd_latin_hypercube(args: argparse.Namespace) -> int:
             seed=args.seed,
             backend=pool,
             out=out,
+            fsync_each=args.fsync_each,
+            fsync_batch=args.fsync_batch,
         )
 
     manifest = Manifest.load(out / "manifest.jsonl")
@@ -476,7 +487,14 @@ def _cmd_explicit(args: argparse.Namespace) -> int:
     samples = _load_samples(Path(args.samples))
     out = Path(args.out)
     with _build_pool(args) as pool:
-        sweep(script, samples=samples, backend=pool, out=out)
+        sweep(
+            script,
+            samples=samples,
+            backend=pool,
+            out=out,
+            fsync_each=args.fsync_each,
+            fsync_batch=args.fsync_batch,
+        )
 
     manifest = Manifest.load(out / "manifest.jsonl")
     print(_format_summary(manifest, out))
@@ -529,6 +547,8 @@ def _cmd_extend(args: argparse.Namespace) -> int:
             n=args.n,
             backend=pool,
             allow_script_drift=args.allow_script_drift,
+            fsync_each=args.fsync_each,
+            fsync_batch=args.fsync_batch,
         )
 
     manifest = Manifest.load(manifest_path)
@@ -555,10 +575,38 @@ def _cmd_resume(args: argparse.Namespace) -> int:
             script,
             backend=pool,
             allow_script_drift=args.allow_script_drift,
+            fsync_each=args.fsync_each,
+            fsync_batch=args.fsync_batch,
         ).resume()
 
     print(_format_summary(sweep_obj.to_manifest(), manifest_path.parent))
     return EXIT_OK
+
+
+def _add_fsync_flags(subparser: argparse.ArgumentParser) -> None:
+    """Attach ``--fsync-each`` / ``--no-fsync-each`` and ``--fsync-batch`` to a subparser."""
+    subparser.add_argument(
+        "--fsync-each",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Fsync the manifest after every appended entry (default: --fsync-each). "
+            "Pass --no-fsync-each to amortise fsyncs across batches of "
+            "--fsync-batch entries — faster for sub-second runs at large counts, "
+            "at the cost of losing up to FSYNC_BATCH-1 trailing entries on host "
+            "crash. The resume flow re-runs the missing slice."
+        ),
+    )
+    subparser.add_argument(
+        "--fsync-batch",
+        type=int,
+        default=50,
+        metavar="N",
+        help=(
+            "Fsync interval (in entries) when --no-fsync-each is set. "
+            "Ignored when --fsync-each is in effect. Default: 50."
+        ),
+    )
 
 
 def _add_backend_flag(subparser: argparse.ArgumentParser) -> None:
@@ -636,6 +684,7 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Path to the GMAT .script file.",
     )
     _add_backend_flag(run)
+    _add_fsync_flags(run)
     run.set_defaults(func=_cmd_run)
 
     show = subparsers.add_parser(
@@ -734,6 +783,7 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Path to the GMAT .script file.",
     )
     _add_backend_flag(monte)
+    _add_fsync_flags(monte)
     monte.set_defaults(func=_cmd_monte_carlo)
 
     lhs = subparsers.add_parser(
@@ -790,6 +840,7 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Path to the GMAT .script file.",
     )
     _add_backend_flag(lhs)
+    _add_fsync_flags(lhs)
     lhs.set_defaults(func=_cmd_latin_hypercube)
 
     explicit = subparsers.add_parser(
@@ -826,6 +877,7 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Path to the GMAT .script file.",
     )
     _add_backend_flag(explicit)
+    _add_fsync_flags(explicit)
     explicit.set_defaults(func=_cmd_explicit)
 
     extend = subparsers.add_parser(
@@ -878,6 +930,7 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     _add_backend_flag(extend)
+    _add_fsync_flags(extend)
     extend.set_defaults(func=_cmd_extend)
 
     resume = subparsers.add_parser(
@@ -920,6 +973,7 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     _add_backend_flag(resume)
+    _add_fsync_flags(resume)
     resume.set_defaults(func=_cmd_resume)
 
     archive = subparsers.add_parser(
@@ -986,7 +1040,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"gmat-sweep: {exc}", file=sys.stderr)
         return EXIT_CONFIG
     except ManifestCorruptError as exc:
-        print(f"gmat-sweep: {exc} ({exc.path})", file=sys.stderr)
+        location = f"{exc.path}:{exc.line_number}" if exc.line_number is not None else str(exc.path)
+        print(f"gmat-sweep: {exc} ({location})", file=sys.stderr)
         return EXIT_MANIFEST
     except BackendError as exc:
         print(f"gmat-sweep: backend error: {exc}", file=sys.stderr)

--- a/src/gmat_sweep/errors.py
+++ b/src/gmat_sweep/errors.py
@@ -68,9 +68,14 @@ class ManifestCorruptError(GmatSweepError):
     """Raised when a sweep manifest cannot be parsed.
 
     The ``path`` attribute points at the offending file so callers can
-    surface it in error messages without re-deriving the path.
+    surface it in error messages without re-deriving the path. The
+    optional ``line_number`` attribute is the 1-indexed line in the file
+    that failed to parse — set by :meth:`gmat_sweep.Manifest.load` when the
+    failure is localised to one line, ``None`` for whole-file failures
+    (e.g. an empty file).
     """
 
-    def __init__(self, message: str, path: Path) -> None:
+    def __init__(self, message: str, path: Path, line_number: int | None = None) -> None:
         self.path = path
+        self.line_number = line_number
         super().__init__(message)

--- a/src/gmat_sweep/manifest.py
+++ b/src/gmat_sweep/manifest.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
@@ -58,14 +58,17 @@ compatibility policy that governs future bumps.
 
 
 def canonical_script_sha256(script_path: Path) -> str:
-    """SHA-256 of the script file after line-ending and trailing-newline normalisation.
+    """SHA-256 of the script file after BOM, line-ending, and trailing-newline normalisation.
 
-    Reads the file as bytes, decodes as UTF-8, replaces ``\\r\\n`` and
-    lone ``\\r`` with ``\\n``, and ensures exactly one trailing ``\\n``.
-    The hash is computed over the resulting UTF-8 bytes.
+    Reads the file as bytes, decodes as UTF-8, strips a leading UTF-8
+    byte-order mark (``\\ufeff``), replaces ``\\r\\n`` and lone ``\\r``
+    with ``\\n``, and ensures exactly one trailing ``\\n``. The hash is
+    computed over the resulting UTF-8 bytes — a script saved from a
+    BOM-emitting Windows editor and the same script saved without a
+    BOM produce identical hashes.
     """
     raw = script_path.read_bytes().decode("utf-8")
-    text = raw.replace("\r\n", "\n").replace("\r", "\n")
+    text = raw.lstrip("﻿").replace("\r\n", "\n").replace("\r", "\n")
     canonical = text.rstrip("\n") + "\n"
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
@@ -176,6 +179,23 @@ class Manifest:
     backend: str = "unknown"
     schema_version: int = MANIFEST_SCHEMA_VERSION
     entries: list[ManifestEntry] = field(default_factory=list)
+    fsync_each: bool = field(default=True, compare=False)
+    """When ``True`` (default), every :meth:`append_entry` fsyncs the file.
+
+    Set to ``False`` and tune :attr:`fsync_batch` to amortise the fsync
+    cost across a batch of entries — useful for sub-second runs at large
+    counts where the per-entry fsync dominates the driver's time. The
+    durability tradeoff is documented in ``docs/manifest-schema.md`` and
+    on :meth:`append_entry`. Not serialised — this is a per-process
+    knob, not part of the on-disk format.
+    """
+    fsync_batch: int = field(default=50, compare=False)
+    """Fsync interval (in entries) when :attr:`fsync_each` is ``False``.
+
+    With ``fsync_each=False``, :meth:`append_entry` fsyncs after every
+    ``fsync_batch`` entries (and :meth:`close` fsyncs the tail). Has no
+    effect when ``fsync_each=True``.
+    """
     _path: Path | None = field(default=None, init=False, repr=False, compare=False)
 
     def _header_dict(self) -> dict[str, Any]:
@@ -192,6 +212,31 @@ class Manifest:
             "run_count": self.run_count,
             "backend": self.backend,
         }
+
+    @classmethod
+    def _migrate_header(cls, data: dict[str, Any], from_version: int, path: Path) -> dict[str, Any]:
+        """Migrate a header dict from ``from_version`` to :data:`MANIFEST_SCHEMA_VERSION`.
+
+        Pass-through for ``from_version == MANIFEST_SCHEMA_VERSION``.
+        The ladder exists so a future schema bump has a single place to
+        register a per-version migration step — when v2 lands, the v1 →
+        v2 transformation goes here and :meth:`load` keeps working
+        unchanged on v1 manifests.
+
+        ``path`` is forwarded only for error reporting if the ladder is
+        ever asked for a migration that hasn't been written.
+        """
+        if from_version == MANIFEST_SCHEMA_VERSION:
+            return data
+        # Future v1 → v2 (and beyond) migrations chain here. Reaching this
+        # branch with no path raises so an unimplemented schema bump fails
+        # loudly rather than silently producing a malformed Manifest.
+        raise ManifestCorruptError(
+            f"no migration path from manifest schema_version={from_version} "
+            f"to current version {MANIFEST_SCHEMA_VERSION}",
+            path,
+            line_number=1,
+        )
 
     @classmethod
     def _header_from_dict(cls, data: dict[str, Any]) -> Manifest:
@@ -230,90 +275,223 @@ class Manifest:
         self._path = path
 
     def append_entry(self, entry: ManifestEntry) -> None:
-        """Append one entry to the bound file with fsync, and to the in-memory list."""
+        """Append one entry to the bound file, and to the in-memory list.
+
+        With :attr:`fsync_each` ``True`` (default), every appended entry
+        is fsynced before this method returns — strict per-entry
+        durability, matching the v0.3 behaviour. With ``fsync_each``
+        ``False``, the file is fsynced only on the boundary set by
+        :attr:`fsync_batch` (every Nth entry); the tail is not durable
+        until :meth:`close` is called or the next batch boundary is
+        crossed. A host crash between fsync boundaries can therefore
+        lose up to ``fsync_batch - 1`` recently-appended entries — the
+        Parquet outputs and the runs themselves are unaffected, and the
+        resume flow re-runs only the missing slice.
+        """
         if self._path is None:
             raise RuntimeError(
                 "Manifest.append_entry requires a path — call save() or load() first."
             )
         line = json.dumps(entry.to_dict(), sort_keys=True) + "\n"
+        # Compute durability boundary against the count *after* this append
+        # so the very first entry doesn't trigger a fsync on the
+        # ``len(entries) + 1 == 1`` edge case when ``fsync_batch`` divides 1.
+        new_count = len(self.entries) + 1
+        should_fsync = self.fsync_each or (new_count % max(1, self.fsync_batch) == 0)
         with open(self._path, "a", encoding="utf-8") as f:
             f.write(line)
             f.flush()
-            os.fsync(f.fileno())
+            if should_fsync:
+                os.fsync(f.fileno())
         self.entries.append(entry)
+
+    def close(self) -> None:
+        """Fsync the manifest file and parent directory.
+
+        Idempotent and a no-op when the manifest has no bound path
+        (i.e. neither :meth:`save` nor :meth:`load` has been called).
+        Sweeps that opt into :attr:`fsync_each` ``False`` should call
+        this on successful completion so the trailing batch of entries
+        becomes durable; a ``KeyboardInterrupt`` deliberately skips
+        ``close()`` so the resume flow exercises the
+        ``fsync_batch - 1``-entry recovery window.
+        """
+        if self._path is None:
+            return
+        with open(self._path, "a", encoding="utf-8") as f:
+            os.fsync(f.fileno())
+        _fsync_dir(self._path.parent)
 
     @classmethod
     def load(cls, path: Path) -> Manifest:
-        """Load a manifest from disk, tolerating a single torn final line."""
+        """Load a manifest from disk, tolerating a single torn final line.
+
+        Materialises every entry into the returned :class:`Manifest`'s
+        :attr:`entries` list, deduplicated last-wins per ``run_id``.
+        For tail-only operations on large manifests prefer
+        :meth:`iter_entries`, :meth:`find_failed`, or
+        :meth:`find_missing` — they stream the file without holding
+        every entry in memory.
+        """
         path = Path(path)
-        with open(path, encoding="utf-8") as f:
-            raw = f.read()
-
-        if not raw:
-            raise ManifestCorruptError("manifest file is empty", path)
-
-        # Split on '\n' and drop the last element. For a clean
-        # newline-terminated file this drops the trailing empty string; for a
-        # torn write (missing trailing newline) it drops the partial line.
-        complete_lines = raw.split("\n")[:-1]
-
-        if not complete_lines:
-            raise ManifestCorruptError("manifest header line missing", path)
-
-        try:
-            header_data = json.loads(complete_lines[0])
-        except json.JSONDecodeError as exc:
-            raise ManifestCorruptError(f"manifest header is not valid JSON: {exc}", path) from exc
-
-        # v0.1 manifests omit schema_version; treat as 1. Anything strictly
-        # greater than the running gmat-sweep's supported version is unparseable
-        # by definition — newer schemas may have changed semantics on existing
-        # fields, and we cannot tell from here which fields are still safe.
-        try:
-            schema_version = int(header_data.get("schema_version", 1))
-        except (TypeError, ValueError) as exc:
-            raise ManifestCorruptError(
-                f"manifest schema_version is not an integer: {header_data.get('schema_version')!r}",
-                path,
-            ) from exc
-        if schema_version > MANIFEST_SCHEMA_VERSION:
-            raise ManifestCorruptError(
-                f"manifest schema_version={schema_version} is newer than this gmat-sweep supports",
-                path,
-            )
-
-        try:
-            manifest = cls._header_from_dict(header_data)
-        except (KeyError, TypeError, ValueError) as exc:
-            raise ManifestCorruptError(f"manifest header is missing fields: {exc}", path) from exc
-
+        manifest, entries_iter = cls._load_header_and_entries_iter(path)
         # Last-wins per run_id: a resumed run appends a new entry with the
         # same run_id as the original failed entry. We keep only the last
         # occurrence's content but preserve the position of the first
         # occurrence so unique-run_id manifests load in file order unchanged.
         by_run_id: dict[int, ManifestEntry] = {}
-        for i, line in enumerate(complete_lines[1:], start=2):
-            try:
-                entry_data = json.loads(line)
-                entry = ManifestEntry.from_dict(entry_data)
-            except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
-                raise ManifestCorruptError(
-                    f"manifest entry on line {i} is malformed: {exc}", path
-                ) from exc
+        for entry in entries_iter:
             by_run_id[entry.run_id] = entry
         manifest.entries.extend(by_run_id.values())
-
         manifest._path = path
         return manifest
 
-    def find_failed(self) -> list[int]:
-        """Return run_ids of entries with status ``failed``, in arrival order."""
-        return [e.run_id for e in self.entries if e.status == "failed"]
+    @classmethod
+    def iter_entries(cls, path: Path) -> Iterator[ManifestEntry]:
+        """Stream parsed entries from disk, lazily, without folding duplicates.
 
-    def find_missing(self, expected_run_ids: Iterable[int]) -> list[int]:
-        """Return run_ids in ``expected_run_ids`` with no entry recorded, in input order."""
-        present = {e.run_id for e in self.entries}
+        Yields one :class:`ManifestEntry` per non-header line in file
+        order; tolerates a single torn final line the same way
+        :meth:`load` does (a partial trailing line is silently dropped).
+        Validates the header (schema version, required fields) before
+        the first yield, raising :class:`ManifestCorruptError` with
+        ``line_number=1`` on header failures and ``line_number=i`` on
+        per-line failures.
+
+        Use this for tail-only scans (per-``run_id`` last-status folds,
+        membership checks) where holding every entry in memory would be
+        wasteful — :meth:`find_failed` and :meth:`find_missing` are
+        built on top. Use :meth:`load` when you need the
+        deduplicated, fully-materialised entry list.
+        """
+        _, entries_iter = cls._load_header_and_entries_iter(Path(path))
+        yield from entries_iter
+
+    @classmethod
+    def find_failed(cls, path: Path) -> list[int]:
+        """Return ``run_id``s whose latest entry has ``status == "failed"``, in first-seen order.
+
+        Streams ``path`` via :meth:`iter_entries` and folds per-``run_id``
+        last-wins state into a small dict — does not materialise the
+        full entry list. Result matches ``[e.run_id for e in
+        Manifest.load(path).entries if e.status == "failed"]`` while
+        running in O(entries) time and O(unique run_ids) memory.
+        """
+        last_status: dict[int, RunStatus] = {}
+        first_seen_order: list[int] = []
+        for entry in cls.iter_entries(Path(path)):
+            if entry.run_id not in last_status:
+                first_seen_order.append(entry.run_id)
+            last_status[entry.run_id] = entry.status
+        return [rid for rid in first_seen_order if last_status[rid] == "failed"]
+
+    @classmethod
+    def find_missing(cls, path: Path, expected_run_ids: Iterable[int]) -> list[int]:
+        """Return ``run_id``s in ``expected_run_ids`` with no entry on disk, in input order."""
+        present: set[int] = set()
+        for entry in cls.iter_entries(Path(path)):
+            present.add(entry.run_id)
         return [rid for rid in expected_run_ids if rid not in present]
+
+    @classmethod
+    def _load_header_and_entries_iter(cls, path: Path) -> tuple[Manifest, Iterator[ManifestEntry]]:
+        """Parse and migrate the header, then return the manifest plus a lazy entry iterator.
+
+        Shared core of :meth:`load` and :meth:`iter_entries` — the header
+        parse and schema-version handling are identical; only the
+        downstream consumption (dedup-into-memory vs. yield-as-you-go)
+        differs. The entries iterator owns the open file handle and
+        closes it on exhaustion.
+        """
+        path = Path(path)
+        # Header is small; read it eagerly so schema validation can fail
+        # before we hand the iterator to the caller. Entries are read
+        # lazily by ``_iter_entries_from_open_file``.
+        f = open(path, encoding="utf-8")  # noqa: SIM115 — closed by the entries iterator
+        try:
+            first_line = f.readline()
+            if not first_line:
+                raise ManifestCorruptError("manifest file is empty", path)
+            if not first_line.endswith("\n"):
+                # The only line in the file has no trailing \n — torn header.
+                raise ManifestCorruptError("manifest header line missing", path, line_number=1)
+            try:
+                header_data = json.loads(first_line)
+            except json.JSONDecodeError as exc:
+                raise ManifestCorruptError(
+                    f"manifest header is not valid JSON: {exc}", path, line_number=1
+                ) from exc
+
+            # v0.1 manifests omit schema_version; treat as 1. Anything strictly
+            # greater than the running gmat-sweep's supported version is unparseable
+            # by definition — newer schemas may have changed semantics on existing
+            # fields, and we cannot tell from here which fields are still safe.
+            try:
+                schema_version = int(header_data.get("schema_version", 1))
+            except (TypeError, ValueError) as exc:
+                raise ManifestCorruptError(
+                    f"manifest schema_version is not an integer: "
+                    f"{header_data.get('schema_version')!r}",
+                    path,
+                    line_number=1,
+                ) from exc
+            if schema_version > MANIFEST_SCHEMA_VERSION:
+                raise ManifestCorruptError(
+                    f"manifest schema_version={schema_version} "
+                    f"is newer than this gmat-sweep supports",
+                    path,
+                    line_number=1,
+                )
+
+            migrated = cls._migrate_header(header_data, schema_version, path)
+
+            try:
+                manifest = cls._header_from_dict(migrated)
+            except (KeyError, TypeError, ValueError) as exc:
+                raise ManifestCorruptError(
+                    f"manifest header is missing fields: {exc}", path, line_number=1
+                ) from exc
+        except BaseException:
+            f.close()
+            raise
+
+        return manifest, cls._iter_entries_from_open_file(f, path)
+
+    @staticmethod
+    def _iter_entries_from_open_file(f: Any, path: Path) -> Iterator[ManifestEntry]:
+        """Yield entries from an open file positioned past the header.
+
+        Buffers one line ahead so a torn final line (no trailing ``\\n``)
+        can be detected and silently dropped — matches :meth:`load`'s
+        ``raw.split("\\n")[:-1]`` torn-tail tolerance. Closes the file on
+        exhaustion or exception.
+        """
+        try:
+            prev_line: str | None = None
+            prev_line_no = 0
+            line_no = 1  # header was line 1
+            for line in f:
+                line_no += 1
+                if prev_line is not None:
+                    yield Manifest._parse_entry_line(prev_line, path, prev_line_no)
+                prev_line = line
+                prev_line_no = line_no
+            if prev_line is not None and prev_line.endswith("\n"):
+                yield Manifest._parse_entry_line(prev_line, path, prev_line_no)
+        finally:
+            f.close()
+
+    @staticmethod
+    def _parse_entry_line(line: str, path: Path, line_no: int) -> ManifestEntry:
+        try:
+            entry_data = json.loads(line)
+            return ManifestEntry.from_dict(entry_data)
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+            raise ManifestCorruptError(
+                f"manifest entry on line {line_no} is malformed: {exc}",
+                path,
+                line_number=line_no,
+            ) from exc
 
     @property
     def extension_run_count(self) -> int:

--- a/src/gmat_sweep/sweep.py
+++ b/src/gmat_sweep/sweep.py
@@ -88,6 +88,22 @@ class Sweep:
         :class:`gmat_sweep.errors.BackendError`. Pass :data:`True` together
         with the matching flag on the pool to opt in to in-process,
         single-run debug dispatch.
+    fsync_each:
+        Forwarded to :class:`Manifest`. ``True`` (default) preserves the
+        v0.3 strict-per-entry fsync cadence — every appended entry is
+        durable before the next run is dispatched. ``False`` defers
+        fsyncs to ``fsync_batch``-entry boundaries plus the
+        end-of-sweep :meth:`Manifest.close`; on a host crash between
+        boundaries up to ``fsync_batch - 1`` recently-completed entries
+        can be lost from the on-disk manifest, but the per-run Parquet
+        outputs and the script hash are unaffected and the resume flow
+        re-runs only the missing slice. A ``KeyboardInterrupt`` mid-sweep
+        deliberately skips ``close()`` so the same recovery window
+        applies to user-aborted sweeps.
+    fsync_batch:
+        Forwarded to :class:`Manifest`. Number of entries between
+        fsyncs when ``fsync_each`` is ``False``. Ignored when
+        ``fsync_each`` is ``True``.
     """
 
     def __init__(
@@ -102,6 +118,8 @@ class Sweep:
         sweep_seed: int | None = None,
         progress: bool = True,
         allow_unisolated_pool: bool = False,
+        fsync_each: bool = True,
+        fsync_batch: int = 50,
     ) -> None:
         if backend.subprocess_isolated is not True and not allow_unisolated_pool:
             raise BackendError(
@@ -110,6 +128,8 @@ class Sweep:
                 "pass allow_unisolated_pool=True to acknowledge in-process or "
                 "otherwise unisolated dispatch."
             )
+        if fsync_batch < 1:
+            raise SweepConfigError(f"fsync_batch must be >= 1, got {fsync_batch}")
         self._runs: list[RunSpec] = list(runs)
         self._backend = backend
         self._manifest_path = Path(manifest_path)
@@ -118,6 +138,8 @@ class Sweep:
         self._parameter_spec: dict[str, Any] = dict(parameter_spec)
         self._sweep_seed = sweep_seed
         self._progress = progress
+        self._fsync_each = fsync_each
+        self._fsync_batch = fsync_batch
         self._manifest: Manifest | None = None
         # Set by :meth:`from_manifest`. Gates :meth:`resume` so a freshly-
         # constructed Sweep can't accidentally append onto an unrelated file.
@@ -160,6 +182,12 @@ class Sweep:
                 )
                 manifest.append_entry(entry)
                 progress_bar.update(1)
+            # close() only on normal completion: KeyboardInterrupt and any
+            # other exception fall through to the finally and skip the
+            # final fsync, which is what makes ``fsync_each=False`` honour
+            # its documented "up to fsync_batch-1 entries lost on crash"
+            # window. Resume picks up the slack.
+            manifest.close()
         finally:
             progress_bar.close()
 
@@ -174,6 +202,8 @@ class Sweep:
         backend: Pool,
         allow_script_drift: bool = False,
         progress: bool = True,
+        fsync_each: bool = True,
+        fsync_batch: int = 50,
     ) -> Sweep:
         """Rebuild a :class:`Sweep` from a manifest written by a prior run.
 
@@ -205,6 +235,11 @@ class Sweep:
         progress:
             Forwarded to the constructor — controls the :mod:`tqdm` bar in
             :meth:`resume`.
+        fsync_each, fsync_batch:
+            Forwarded to the constructor; control the manifest's fsync
+            cadence on the appended resume / extend entries. The on-disk
+            manifest's existing entries are not affected — these knobs
+            govern only the writes the returned sweep performs.
 
         Raises
         ------
@@ -253,7 +288,14 @@ class Sweep:
             parameter_spec=manifest.parameter_spec,
             sweep_seed=manifest.sweep_seed,
             progress=progress,
+            fsync_each=fsync_each,
+            fsync_batch=fsync_batch,
         )
+        # The loaded manifest's cadence knobs default to the on-disk-agnostic
+        # ``True`` / ``50``; align them with the freshly-constructed Sweep so
+        # the next ``append_entry`` honours the caller's choice.
+        manifest.fsync_each = fsync_each
+        manifest.fsync_batch = fsync_batch
         sweep._manifest = manifest
         sweep._loaded_from_manifest = True
         return sweep
@@ -275,8 +317,11 @@ class Sweep:
         manifest = self._manifest
 
         expected_run_ids = [s.run_id for s in self._runs]
-        to_retry: set[int] = set(manifest.find_failed()) | set(
-            manifest.find_missing(expected_run_ids)
+        # Stream the on-disk manifest for the failed/missing scan so a
+        # 10k-run resume doesn't pay 10k JSON parses against an
+        # in-memory entry list it never reads from again.
+        to_retry: set[int] = set(Manifest.find_failed(self._manifest_path)) | set(
+            Manifest.find_missing(self._manifest_path, expected_run_ids)
         )
         specs_by_run_id: dict[int, RunSpec] = {s.run_id: s for s in self._runs}
         runs_to_submit: list[RunSpec] = [specs_by_run_id[rid] for rid in sorted(to_retry)]
@@ -300,6 +345,7 @@ class Sweep:
                 )
                 manifest.append_entry(entry)
                 progress_bar.update(1)
+            manifest.close()
         finally:
             progress_bar.close()
 
@@ -345,8 +391,8 @@ class Sweep:
 
         # Refuse on a torn base — extending past gaps would mix run_ids in a
         # way the aggregated DataFrame can't recover from.
-        gaps_failed = [rid for rid in manifest.find_failed() if rid < old_n]
-        gaps_missing = manifest.find_missing(range(old_n))
+        gaps_failed = [rid for rid in Manifest.find_failed(self._manifest_path) if rid < old_n]
+        gaps_missing = Manifest.find_missing(self._manifest_path, range(old_n))
         if gaps_failed or gaps_missing:
             details = []
             if gaps_failed:
@@ -397,6 +443,7 @@ class Sweep:
                 )
                 manifest.append_entry(entry)
                 progress_bar.update(1)
+            manifest.close()
         finally:
             progress_bar.close()
 
@@ -601,6 +648,8 @@ class Sweep:
             parameter_spec=self._parameter_spec,
             run_count=len(self._runs),
             backend=self._backend.__class__.__name__,
+            fsync_each=self._fsync_each,
+            fsync_batch=self._fsync_batch,
         )
 
 

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -245,8 +245,7 @@ def test_failed_runs_are_packed_without_parquet_with_stderr_intact(
         progress=False,
     )
 
-    pre = Manifest.load(out / "manifest.jsonl")
-    failed = pre.find_failed()
+    failed = Manifest.find_failed(out / "manifest.jsonl")
     assert len(failed) == 1
     failed_run_id = failed[0]
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -447,70 +447,76 @@ def test_load_dedup_no_op_when_run_ids_unique(tmp_path: Path) -> None:
     assert reloaded.entries == m.entries
 
 
-def test_find_failed_after_resume_excludes_recovered_run_ids(tmp_path: Path) -> None:
-    """After dedup, find_failed only surfaces run_ids whose LAST entry is failed."""
+def _saved_manifest(tmp_path: Path, entries: list[ManifestEntry]) -> Path:
+    """Write a fresh manifest with ``entries`` to ``tmp_path/manifest.jsonl``, return the path."""
     m = _make_manifest()
     path = tmp_path / "manifest.jsonl"
     m.save(path)
-    m.append_entry(_make_entry(run_id=0, status="failed"))
-    m.append_entry(_make_entry(run_id=1, status="failed"))
-    m.append_entry(_make_entry(run_id=0, status="ok"))  # recovered on resume
-
-    reloaded = Manifest.load(path)
-    assert reloaded.find_failed() == [1]
+    for entry in entries:
+        m.append_entry(entry)
+    return path
 
 
-def test_find_failed_returns_failed_run_ids_in_order() -> None:
-    m = _make_manifest()
-    m.entries = [
-        _make_entry(0, status="ok"),
-        _make_entry(1, status="failed"),
-        _make_entry(2, status="ok"),
-        _make_entry(3, status="failed"),
-        _make_entry(4, status="skipped"),
-    ]
-    assert m.find_failed() == [1, 3]
+def test_find_failed_after_resume_excludes_recovered_run_ids(tmp_path: Path) -> None:
+    """After dedup, find_failed only surfaces run_ids whose LAST entry is failed."""
+    path = _saved_manifest(
+        tmp_path,
+        [
+            _make_entry(run_id=0, status="failed"),
+            _make_entry(run_id=1, status="failed"),
+            _make_entry(run_id=0, status="ok"),  # recovered on resume
+        ],
+    )
+    assert Manifest.find_failed(path) == [1]
 
 
-def test_find_failed_empty_when_all_ok() -> None:
-    m = _make_manifest()
-    m.entries = [_make_entry(0), _make_entry(1)]
-    assert m.find_failed() == []
+def test_find_failed_returns_failed_run_ids_in_order(tmp_path: Path) -> None:
+    path = _saved_manifest(
+        tmp_path,
+        [
+            _make_entry(0, status="ok"),
+            _make_entry(1, status="failed"),
+            _make_entry(2, status="ok"),
+            _make_entry(3, status="failed"),
+            _make_entry(4, status="skipped"),
+        ],
+    )
+    assert Manifest.find_failed(path) == [1, 3]
 
 
-def test_find_failed_returns_all_when_all_failed() -> None:
-    m = _make_manifest()
-    m.entries = [_make_entry(i, status="failed") for i in range(3)]
-    assert m.find_failed() == [0, 1, 2]
+def test_find_failed_empty_when_all_ok(tmp_path: Path) -> None:
+    path = _saved_manifest(tmp_path, [_make_entry(0), _make_entry(1)])
+    assert Manifest.find_failed(path) == []
 
 
-def test_find_failed_skipped_runs_are_not_failed() -> None:
-    m = _make_manifest()
-    m.entries = [_make_entry(0, status="skipped")]
-    assert m.find_failed() == []
+def test_find_failed_returns_all_when_all_failed(tmp_path: Path) -> None:
+    path = _saved_manifest(tmp_path, [_make_entry(i, status="failed") for i in range(3)])
+    assert Manifest.find_failed(path) == [0, 1, 2]
 
 
-def test_find_missing_preserves_input_order() -> None:
-    m = _make_manifest()
-    m.entries = [_make_entry(0), _make_entry(2), _make_entry(4)]
-    assert m.find_missing([4, 3, 2, 1, 0]) == [3, 1]
+def test_find_failed_skipped_runs_are_not_failed(tmp_path: Path) -> None:
+    path = _saved_manifest(tmp_path, [_make_entry(0, status="skipped")])
+    assert Manifest.find_failed(path) == []
 
 
-def test_find_missing_empty_input_returns_empty() -> None:
-    m = _make_manifest()
-    m.entries = [_make_entry(0)]
-    assert m.find_missing([]) == []
+def test_find_missing_preserves_input_order(tmp_path: Path) -> None:
+    path = _saved_manifest(tmp_path, [_make_entry(0), _make_entry(2), _make_entry(4)])
+    assert Manifest.find_missing(path, [4, 3, 2, 1, 0]) == [3, 1]
 
 
-def test_find_missing_all_present_returns_empty() -> None:
-    m = _make_manifest()
-    m.entries = [_make_entry(0), _make_entry(1)]
-    assert m.find_missing([0, 1]) == []
+def test_find_missing_empty_input_returns_empty(tmp_path: Path) -> None:
+    path = _saved_manifest(tmp_path, [_make_entry(0)])
+    assert Manifest.find_missing(path, []) == []
 
 
-def test_find_missing_none_present_returns_all() -> None:
-    m = _make_manifest()
-    assert m.find_missing([0, 1, 2]) == [0, 1, 2]
+def test_find_missing_all_present_returns_empty(tmp_path: Path) -> None:
+    path = _saved_manifest(tmp_path, [_make_entry(0), _make_entry(1)])
+    assert Manifest.find_missing(path, [0, 1]) == []
+
+
+def test_find_missing_none_present_returns_all(tmp_path: Path) -> None:
+    path = _saved_manifest(tmp_path, [])
+    assert Manifest.find_missing(path, [0, 1, 2]) == [0, 1, 2]
 
 
 # ---- canonical_script_sha256 --------------------------------------------
@@ -706,3 +712,239 @@ def test_load_drops_unknown_extra_header_fields(tmp_path: Path) -> None:
     assert reloaded.script_sha256 == m.script_sha256
     assert reloaded.run_count == m.run_count
     assert [e.run_id for e in reloaded.entries] == [0]
+
+
+# ---- BOM-stable canonical script hash ------------------------------------
+
+
+def test_canonical_hash_strips_leading_bom(tmp_path: Path) -> None:
+    """A script saved by a BOM-emitting Windows editor must hash equal to the BOM-less copy."""
+    body = b"Create Spacecraft Sat;\nSat.SMA = 7000;\n"
+    plain = _write_script(tmp_path, "plain.script", body)
+    bom = _write_script(tmp_path, "bom.script", b"\xef\xbb\xbf" + body)
+    assert canonical_script_sha256(bom) == canonical_script_sha256(plain)
+
+
+def test_canonical_hash_strips_bom_with_crlf_endings(tmp_path: Path) -> None:
+    """BOM stripping composes with line-ending normalisation."""
+    body = "Sat.SMA = 7000;\nSat.ECC = 0;\n"
+    plain = _write_script(tmp_path, "plain.script", body.encode("utf-8"))
+    bom_crlf = _write_script(
+        tmp_path, "bom_crlf.script", b"\xef\xbb\xbf" + body.replace("\n", "\r\n").encode("utf-8")
+    )
+    assert canonical_script_sha256(bom_crlf) == canonical_script_sha256(plain)
+
+
+# ---- Streaming iter_entries ----------------------------------------------
+
+
+def test_iter_entries_yields_every_entry_in_file_order(tmp_path: Path) -> None:
+    path = _saved_manifest(
+        tmp_path,
+        [_make_entry(0), _make_entry(1, status="failed"), _make_entry(2)],
+    )
+    yielded = list(Manifest.iter_entries(path))
+    assert [e.run_id for e in yielded] == [0, 1, 2]
+    assert [e.status for e in yielded] == ["ok", "failed", "ok"]
+
+
+def test_iter_entries_does_not_dedupe_duplicate_run_ids(tmp_path: Path) -> None:
+    """iter_entries is the streaming primitive — last-wins folding is the caller's job."""
+    path = _saved_manifest(
+        tmp_path,
+        [
+            _make_entry(0, status="failed"),
+            _make_entry(0, status="ok"),  # duplicate run_id
+            _make_entry(1),
+        ],
+    )
+    yielded = list(Manifest.iter_entries(path))
+    assert [(e.run_id, e.status) for e in yielded] == [(0, "failed"), (0, "ok"), (1, "ok")]
+
+
+def test_iter_entries_drops_torn_final_line(tmp_path: Path) -> None:
+    """Same torn-tail tolerance as Manifest.load."""
+    path = _saved_manifest(tmp_path, [_make_entry(0), _make_entry(1)])
+    raw = path.read_bytes()
+    truncated = raw.rstrip(b"\n")[: -len(b'"run_id": 1}') // 2]
+    path.write_bytes(truncated)
+
+    yielded = list(Manifest.iter_entries(path))
+    assert [e.run_id for e in yielded] == [0]
+
+
+def test_iter_entries_empty_file_raises(tmp_path: Path) -> None:
+    path = tmp_path / "empty.jsonl"
+    path.write_text("", encoding="utf-8")
+    with pytest.raises(ManifestCorruptError) as excinfo:
+        list(Manifest.iter_entries(path))
+    assert excinfo.value.path == path
+
+
+def test_iter_entries_malformed_entry_raises_with_line_number(tmp_path: Path) -> None:
+    path = _saved_manifest(tmp_path, [_make_entry(0)])
+    with open(path, "a", encoding="utf-8") as f:
+        f.write("{garbage}\n")
+    with pytest.raises(ManifestCorruptError) as excinfo:
+        list(Manifest.iter_entries(path))
+    assert excinfo.value.line_number == 3  # header=1, entry0=2, garbage=3
+
+
+# ---- ManifestCorruptError.line_number ------------------------------------
+
+
+def test_corrupt_error_line_number_set_on_entry_parse_failure(tmp_path: Path) -> None:
+    path = _saved_manifest(tmp_path, [_make_entry(0)])
+    with open(path, "a", encoding="utf-8") as f:
+        f.write("{not valid json}\n")
+    with pytest.raises(ManifestCorruptError) as excinfo:
+        Manifest.load(path)
+    assert excinfo.value.line_number == 3
+    assert excinfo.value.path == path
+
+
+def test_corrupt_error_line_number_set_on_header_failure(tmp_path: Path) -> None:
+    path = tmp_path / "bad.jsonl"
+    path.write_text("{not valid json\n", encoding="utf-8")
+    with pytest.raises(ManifestCorruptError) as excinfo:
+        Manifest.load(path)
+    assert excinfo.value.line_number == 1
+
+
+def test_corrupt_error_line_number_none_on_empty_file(tmp_path: Path) -> None:
+    """Empty file has no line to point at — line_number stays None."""
+    path = tmp_path / "empty.jsonl"
+    path.write_text("", encoding="utf-8")
+    with pytest.raises(ManifestCorruptError) as excinfo:
+        Manifest.load(path)
+    assert excinfo.value.line_number is None
+
+
+# ---- Schema-migration shim -----------------------------------------------
+
+
+def test_migrate_header_v1_to_v1_is_pass_through(tmp_path: Path) -> None:
+    """The shim exists so future bumps have a place to hang per-version steps;
+    today the v1 → v1 path returns the dict unchanged."""
+    m = _make_manifest()
+    header = m._header_dict()
+    migrated = Manifest._migrate_header(header, MANIFEST_SCHEMA_VERSION, tmp_path / "x.jsonl")
+    assert migrated is header  # identity pass-through
+
+
+def test_migrate_header_unknown_lower_version_raises_with_path(tmp_path: Path) -> None:
+    """If a hypothetical v0 manifest reaches the shim with no migration written,
+    we raise ManifestCorruptError with the path (not silently produce a malformed
+    Manifest). Today there are no lower versions, but the guard rail exists for
+    when there are."""
+    path = tmp_path / "manifest.jsonl"
+    with pytest.raises(ManifestCorruptError) as excinfo:
+        Manifest._migrate_header({}, from_version=0, path=path)
+    assert excinfo.value.path == path
+    assert excinfo.value.line_number == 1
+
+
+# ---- fsync cadence knob --------------------------------------------------
+
+
+def test_fsync_each_default_true_fsyncs_every_append(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import os as os_module
+
+    fsynced: list[int] = []
+    real_fsync = os_module.fsync
+
+    def fake_fsync(fd: int) -> None:
+        fsynced.append(fd)
+        real_fsync(fd)
+
+    monkeypatch.setattr("gmat_sweep.manifest.os.fsync", fake_fsync)
+
+    m = _make_manifest()
+    path = tmp_path / "manifest.jsonl"
+    m.save(path)
+    fsynced.clear()
+
+    for i in range(5):
+        m.append_entry(_make_entry(run_id=i))
+    assert len(fsynced) == 5  # one per append
+
+
+def test_fsync_each_false_fsyncs_only_on_batch_boundaries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import os as os_module
+
+    fsynced: list[int] = []
+    real_fsync = os_module.fsync
+
+    def fake_fsync(fd: int) -> None:
+        fsynced.append(fd)
+        real_fsync(fd)
+
+    monkeypatch.setattr("gmat_sweep.manifest.os.fsync", fake_fsync)
+
+    m = _make_manifest()
+    m.fsync_each = False
+    m.fsync_batch = 3
+    path = tmp_path / "manifest.jsonl"
+    m.save(path)
+    fsynced.clear()
+
+    # 7 appends with batch=3 should fsync at counts 3 and 6: 2 fsyncs total.
+    for i in range(7):
+        m.append_entry(_make_entry(run_id=i))
+    assert len(fsynced) == 2
+
+
+def test_fsync_each_false_close_flushes_tail(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """close() must fsync the file (and parent dir) so the trailing batch
+    becomes durable on normal shutdown."""
+    import os as os_module
+
+    fsynced: list[int] = []
+    real_fsync = os_module.fsync
+
+    def fake_fsync(fd: int) -> None:
+        fsynced.append(fd)
+        real_fsync(fd)
+
+    monkeypatch.setattr("gmat_sweep.manifest.os.fsync", fake_fsync)
+
+    m = _make_manifest()
+    m.fsync_each = False
+    m.fsync_batch = 100  # so no append triggers fsync
+    path = tmp_path / "manifest.jsonl"
+    m.save(path)
+    fsynced.clear()
+
+    for i in range(5):
+        m.append_entry(_make_entry(run_id=i))
+    assert fsynced == []  # batch boundary not reached
+
+    m.close()
+    assert len(fsynced) >= 1  # file fsync; parent dir fsync is best-effort
+
+
+def test_close_no_op_when_unbound() -> None:
+    """close() on a Manifest with no path is a silent no-op."""
+    m = _make_manifest()
+    m.close()  # must not raise
+
+
+def test_load_then_append_with_fsync_each_false_writes_durable_batches(tmp_path: Path) -> None:
+    """End-to-end: load a manifest, opt into batched fsyncs, append, and the
+    on-disk file is still parseable at every point (we just delay durability)."""
+    path = _saved_manifest(tmp_path, [_make_entry(0)])
+    m = Manifest.load(path)
+    m.fsync_each = False
+    m.fsync_batch = 4
+    for i in range(1, 5):
+        m.append_entry(_make_entry(run_id=i))
+    m.close()
+
+    reloaded = Manifest.load(path)
+    assert sorted(e.run_id for e in reloaded.entries) == [0, 1, 2, 3, 4]

--- a/tests/test_resume_roundtrip.py
+++ b/tests/test_resume_roundtrip.py
@@ -102,8 +102,7 @@ def test_16_run_grid_with_3_failures_resumes_to_all_ok(
         progress=False,
     )
 
-    first_pass = Manifest.load(out / "manifest.jsonl")
-    assert sorted(first_pass.find_failed()) == [3, 7, 11]
+    assert sorted(Manifest.find_failed(out / "manifest.jsonl")) == [3, 7, 11]
 
     # Patch the failure source out and resume.
     fake_gmat_run.install_loader(run_hook=_payload_run_hook())
@@ -168,8 +167,8 @@ def test_monte_carlo_resume_preserves_bit_equal_draws_for_failed_runs(
         progress=False,
     )
 
+    assert 3 in Manifest.find_failed(out / "manifest.jsonl")
     pre_resume = Manifest.load(out / "manifest.jsonl")
-    assert 3 in pre_resume.find_failed()
     pre_overrides = {e.run_id: e.overrides for e in pre_resume.entries}
 
     # Resume with no failure source.

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -790,8 +790,7 @@ def test_resume_acceptance_16_runs_with_3_failures(
         ).run()
 
     # Sanity: 3 failed in the first pass.
-    first_pass = Manifest.load(output_dir / "manifest.jsonl")
-    assert sorted(first_pass.find_failed()) == [3, 7, 11]
+    assert sorted(Manifest.find_failed(output_dir / "manifest.jsonl")) == [3, 7, 11]
 
     # Patch the override out, resume.
     fake_gmat_run.install_loader(run_hook=_payload_run_hook(rows=1))


### PR DESCRIPTION
## Summary

Five v0.4-review fixes on the manifest layer, plus the docs touches each one demanded.

- **fsync cadence knob.** `Manifest.fsync_each: bool = True` (default preserves v0.3 strict-per-entry durability) plus `fsync_batch: int = 50`. Set `fsync_each=False` to amortise fsyncs across batches, with `Manifest.close()` flushing the tail on successful sweep exit. Plumbed through `Sweep`, the four public api entry points, and every sweep-running CLI subcommand as `--fsync-each / --no-fsync-each` and `--fsync-batch N`. `KeyboardInterrupt` deliberately skips `close()` so the documented "up to `fsync_batch - 1` entries lost on host crash" recovery window also covers user-aborted sweeps — the resume flow picks up the missing slice.
- **Streaming manifest scans.** New `Manifest.iter_entries(path)` lazily yields parsed entries from disk; `Manifest.find_failed` / `find_missing` become classmethods taking a `path`, consume `iter_entries`, and fold per-`run_id` last-wins state into a small dict instead of materialising the full entry list. `gmat-sweep resume` on a 10k-run manifest no longer pays 10k JSON parses against an entry list it never reads. `Manifest.load` stays eager for the consumers that need every entry (`gmat-sweep show`, archive, aggregation).
- **BOM-stable canonical script hash.** `canonical_script_sha256` strips a leading UTF-8 BOM before line-ending normalisation so a `.script` saved from a BOM-emitting Windows editor and the same script saved without a BOM hash equal.
- **Schema-migration shim.** Header loads route through `Manifest._migrate_header(data, from_version, path)`. Today a no-op for v1 → v1; the ladder gives a future v2 bump a single place to hang per-version migration steps.
- **Line-numbered corrupt errors.** `ManifestCorruptError` gains `line_number: int | None` (1-indexed line that failed to parse, `None` for whole-file failures). `Manifest.load` and `iter_entries` set it on every line-localised raise; the CLI's top-level error handler prints `path:line` so the offending line is locatable without re-grepping.

### API break

`Manifest.find_failed()` and `Manifest.find_missing(...)` become classmethods taking a `path` argument. Pre-1.0 (0.3.0); the only public doc snippet that called the old form has been updated.

## Test plan

- [x] `uv run pytest` — 773 passed.
- [x] `uv run ruff check` — clean.
- [x] `uv run ruff format --check` — clean.
- [x] `uv run mkdocs build --strict` — clean (no broken cross-refs in the new sections).
- [ ] Benchmark on the synthetic 1000-run fixture to quantify the `fsync_each=False` speedup (not gated on this PR; happy to add a follow-up benchmark commit if wanted).

## Out of scope

- Bumping `MANIFEST_SCHEMA_VERSION` to 2 — the shim is for *future* bumps.
- Refactoring `Sweep.from_manifest` to skip the eager entry load — the issue explicitly kept `Manifest.load` eager.
- `CHANGELOG.md` — release-cut PRs aggregate the section.

Closes #131