### PR TITLE
Backends: uniform RunOutcome.failed on worker exceptions + drain round-trip cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ from gmat_sweep import LocalJoblibPool, sweep
 df = sweep(
     "mission.script",
     grid={"Sat.SMA": [7000, 7100, 7200]},
-    backend=LocalJoblibPool(workers=8),
+    backend=LocalJoblibPool(max_workers=8),
 )
 print(df)
 ```
@@ -109,7 +109,7 @@ df = monte_carlo(
     "mission.script",
     n=1000,
     perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
-    backend=LocalJoblibPool(workers=8),
+    backend=LocalJoblibPool(max_workers=8),
     seed=42,
 )
 ```

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -38,12 +38,13 @@ from gmat_sweep import LocalJoblibPool, sweep
 df = sweep(
     "mission.script",
     grid={"Sat.SMA": [7000.0, 7100.0, 7200.0, 7300.0]},
-    backend=LocalJoblibPool(workers=4),
+    backend=LocalJoblibPool(max_workers=4),
     out="./sweep",
 )
 ```
 
-`workers=-1` (the default) uses every core. See
+`max_workers=-1` (the default) uses every core. `workers=` is accepted as
+a deprecated alias and emits a `DeprecationWarning`. See
 [Choosing a backend](parameter-spec.md#choosing-a-backend) on the parameter
 spec page for the full set of LocalJoblibPool patterns (capping
 parallelism, sharing one pool across several sweeps).
@@ -74,6 +75,11 @@ That makes this the natural choice when avoiding the `joblib` runtime
 dependency matters; for a sweep where many runs share the same script,
 `LocalJoblibPool`'s reuse path amortises the bootstrap and finishes
 faster.
+
+`reuse_gmat_context` is accepted for `Pool` API parity but has no
+practical effect on this backend — `max_tasks_per_child=1` already gives
+every task a fresh interpreter, so both modes dispatch `run_one`
+directly without nesting through a second subprocess.
 
 ## `DaskPool` — `dask.distributed`
 
@@ -290,6 +296,16 @@ manifest with `status="failed"`, and the aggregated DataFrame gets one
 NaN-filled row with `__status="failed"`. The
 [killed-sweep recovery example](examples/03_killed_sweep_recovery.ipynb)
 shows the resume flow end-to-end.
+
+The same row-not-raise contract holds for *transport-level* failures
+that escape the worker entirely — a loky / Ray / Dask / MPI worker
+process dying mid-task, a `RayTaskError` from a remote-side raise,
+`BrokenProcessPool` from a `ProcessPoolExecutor` worker crash, an MPI
+rank disappearing under a `SIGSEGV`, a Kubernetes Pod evicted before it
+writes its outcome JSON. Every pool catches the exception at the drain
+site and folds it into a synthetic `RunOutcome.failed` whose `stderr`
+carries the captured traceback, so a single bad worker never aborts the
+sweep.
 
 ## Backend equivalence guarantee
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -43,7 +43,7 @@ Wall-clock seconds, median of three runs, min–max range in parentheses.
 
 | Backend | Median (s) | Min (s) | Max (s) |
 | --- | --- | --- | --- |
-| `LocalJoblibPool(workers=8)` | 11.93 | 11.02 | 12.37 |
+| `LocalJoblibPool(max_workers=8)` | 11.93 | 11.02 | 12.37 |
 | `DaskPool(n_workers=8)` (LocalCluster) | 13.55 | 13.30 | 14.48 |
 | `RayPool(num_cpus=8)` (local) | 14.06 | 13.71 | 14.68 |
 | `MPIPool(max_workers=8)` (`mpi4py.futures`, 9 ranks) | 12.64 | 12.54 | 13.01 |
@@ -53,7 +53,7 @@ Wall-clock seconds, median of three runs, min–max range in parentheses.
 
 | Backend | Runs/sec | Per-worker runs/sec |
 | --- | --- | --- |
-| `LocalJoblibPool(workers=8)` | 83.83 | 10.48 |
+| `LocalJoblibPool(max_workers=8)` | 83.83 | 10.48 |
 | `DaskPool(n_workers=8)` | 73.80 | 9.23 |
 | `RayPool(num_cpus=8)` | 71.11 | 8.89 |
 | `MPIPool(max_workers=8)` | 79.14 | 9.89 |

--- a/docs/examples/03_killed_sweep_recovery.ipynb
+++ b/docs/examples/03_killed_sweep_recovery.ipynb
@@ -477,7 +477,7 @@
     "from gmat_sweep import Sweep\n",
     "from gmat_sweep.backends.joblib import LocalJoblibPool\n",
     "\n",
-    "with LocalJoblibPool(workers=1) as pool:\n",
+    "with LocalJoblibPool(max_workers=1) as pool:\n",
     "    resumed_df = (\n",
     "        Sweep.from_manifest(\n",
     "            manifest_path,\n",

--- a/docs/examples/09_archive_bundle.ipynb
+++ b/docs/examples/09_archive_bundle.ipynb
@@ -146,7 +146,7 @@
     }
    ],
    "source": [
-    "with LocalJoblibPool(workers=1) as pool:\n",
+    "with LocalJoblibPool(max_workers=1) as pool:\n",
     "    sweep_obj = Sweep.from_manifest(out_dir / \"manifest.jsonl\", script_path, backend=pool)\n",
     "    bundle_path = sweep_obj.archive(out=out_dir / \"sweep_bundle.zip\")\n",
     "\n",

--- a/docs/monte-carlo.md
+++ b/docs/monte-carlo.md
@@ -179,7 +179,7 @@ df = monte_carlo(
         "Sat.DryMass": ("lognormal", math.log(1200.0), 0.02),
     },
     seed=20260504,
-    backend=LocalJoblibPool(workers=8),
+    backend=LocalJoblibPool(max_workers=8),
     out="./launch-dispersion",
 )
 

--- a/docs/parameter-spec.md
+++ b/docs/parameter-spec.md
@@ -335,7 +335,7 @@ core. Pass an explicit pool via `backend=` to:
     df = sweep(
         "mission.script",
         grid={"Sat.SMA": [7000.0, 7100.0, 7200.0, 7300.0]},
-        backend=LocalJoblibPool(workers=4),
+        backend=LocalJoblibPool(max_workers=4),
         out="./sweep",
     )
     ```
@@ -347,7 +347,7 @@ core. Pass an explicit pool via `backend=` to:
     ```python
     from gmat_sweep import LocalJoblibPool, monte_carlo, sweep
 
-    with LocalJoblibPool(workers=8) as pool:
+    with LocalJoblibPool(max_workers=8) as pool:
         baseline = sweep(
             "mission.script",
             grid={"Sat.DryMass": [100.0, 150.0, 200.0]},

--- a/docs/resume.md
+++ b/docs/resume.md
@@ -33,7 +33,7 @@ from pathlib import Path
 from gmat_sweep import Sweep
 from gmat_sweep.backends.joblib import LocalJoblibPool
 
-with LocalJoblibPool(workers=4) as pool:
+with LocalJoblibPool(max_workers=4) as pool:
     df = (
         Sweep.from_manifest(
             "./sweep/manifest.jsonl",

--- a/src/gmat_sweep/api.py
+++ b/src/gmat_sweep/api.py
@@ -128,7 +128,7 @@ def sweep(
         (default) constructs a fresh :class:`LocalJoblibPool` over every
         available core for the duration of the call and closes it on the way
         out. Pass an explicit pool to cap parallelism
-        (``LocalJoblibPool(workers=4)``), to use a different execution
+        (``LocalJoblibPool(max_workers=4)``), to use a different execution
         backend (Dask, Ray, a custom subclass), or to share one pool across
         several sweeps — when supplied, the caller owns the pool's lifecycle
         and ``sweep()`` does not call :meth:`Pool.close`.

--- a/src/gmat_sweep/backends/dask.py
+++ b/src/gmat_sweep/backends/dask.py
@@ -30,14 +30,26 @@ Submission semantics match :class:`gmat_sweep.backends.joblib.LocalJoblibPool`:
 :meth:`submit` parks the spec under a placeholder
 :class:`concurrent.futures.Future` and returns immediately; dispatch happens
 inside :meth:`as_completed`, which submits one Dask task per parked spec and
-drains via :func:`distributed.as_completed`.
+drains via :func:`distributed.as_completed` with ``with_results=True`` so
+the completion event and the result arrive in the same round-trip.
+
+Transport-failure semantics
+---------------------------
+
+A worker-side exception that escapes the task callable (Dask worker death,
+serialiser failure, …) is caught at the drain site — :meth:`as_completed`
+runs with ``raise_errors=False`` and folds the captured traceback into a
+synthetic :meth:`gmat_sweep.spec.RunOutcome.failed` so the parent sweep
+does not abort.
 """
 
 from __future__ import annotations
 
 import os
+import traceback
 from collections.abc import Iterable, Iterator
 from concurrent.futures import Future
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 from gmat_sweep.backends._subprocess import run_spec_in_subprocess
@@ -138,6 +150,7 @@ class DaskPool(Pool):
 
         wanted = list(futures)
         future_by_run_id: dict[int, Future[RunOutcome]] = {}
+        run_id_by_dask_key: dict[Any, int] = {}
         dask_futures: list[Any] = []
         task_fn = run_one if self._reuse_gmat_context else _dask_run_one
         for f in wanted:
@@ -147,10 +160,24 @@ class DaskPool(Pool):
                     "Future was not submitted to this pool, or has already been drained"
                 )
             future_by_run_id[spec.run_id] = f
-            dask_futures.append(self._client.submit(task_fn, spec, pure=False))
+            dask_future = self._client.submit(task_fn, spec, pure=False)
+            dask_futures.append(dask_future)
+            run_id_by_dask_key[dask_future.key] = spec.run_id
 
-        for dask_future in self._distributed.as_completed(dask_futures):
-            outcome: RunOutcome = dask_future.result()
+        # ``with_results=True`` pulls the result in the same round-trip as
+        # the completion event, instead of issuing a separate ``.result()``
+        # per future.
+        for dask_future, payload in self._distributed.as_completed(
+            dask_futures, with_results=True, raise_errors=False
+        ):
+            run_id = run_id_by_dask_key[dask_future.key]
+            if isinstance(payload, RunOutcome):
+                outcome = payload
+            else:
+                # ``raise_errors=False`` hands us the exception instance as
+                # the payload when the task raised. Fold into a synthetic
+                # RunOutcome.failed so the sweep does not abort.
+                outcome = _failed_outcome(run_id, "".join(traceback.format_exception(payload)))
             f = future_by_run_id.pop(outcome.run_id)
             f.set_result(outcome)
             yield outcome
@@ -168,3 +195,8 @@ class DaskPool(Pool):
                 self._client.close()
             if self._owns_cluster and self._cluster is not None:
                 self._cluster.close()
+
+
+def _failed_outcome(run_id: int, stderr: str) -> RunOutcome:
+    now = datetime.now(timezone.utc)
+    return RunOutcome.failed(run_id=run_id, stderr=stderr, started_at=now, ended_at=now)

--- a/src/gmat_sweep/backends/joblib.py
+++ b/src/gmat_sweep/backends/joblib.py
@@ -15,9 +15,15 @@ Submission semantics:
   :func:`gmat_sweep.worker.run_one` (when ``reuse_gmat_context=True``) or
   :func:`gmat_sweep.backends._subprocess.run_spec_in_subprocess` (when
   ``reuse_gmat_context=False``), and yields :class:`RunOutcome` values in
-  completion order, marking each future done as it goes.
-- :meth:`close` exits the underlying ``Parallel`` context, terminating loky
-  workers, and cancels any still-pending futures.
+  completion order, marking each future done as it goes. A worker-side
+  exception that escapes the task callable (loky worker death, pickling
+  failure, …) is folded into a synthetic :meth:`RunOutcome.failed` carrying
+  the formatted traceback as ``stderr`` so the parent sweep does not abort
+  on a single transport failure.
+- :meth:`close` cancels any still-pending futures and then exits the
+  underlying ``Parallel`` context. Cancellation runs before the loky exit
+  so a parked future whose outcome loky is about to compute on the way out
+  is not silently dropped.
 
 See :class:`gmat_sweep.backends.base.Pool` for the semantics of
 ``reuse_gmat_context``.
@@ -25,8 +31,11 @@ See :class:`gmat_sweep.backends.base.Pool` for the semantics of
 
 from __future__ import annotations
 
+import traceback
+import warnings
 from collections.abc import Callable, Iterable, Iterator
 from concurrent.futures import Future
+from datetime import datetime, timezone
 
 import joblib
 
@@ -44,10 +53,14 @@ class LocalJoblibPool(Pool):
 
     Parameters
     ----------
-    workers:
+    max_workers:
         Number of loky worker processes. ``-1`` (the default) uses every
         available core. Any other negative value or ``0`` is rejected with
-        :class:`gmat_sweep.errors.BackendError`.
+        :class:`gmat_sweep.errors.BackendError`. ``workers=`` is accepted as
+        a deprecated alias.
+    workers:
+        Deprecated alias for ``max_workers=``. Emits a
+        :class:`DeprecationWarning`; will be removed in a future release.
     reuse_gmat_context:
         ``True`` (default) dispatches each task as
         :func:`gmat_sweep.worker.run_one`, which imports ``gmat_run`` once
@@ -61,18 +74,38 @@ class LocalJoblibPool(Pool):
         :class:`gmat_sweep.backends.base.Pool` for the contract.
     """
 
-    def __init__(self, workers: int = -1, *, reuse_gmat_context: bool = True) -> None:
-        if workers == 0 or workers < -1:
+    def __init__(
+        self,
+        max_workers: int | None = None,
+        *,
+        workers: int | None = None,
+        reuse_gmat_context: bool = True,
+    ) -> None:
+        if workers is not None and max_workers is not None:
             raise BackendError(
-                f"workers must be -1 (all cores) or a positive integer, got {workers!r}"
+                "pass either workers= or max_workers=, not both (workers= is the deprecated alias)"
             )
-        self._workers = workers
+        if workers is not None:
+            warnings.warn(
+                "LocalJoblibPool(workers=...) is deprecated and will be removed in "
+                "a future release; pass max_workers= instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            resolved = workers
+        else:
+            resolved = -1 if max_workers is None else max_workers
+        if resolved == 0 or resolved < -1:
+            raise BackendError(
+                f"max_workers must be -1 (all cores) or a positive integer, got {resolved!r}"
+            )
+        self._workers = resolved
         self._reuse_gmat_context = reuse_gmat_context
         self._pending: dict[Future[RunOutcome], RunSpec] = {}
         self._closed = False
         self._parallel = joblib.Parallel(
             backend="loky",
-            n_jobs=workers,
+            n_jobs=resolved,
             return_as="generator_unordered",
         )
         self._parallel.__enter__()
@@ -103,7 +136,29 @@ class LocalJoblibPool(Pool):
         task_fn: Callable[[RunSpec], RunOutcome] = (
             run_one if self._reuse_gmat_context else run_spec_in_subprocess
         )
-        for outcome in self._parallel(joblib.delayed(task_fn)(s) for s in specs):
+        gen = self._parallel(joblib.delayed(task_fn)(s) for s in specs)
+        while future_by_run_id:
+            try:
+                outcome = next(gen)
+            except StopIteration:
+                break
+            except Exception as exc:
+                # Worker-side transport failure (loky worker death, pickling
+                # error, …): the generator has raised before we could match
+                # an outcome to a run_id. Fold synthetic failures for every
+                # remaining run_id, carrying the captured traceback as
+                # ``stderr``. The Parallel context is unrecoverable after
+                # this point in ``generator_unordered`` mode, so we drain
+                # the leftover futures here rather than try to resume.
+                # KeyboardInterrupt deliberately is not caught — Ctrl-C
+                # should reach the driver.
+                stderr = "".join(traceback.format_exception(exc))
+                for run_id in list(future_by_run_id):
+                    f = future_by_run_id.pop(run_id)
+                    folded = _failed_outcome(run_id, stderr)
+                    f.set_result(folded)
+                    yield folded
+                return
             f = future_by_run_id.pop(outcome.run_id)
             f.set_result(outcome)
             yield outcome
@@ -113,8 +168,13 @@ class LocalJoblibPool(Pool):
             return
         self._closed = True
         try:
-            self._parallel.__exit__(None, None, None)
-        finally:
             for f in self._pending:
                 f.cancel()
             self._pending.clear()
+        finally:
+            self._parallel.__exit__(None, None, None)
+
+
+def _failed_outcome(run_id: int, stderr: str) -> RunOutcome:
+    now = datetime.now(timezone.utc)
+    return RunOutcome.failed(run_id=run_id, stderr=stderr, started_at=now, ended_at=now)

--- a/src/gmat_sweep/backends/mpi.py
+++ b/src/gmat_sweep/backends/mpi.py
@@ -45,13 +45,24 @@ Lifecycle
 ``MPIPool`` always owns the underlying ``MPIPoolExecutor``. :meth:`close`
 calls :meth:`MPIPoolExecutor.shutdown` with ``wait=True`` so worker-rank
 shutdown is bounded by the pool's context-manager exit.
+
+Transport-failure semantics
+---------------------------
+
+A worker-side exception that escapes the task callable — a generic
+``MPIException`` from a rank that ``SIGSEGV``-ed mid-task, a pickling
+failure, etc. — is caught at the drain site and folded into a synthetic
+:meth:`gmat_sweep.spec.RunOutcome.failed` carrying the formatted traceback
+as ``stderr`` so a single rank crash does not abort the sweep.
 """
 
 from __future__ import annotations
 
+import traceback
 from collections.abc import Iterable, Iterator
 from concurrent.futures import Future
 from concurrent.futures import as_completed as _futures_as_completed
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 from gmat_sweep.backends._subprocess import run_spec_in_subprocess
@@ -137,6 +148,7 @@ class MPIPool(Pool):
 
         wanted = list(futures)
         future_by_mpi_future: dict[Future[RunOutcome], Future[RunOutcome]] = {}
+        run_id_by_mpi_future: dict[Future[RunOutcome], int] = {}
         task_fn = run_one if self._reuse_gmat_context else _mpi_run_one_impl
         for f in wanted:
             spec = self._pending.pop(f, None)
@@ -146,10 +158,19 @@ class MPIPool(Pool):
                 )
             mpi_future = self._executor.submit(task_fn, spec)
             future_by_mpi_future[mpi_future] = f
+            run_id_by_mpi_future[mpi_future] = spec.run_id
 
         for mpi_future in _futures_as_completed(future_by_mpi_future):
-            outcome: RunOutcome = mpi_future.result()
             user_future = future_by_mpi_future[mpi_future]
+            run_id = run_id_by_mpi_future[mpi_future]
+            try:
+                outcome: RunOutcome = mpi_future.result()
+            except Exception as exc:
+                # Worker-side transport failure (rank crash, ``MPIException``
+                # from a SIGSEGV on a worker, pickling fault, …). Without
+                # this fold the rank-crash exception would propagate from
+                # ``.result()`` and abort the entire sweep.
+                outcome = _failed_outcome(run_id, "".join(traceback.format_exception(exc)))
             user_future.set_result(outcome)
             yield outcome
 
@@ -163,3 +184,8 @@ class MPIPool(Pool):
             self._pending.clear()
         finally:
             self._executor.shutdown(wait=True)
+
+
+def _failed_outcome(run_id: int, stderr: str) -> RunOutcome:
+    now = datetime.now(timezone.utc)
+    return RunOutcome.failed(run_id=run_id, stderr=stderr, started_at=now, ended_at=now)

--- a/src/gmat_sweep/backends/process_pool.py
+++ b/src/gmat_sweep/backends/process_pool.py
@@ -12,6 +12,22 @@ remains the default; ``ProcessPoolExecutorPool`` is opt-in via explicit
 construction. Pick it when avoiding the ``joblib`` runtime dep matters and
 the per-task gmatpy bootstrap cost is acceptable.
 
+Because ``max_tasks_per_child=1`` already gives every task a fresh
+interpreter, this backend dispatches each task as
+:func:`gmat_sweep.worker.run_one` directly regardless of
+``reuse_gmat_context``. The nested ``run_spec_in_subprocess`` hop that
+other backends use for the ``reuse_gmat_context=False`` mode would just
+double-pay the subprocess cost here without changing the contract.
+
+Transport-failure semantics
+---------------------------
+
+A worker-side exception that escapes :func:`gmat_sweep.worker.run_one`
+(``BrokenProcessPool`` on worker death, an unpicklable return value, …)
+is caught at the drain site and folded into a synthetic
+:meth:`gmat_sweep.spec.RunOutcome.failed` carrying the formatted traceback
+as ``stderr`` so the parent sweep does not abort.
+
 Python floor
 ------------
 
@@ -37,11 +53,12 @@ if not TYPE_CHECKING and sys.version_info < (3, 11):
         "use gmat_sweep.LocalJoblibPool on Python 3.10."
     )
 
-from collections.abc import Callable, Iterable, Iterator
+import traceback
+from collections.abc import Iterable, Iterator
 from concurrent.futures import Future, ProcessPoolExecutor
 from concurrent.futures import as_completed as _futures_as_completed
+from datetime import datetime, timezone
 
-from gmat_sweep.backends._subprocess import run_spec_in_subprocess
 from gmat_sweep.backends.base import Pool
 from gmat_sweep.errors import BackendError
 from gmat_sweep.spec import RunOutcome, RunSpec
@@ -67,14 +84,13 @@ class ProcessPoolExecutorPool(Pool):
         default) lets the executor pick — :func:`os.process_cpu_count`
         on Python 3.13+, :func:`os.cpu_count` on 3.11-3.12.
     reuse_gmat_context:
-        ``True`` (default) dispatches each task as
-        :func:`gmat_sweep.worker.run_one` directly inside the fresh worker
-        process — one gmatpy bootstrap per task (the worker is already
-        fresh thanks to ``max_tasks_per_child=1``). ``False`` dispatches
-        through :func:`gmat_sweep.backends._subprocess.run_spec_in_subprocess`,
-        spawning a *second* nested Python interpreter for the gmatpy load
-        — wasteful but contract-compliant. Same flag, same contract as
-        :class:`gmat_sweep.backends.base.Pool` documents.
+        Accepted for :class:`Pool` API parity. Both values dispatch each
+        task as :func:`gmat_sweep.worker.run_one` directly inside the
+        worker process — the ``max_tasks_per_child=1`` baked into the
+        executor already provides the per-task fresh-interpreter
+        guarantee the ``reuse_gmat_context=False`` contract requires.
+        Nested ``run_spec_in_subprocess`` hops on this backend would
+        double-pay the subprocess cost without changing the contract.
     """
 
     def __init__(
@@ -108,9 +124,7 @@ class ProcessPoolExecutorPool(Pool):
             raise BackendError("ProcessPoolExecutorPool is closed; cannot drain futures")
 
         wanted = list(futures)
-        task_fn: Callable[[RunSpec], RunOutcome] = (
-            run_one if self._reuse_gmat_context else run_spec_in_subprocess
-        )
+        executor_future_to_run_id: dict[Future[RunOutcome], int] = {}
         future_by_executor_future: dict[Future[RunOutcome], Future[RunOutcome]] = {}
         for f in wanted:
             spec = self._pending.pop(f, None)
@@ -118,12 +132,21 @@ class ProcessPoolExecutorPool(Pool):
                 raise BackendError(
                     "Future was not submitted to this pool, or has already been drained"
                 )
-            executor_future = self._executor.submit(task_fn, spec)
+            executor_future = self._executor.submit(run_one, spec)
             future_by_executor_future[executor_future] = f
+            executor_future_to_run_id[executor_future] = spec.run_id
 
         for executor_future in _futures_as_completed(future_by_executor_future):
-            outcome: RunOutcome = executor_future.result()
             user_future = future_by_executor_future[executor_future]
+            run_id = executor_future_to_run_id[executor_future]
+            try:
+                outcome: RunOutcome = executor_future.result()
+            except Exception as exc:
+                # Worker-side transport failure (BrokenProcessPool from
+                # worker death, unpicklable result, …). ``run_one`` itself
+                # already catches its own exceptions into RunOutcome.failed;
+                # anything that escapes here is a transport-level fault.
+                outcome = _failed_outcome(run_id, "".join(traceback.format_exception(exc)))
             user_future.set_result(outcome)
             yield outcome
 
@@ -137,3 +160,8 @@ class ProcessPoolExecutorPool(Pool):
             self._pending.clear()
         finally:
             self._executor.shutdown(wait=True)
+
+
+def _failed_outcome(run_id: int, stderr: str) -> RunOutcome:
+    now = datetime.now(timezone.utc)
+    return RunOutcome.failed(run_id=run_id, stderr=stderr, started_at=now, ended_at=now)

--- a/src/gmat_sweep/backends/ray.py
+++ b/src/gmat_sweep/backends/ray.py
@@ -39,12 +39,23 @@ store. :class:`RunSpec` is :func:`dataclasses.dataclass` with
 JSON-encodable fields, well within Ray's serialisation surface; values
 inside ``overrides`` and ``run_options`` must already be JSON-encodable
 per the v0.1 spec contract.
+
+Transport-failure semantics
+---------------------------
+
+A worker-side exception that escapes the remote task — ``RayTaskError``
+from a worker crash, a serialisation fault, … — is caught at the drain
+site (``ray.get`` in :meth:`as_completed`) and folded into a synthetic
+:meth:`gmat_sweep.spec.RunOutcome.failed` so the parent sweep does not
+abort on a single transport failure.
 """
 
 from __future__ import annotations
 
+import traceback
 from collections.abc import Iterable, Iterator
 from concurrent.futures import Future
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 from gmat_sweep.backends._subprocess import run_spec_in_subprocess
@@ -138,6 +149,7 @@ class RayPool(Pool):
 
         wanted = list(futures)
         future_by_run_id: dict[int, Future[RunOutcome]] = {}
+        run_id_by_ref: dict[Any, int] = {}
         object_refs: list[Any] = []
         for f in wanted:
             spec = self._pending.pop(f, None)
@@ -146,15 +158,30 @@ class RayPool(Pool):
                     "Future was not submitted to this pool, or has already been drained"
                 )
             future_by_run_id[spec.run_id] = f
-            object_refs.append(self._remote_run_one.remote(spec))
+            ref = self._remote_run_one.remote(spec)
+            object_refs.append(ref)
+            run_id_by_ref[ref] = spec.run_id
 
         unready: list[Any] = list(object_refs)
         while unready:
-            ready, unready = self._ray.wait(unready, num_returns=1)
-            outcome: RunOutcome = self._ray.get(ready[0])
-            f = future_by_run_id.pop(outcome.run_id)
-            f.set_result(outcome)
-            yield outcome
+            # ``fetch_local=True`` primes the local object store with the
+            # ready refs as part of the wait, so the per-ref ``ray.get``
+            # below is an in-store read rather than a second network
+            # round-trip. The old shape — ``wait(num_returns=1)`` then a
+            # separate ``ray.get(ready[0])`` — paid two trips per outcome.
+            ready, unready = self._ray.wait(unready, num_returns=1, fetch_local=True)
+            for ref in ready:
+                run_id = run_id_by_ref[ref]
+                try:
+                    outcome: RunOutcome = self._ray.get(ref)
+                except Exception as exc:
+                    # ``RayTaskError`` (a remote-side raise that escaped
+                    # ``run_one``) or a Ray transport error — fold into a
+                    # synthetic failed outcome so the sweep does not abort.
+                    outcome = _failed_outcome(run_id, "".join(traceback.format_exception(exc)))
+                f = future_by_run_id.pop(outcome.run_id)
+                f.set_result(outcome)
+                yield outcome
 
     def close(self) -> None:
         if self._closed:
@@ -167,3 +194,8 @@ class RayPool(Pool):
         finally:
             if self._owns_runtime:
                 self._ray.shutdown()
+
+
+def _failed_outcome(run_id: int, stderr: str) -> RunOutcome:
+    now = datetime.now(timezone.utc)
+    return RunOutcome.failed(run_id=run_id, stderr=stderr, started_at=now, ended_at=now)

--- a/src/gmat_sweep/cli.py
+++ b/src/gmat_sweep/cli.py
@@ -218,7 +218,7 @@ def _build_pool(args: argparse.Namespace) -> Pool:
                 "--backend-arg is not supported with --backend local; "
                 "the local pool only accepts --workers"
             )
-        return LocalJoblibPool(workers=args.workers)
+        return LocalJoblibPool(max_workers=args.workers)
     workers = args.workers if args.workers > 0 else None
     if args.backend == "dask":
         return DaskPool(n_workers=workers, **backend_kwargs)

--- a/tests/data/benchmark_sweep.py
+++ b/tests/data/benchmark_sweep.py
@@ -85,7 +85,7 @@ def build_pool(backend: Backend, workers: int) -> Pool:
     the local-backend benchmark.
     """
     if backend == "local":
-        return LocalJoblibPool(workers=workers)
+        return LocalJoblibPool(max_workers=workers)
     if backend == "dask":
         from gmat_sweep.backends.dask import DaskPool
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -43,7 +43,7 @@ def test_sweep_returns_multiindexed_dataframe(tmp_path: Path, fake_gmat_run: Fak
     df = sweep(
         script,
         grid={"Sat.SMA": [7000.0, 7100.0]},
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out,
     )
 
@@ -63,7 +63,7 @@ def test_sweep_writes_manifest_with_grid_in_header(
     sweep(
         script,
         grid={"Sat.SMA": [7000.0, 7100.0]},
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out,
         seed=42,
     )
@@ -86,7 +86,7 @@ def test_sweep_string_path_is_accepted(tmp_path: Path, fake_gmat_run: FakeGmatRu
     df = sweep(
         str(script),
         grid={"Sat.SMA": [7000.0]},
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out,
     )
 
@@ -102,7 +102,7 @@ def test_sweep_creates_out_directory_when_missing(
 
     fake_gmat_run.install_loader(run_hook=_payload_run_hook())
 
-    sweep(script, grid={"Sat.SMA": [7000.0]}, backend=LocalJoblibPool(workers=1), out=out)
+    sweep(script, grid={"Sat.SMA": [7000.0]}, backend=LocalJoblibPool(max_workers=1), out=out)
 
     assert out.is_dir()
     assert (out / "manifest.jsonl").exists()
@@ -121,7 +121,7 @@ def test_sweep_resolves_relative_out_to_absolute(
 
     fake_gmat_run.install_loader(run_hook=_payload_run_hook())
 
-    sweep(script, grid={"Sat.SMA": [7000.0]}, backend=LocalJoblibPool(workers=1), out="rel-out")
+    sweep(script, grid={"Sat.SMA": [7000.0]}, backend=LocalJoblibPool(max_workers=1), out="rel-out")
 
     manifest_path = tmp_path / "rel-out" / "manifest.jsonl"
     manifest = Manifest.load(manifest_path)
@@ -145,7 +145,7 @@ def test_sweep_with_no_out_returns_usable_dataframe(
     df = sweep(
         script,
         grid={"Sat.SMA": [7000.0]},
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=None,
     )
 
@@ -172,7 +172,7 @@ def test_sweep_with_no_out_cleans_up_temp_dir_after_df_dropped(
     script = _write_script(tmp_path)
     fake_gmat_run.install_loader(run_hook=_payload_run_hook())
 
-    df = sweep(script, grid={"Sat.SMA": [7000.0]}, backend=LocalJoblibPool(workers=1), out=None)
+    df = sweep(script, grid={"Sat.SMA": [7000.0]}, backend=LocalJoblibPool(max_workers=1), out=None)
 
     assert len(captured_paths) == 1
     sweep_dir = captured_paths[0]
@@ -202,7 +202,7 @@ def test_sweep_with_failing_run_includes_failed_row(
     df = sweep(
         script,
         grid={"Sat.SMA": [7000.0, 7100.0]},
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out,
     )
 
@@ -220,7 +220,7 @@ def test_sweep_with_empty_grid_runs_once(tmp_path: Path, fake_gmat_run: FakeGmat
 
     fake_gmat_run.install_loader(run_hook=_payload_run_hook())
 
-    df = sweep(script, grid={}, backend=LocalJoblibPool(workers=1), out=out)
+    df = sweep(script, grid={}, backend=LocalJoblibPool(max_workers=1), out=out)
 
     run_ids = sorted(df.index.get_level_values("run_id").unique().tolist())
     assert run_ids == [0]
@@ -246,7 +246,7 @@ def test_sweep_progress_false_quiet_on_stderr(
     sweep(
         script,
         grid={"Sat.SMA": [7000.0, 7100.0]},
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out,
         progress=False,
     )
@@ -264,12 +264,12 @@ def test_sweep_default_backend_constructs_local_joblib_pool(
 ) -> None:
     """When ``backend=`` is omitted, ``_run_sweep`` builds a LocalJoblibPool
     and dispatches through it. Verified by intercepting the constructor and
-    forcing ``workers=1`` so the fake ``gmat_run`` is visible to the
+    forcing ``max_workers=1`` so the fake ``gmat_run`` is visible to the
     in-process worker."""
     captured: list[LocalJoblibPool] = []
 
     def _intercept(*_args: Any, **_kwargs: Any) -> LocalJoblibPool:
-        instance = LocalJoblibPool(workers=1)
+        instance = LocalJoblibPool(max_workers=1)
         captured.append(instance)
         return instance
 
@@ -298,7 +298,7 @@ def test_sweep_user_supplied_backend_records_pool_class_name_on_manifest(
     class _CustomLabelPool(LocalJoblibPool):
         pass
 
-    with _CustomLabelPool(workers=1) as pool:
+    with _CustomLabelPool(max_workers=1) as pool:
         sweep(script, grid={"Sat.SMA": [7000.0]}, backend=pool, out=out)
 
     manifest = Manifest.load(out / "manifest.jsonl")
@@ -313,7 +313,7 @@ def test_sweep_user_supplied_backend_is_not_closed_by_sweep(
     script = _write_script(tmp_path)
     fake_gmat_run.install_loader(run_hook=_payload_run_hook())
 
-    pool = LocalJoblibPool(workers=1)
+    pool = LocalJoblibPool(max_workers=1)
     try:
         sweep(script, grid={"Sat.SMA": [7000.0]}, backend=pool, out=tmp_path / "out-a")
         # If sweep() had closed the pool, this second call would fail.
@@ -329,7 +329,7 @@ def test_monte_carlo_user_backend_records_pool_class_on_manifest(
     out = tmp_path / "out"
     fake_gmat_run.install_loader(run_hook=_payload_run_hook())
 
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         monte_carlo(
             script,
             n=4,
@@ -349,7 +349,7 @@ def test_latin_hypercube_user_backend_records_pool_class_on_manifest(
     out = tmp_path / "out"
     fake_gmat_run.install_loader(run_hook=_payload_run_hook())
 
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         latin_hypercube(
             script,
             n=4,
@@ -394,7 +394,7 @@ def test_sweep_with_samples_returns_one_run_per_row(
     fake_gmat_run.install_loader(setitem_hook=_setitem, run_hook=_payload_run_hook())
 
     samples = pd.DataFrame({"Sat.SMA": [7000, 7100, 7200, 7300]})
-    df = sweep(script, samples=samples, backend=LocalJoblibPool(workers=1), out=out)
+    df = sweep(script, samples=samples, backend=LocalJoblibPool(max_workers=1), out=out)
 
     run_ids = sorted(df.index.get_level_values("run_id").unique().tolist())
     assert run_ids == [0, 1, 2, 3]
@@ -416,7 +416,7 @@ def test_sweep_with_both_grid_and_samples_raises(
             script,
             grid={"Sat.SMA": [7000.0]},
             samples=pd.DataFrame({"Sat.SMA": [7000.0]}),
-            backend=LocalJoblibPool(workers=1),
+            backend=LocalJoblibPool(max_workers=1),
             out=tmp_path / "out",
         )
 
@@ -428,7 +428,7 @@ def test_sweep_with_neither_grid_nor_samples_raises(
     fake_gmat_run.install_loader(run_hook=_payload_run_hook())
 
     with pytest.raises(SweepConfigError, match="one of grid= or samples="):
-        sweep(script, backend=LocalJoblibPool(workers=1), out=tmp_path / "out")
+        sweep(script, backend=LocalJoblibPool(max_workers=1), out=tmp_path / "out")
 
 
 def test_sweep_with_samples_non_default_index_raises(
@@ -442,7 +442,7 @@ def test_sweep_with_samples_non_default_index_raises(
         index=pd.RangeIndex(10, 14),
     )
     with pytest.raises(SweepConfigError, match="default RangeIndex"):
-        sweep(script, samples=samples, backend=LocalJoblibPool(workers=1), out=tmp_path / "out")
+        sweep(script, samples=samples, backend=LocalJoblibPool(max_workers=1), out=tmp_path / "out")
 
 
 def test_sweep_with_grid_writes_grid_kind_in_manifest(
@@ -458,7 +458,7 @@ def test_sweep_with_grid_writes_grid_kind_in_manifest(
     sweep(
         script,
         grid={"Sat.SMA": [7000.0, 7100.0], "Sat.ECC": [0.001, 0.002]},
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out,
     )
 
@@ -485,7 +485,7 @@ def test_sweep_with_samples_writes_explicit_kind_in_manifest(
             "Sat.ECC": [0.001, 0.002],
         }
     )
-    sweep(script, samples=samples, backend=LocalJoblibPool(workers=1), out=out)
+    sweep(script, samples=samples, backend=LocalJoblibPool(max_workers=1), out=out)
 
     manifest = Manifest.load(out / "manifest.jsonl")
     spec = manifest.parameter_spec
@@ -510,7 +510,7 @@ def test_sweep_with_samples_manifest_round_trips_to_dataframe(
             "Sat.ECC": [0.001, 0.002, 0.003],
         }
     )
-    sweep(script, samples=samples, backend=LocalJoblibPool(workers=1), out=out)
+    sweep(script, samples=samples, backend=LocalJoblibPool(max_workers=1), out=out)
 
     manifest = Manifest.load(out / "manifest.jsonl")
     spec = manifest.parameter_spec
@@ -535,7 +535,7 @@ def test_monte_carlo_returns_n_run_dataframe(tmp_path: Path, fake_gmat_run: Fake
         n=100,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
         seed=42,
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out,
     )
 
@@ -561,7 +561,7 @@ def test_monte_carlo_two_calls_at_same_seed_produce_equal_overrides(
         n=20,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
         seed=42,
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out_a,
     )
     monte_carlo(
@@ -569,7 +569,7 @@ def test_monte_carlo_two_calls_at_same_seed_produce_equal_overrides(
         n=20,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
         seed=42,
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out_b,
     )
 
@@ -592,7 +592,7 @@ def test_monte_carlo_different_seed_produces_different_overrides(
         n=20,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
         seed=42,
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out_a,
     )
     monte_carlo(
@@ -600,7 +600,7 @@ def test_monte_carlo_different_seed_produces_different_overrides(
         n=20,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
         seed=43,
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out_b,
     )
 
@@ -626,7 +626,7 @@ def test_monte_carlo_adding_a_perturbed_parameter_preserves_other_draws(
         n=20,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
         seed=42,
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out_one,
     )
     monte_carlo(
@@ -637,7 +637,7 @@ def test_monte_carlo_adding_a_perturbed_parameter_preserves_other_draws(
             "Sat.INC": ("uniform", 0.0, 90.0),
         },
         seed=42,
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out_two,
     )
 
@@ -662,7 +662,7 @@ def test_monte_carlo_accepts_pre_frozen_rv(tmp_path: Path, fake_gmat_run: FakeGm
         n=10,
         perturb={"x": stats.beta(2, 5)},
         seed=42,
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out,
     )
     assert sorted(df.index.get_level_values("run_id").unique().tolist()) == list(range(10))
@@ -691,7 +691,7 @@ def test_monte_carlo_failed_run_lands_as_nan_row(
         n=8,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
         seed=42,
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out,
     )
 
@@ -713,7 +713,7 @@ def test_monte_carlo_writes_tagged_parameter_spec(
         n=10,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
         seed=42,
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out,
     )
 
@@ -736,7 +736,7 @@ def test_monte_carlo_rejects_empty_perturb(tmp_path: Path, fake_gmat_run: FakeGm
             n=10,
             perturb={},
             seed=42,
-            backend=LocalJoblibPool(workers=1),
+            backend=LocalJoblibPool(max_workers=1),
             out=tmp_path / "out",
         )
 
@@ -751,7 +751,7 @@ def test_monte_carlo_rejects_n_less_than_one(tmp_path: Path, fake_gmat_run: Fake
             n=0,
             perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
             seed=42,
-            backend=LocalJoblibPool(workers=1),
+            backend=LocalJoblibPool(max_workers=1),
             out=tmp_path / "out",
         )
 
@@ -777,7 +777,7 @@ def test_latin_hypercube_returns_n_run_dataframe(
             "Sat.INC": ("uniform", 0.0, 90.0),
         },
         seed=42,
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out,
     )
 
@@ -799,10 +799,10 @@ def test_latin_hypercube_two_calls_at_same_seed_produce_equal_overrides(
         "Sat.INC": ("uniform", 0.0, 90.0),
     }
     latin_hypercube(
-        script, n=16, perturb=perturb, seed=42, backend=LocalJoblibPool(workers=1), out=out_a
+        script, n=16, perturb=perturb, seed=42, backend=LocalJoblibPool(max_workers=1), out=out_a
     )
     latin_hypercube(
-        script, n=16, perturb=perturb, seed=42, backend=LocalJoblibPool(workers=1), out=out_b
+        script, n=16, perturb=perturb, seed=42, backend=LocalJoblibPool(max_workers=1), out=out_b
     )
 
     a = {e.run_id: e.overrides for e in Manifest.load(out_a / "manifest.jsonl").entries}
@@ -828,7 +828,7 @@ def test_latin_hypercube_writes_tagged_parameter_spec(
             "Sat.INC": ("uniform", 0.0, 90.0),
         },
         seed=42,
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out,
     )
 
@@ -854,7 +854,7 @@ def test_latin_hypercube_rejects_empty_perturb(tmp_path: Path, fake_gmat_run: Fa
             n=10,
             perturb={},
             seed=42,
-            backend=LocalJoblibPool(workers=1),
+            backend=LocalJoblibPool(max_workers=1),
             out=tmp_path / "out",
         )
 
@@ -871,6 +871,6 @@ def test_latin_hypercube_rejects_n_less_than_one(
             n=0,
             perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
             seed=42,
-            backend=LocalJoblibPool(workers=1),
+            backend=LocalJoblibPool(max_workers=1),
             out=tmp_path / "out",
         )

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -49,7 +49,7 @@ def _install_sma_echoing_loader(fake_gmat_run: FakeGmatRun) -> None:
 def _run_grid(*, script: Path, out: Path, n: int = 16, fake_gmat_run: FakeGmatRun) -> Sweep:
     _install_sma_echoing_loader(fake_gmat_run)
     grid_values = [7000.0 + i for i in range(n)]
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         sweep_obj = Sweep(
             runs=__import__(
                 "gmat_sweep.grids", fromlist=["expand_grid_to_run_specs"]
@@ -193,7 +193,7 @@ def test_16_run_grid_archive_and_resume_yields_bit_equal_dataframe(
     with zipfile.ZipFile(bundle) as zf:
         zf.extractall(extracted)
 
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         resumed = (
             Sweep.from_manifest(
                 extracted / "manifest.jsonl",
@@ -240,7 +240,7 @@ def test_failed_runs_are_packed_without_parquet_with_stderr_intact(
     sweep(
         script,
         grid={"Sat.SMA": [7000.0, 7001.0, 7002.0, 7003.0]},
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out,
         progress=False,
     )
@@ -249,7 +249,7 @@ def test_failed_runs_are_packed_without_parquet_with_stderr_intact(
     assert len(failed) == 1
     failed_run_id = failed[0]
 
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         loaded_sweep = Sweep.from_manifest(
             out / "manifest.jsonl", script, backend=pool, progress=False
         )
@@ -294,7 +294,7 @@ def test_archive_before_run_raises_runtime_error(
     out.mkdir()
     runs = expand_grid_to_run_specs({"Sat.SMA": [7000.0, 7001.0]}, script, out)
 
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         sweep_obj = Sweep(
             runs=runs,
             backend=pool,

--- a/tests/test_backends_dask.py
+++ b/tests/test_backends_dask.py
@@ -39,12 +39,26 @@ def _ok_outcome(run_id: int) -> RunOutcome:
 
 
 class _StubFuture:
-    """Minimal stand-in for ``distributed.Future`` carrying a precomputed result."""
+    """Minimal stand-in for ``distributed.Future`` carrying a precomputed result.
 
-    def __init__(self, value: RunOutcome) -> None:
+    ``exc`` (optional) lets the stub surface an exception via the
+    ``as_completed(... raise_errors=False)`` path — see
+    :func:`_stub_as_completed`.
+    """
+
+    _next_key = 0
+
+    def __init__(self, value: RunOutcome | None, *, exc: BaseException | None = None) -> None:
         self._value = value
+        self._exc = exc
+        # Mirror distributed.Future.key — DaskPool keys its run_id lookup on it.
+        _StubFuture._next_key += 1
+        self.key = f"stub-{_StubFuture._next_key}"
 
     def result(self) -> RunOutcome:
+        if self._exc is not None:
+            raise self._exc
+        assert self._value is not None
         return self._value
 
 
@@ -71,6 +85,34 @@ class _StubCluster:
         self.closed = True
 
 
+def _stub_as_completed(
+    futures: Iterable[_StubFuture],
+    *,
+    with_results: bool = False,
+    raise_errors: bool = True,
+) -> Iterator[Any]:
+    """Stand-in for ``distributed.as_completed`` covering the kwargs DaskPool uses.
+
+    Mirrors the real distributed.as_completed surface: ``with_results=True``
+    yields ``(future, payload)`` pairs; ``raise_errors=False`` surfaces a
+    task's exception as the payload instead of re-raising. The drain code
+    in :class:`DaskPool.as_completed` depends on both knobs together to
+    fold worker-side exceptions.
+    """
+    for f in futures:
+        if with_results:
+            try:
+                value = f.result()
+            except Exception as exc:
+                if raise_errors:
+                    raise
+                yield f, exc
+                continue
+            yield f, value
+        else:
+            yield f
+
+
 def _patch_distributed_with_stubs(
     monkeypatch: pytest.MonkeyPatch,
     *,
@@ -85,12 +127,7 @@ def _patch_distributed_with_stubs(
 
     monkeypatch.setattr(distributed, "LocalCluster", cluster_factory, raising=True)
     monkeypatch.setattr(distributed, "Client", client_factory, raising=True)
-    monkeypatch.setattr(
-        distributed,
-        "as_completed",
-        lambda futures: iter(futures),
-        raising=True,
-    )
+    monkeypatch.setattr(distributed, "as_completed", _stub_as_completed, raising=True)
 
 
 def test_daskpool_is_pool_subclass() -> None:
@@ -276,6 +313,69 @@ def test_default_dispatches_run_one_directly(
     pool.close()
 
     assert calls == [("run_one", 0)]
+
+
+def test_worker_side_exception_folds_into_failed_outcome(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A Dask task that raises is folded into ``RunOutcome.failed``.
+
+    The drain loop runs ``distributed.as_completed`` with
+    ``raise_errors=False`` and the worker-side exception arrives as the
+    payload instead of propagating out of ``.result()``. The fold must
+    keep the sweep alive and surface the traceback on ``stderr``.
+    """
+
+    class _ExplodingClient:
+        def submit(self, fn: Any, spec: RunSpec, *, pure: bool = True) -> _StubFuture:
+            # Park the exception on the future via the new exc= kwarg —
+            # the stub_as_completed helper surfaces it as the payload.
+            return _StubFuture(None, exc=RuntimeError("worker exploded"))
+
+        def close(self) -> None:
+            pass
+
+    _patch_distributed_with_stubs(monkeypatch)
+    pool = DaskPool(client=_ExplodingClient())
+    f = pool.submit(_make_spec(output_dir=tmp_path / "run_0", run_id=0))
+    outcomes = list(pool.as_completed([f]))
+    pool.close()
+
+    assert len(outcomes) == 1
+    assert outcomes[0].run_id == 0
+    assert outcomes[0].status == "failed"
+    assert outcomes[0].stderr is not None
+    assert "worker exploded" in outcomes[0].stderr
+    assert f.done()
+    assert f.result() is outcomes[0]
+
+
+def test_one_failed_run_does_not_abort_other_runs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Mix one task that raises with two that succeed — sweep yields all three."""
+
+    class _MixedClient:
+        def submit(self, fn: Any, spec: RunSpec, *, pure: bool = True) -> _StubFuture:
+            if spec.run_id == 1:
+                return _StubFuture(None, exc=RuntimeError("worker 1 down"))
+            return _StubFuture(_ok_outcome(spec.run_id))
+
+        def close(self) -> None:
+            pass
+
+    _patch_distributed_with_stubs(monkeypatch)
+    pool = DaskPool(client=_MixedClient())
+    futures = [
+        pool.submit(_make_spec(output_dir=tmp_path / f"run_{i}", run_id=i)) for i in range(3)
+    ]
+    outcomes = sorted(pool.as_completed(futures), key=lambda o: o.run_id)
+    pool.close()
+
+    assert [o.run_id for o in outcomes] == [0, 1, 2]
+    assert [o.status for o in outcomes] == ["ok", "failed", "ok"]
+    assert outcomes[1].stderr is not None
+    assert "worker 1 down" in outcomes[1].stderr
 
 
 def test_reuse_gmat_context_false_dispatches_subprocess_hop(

--- a/tests/test_backends_joblib.py
+++ b/tests/test_backends_joblib.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Iterator
 from datetime import datetime, timezone
 from pathlib import Path
@@ -32,7 +33,7 @@ def _make_spec(*, output_dir: Path, run_id: int = 0) -> RunSpec:
 # exercised by integration tests against real GMAT (deferred to #11).
 @pytest.fixture
 def pool() -> Iterator[LocalJoblibPool]:
-    p = LocalJoblibPool(workers=1)
+    p = LocalJoblibPool(max_workers=1)
     yield p
     p.close()
 
@@ -43,9 +44,9 @@ def test_localjoblibpool_is_pool_subclass() -> None:
 
 
 @pytest.mark.parametrize("workers", [0, -2, -100])
-def test_invalid_workers_raises(workers: int) -> None:
+def test_invalid_max_workers_raises(workers: int) -> None:
     with pytest.raises(BackendError):
-        LocalJoblibPool(workers=workers)
+        LocalJoblibPool(max_workers=workers)
 
 
 def test_submit_returns_pending_future(pool: LocalJoblibPool, tmp_path: Path) -> None:
@@ -111,27 +112,54 @@ def test_as_completed_rejects_unknown_future(
 
 
 def test_close_is_idempotent() -> None:
-    pool = LocalJoblibPool(workers=1)
+    pool = LocalJoblibPool(max_workers=1)
     pool.close()
     pool.close()
+
+
+def test_workers_kwarg_emits_deprecation_warning() -> None:
+    with pytest.warns(DeprecationWarning, match="max_workers"):
+        pool = LocalJoblibPool(workers=1)
+    pool.close()
+
+
+def test_workers_kwarg_still_constructs_a_working_pool(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun
+) -> None:
+    """The deprecation alias remains functional until removal."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        pool = LocalJoblibPool(workers=1)
+    try:
+        f = pool.submit(_make_spec(output_dir=tmp_path / "run_0", run_id=0))
+        outcomes = list(pool.as_completed([f]))
+    finally:
+        pool.close()
+    assert len(outcomes) == 1
+    assert outcomes[0].status == "ok"
+
+
+def test_passing_both_workers_and_max_workers_raises() -> None:
+    with pytest.raises(BackendError, match="not both"):
+        LocalJoblibPool(max_workers=2, workers=2)
 
 
 def test_submit_after_close_raises(tmp_path: Path) -> None:
-    pool = LocalJoblibPool(workers=1)
+    pool = LocalJoblibPool(max_workers=1)
     pool.close()
     with pytest.raises(BackendError):
         pool.submit(_make_spec(output_dir=tmp_path / "run_0"))
 
 
 def test_as_completed_after_close_raises() -> None:
-    pool = LocalJoblibPool(workers=1)
+    pool = LocalJoblibPool(max_workers=1)
     pool.close()
     with pytest.raises(BackendError):
         list(pool.as_completed([]))
 
 
 def test_pool_as_context_manager_closes_on_exit(tmp_path: Path, fake_gmat_run: FakeGmatRun) -> None:
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         f = pool.submit(_make_spec(output_dir=tmp_path / "run_0"))
         list(pool.as_completed([f]))
     with pytest.raises(BackendError):
@@ -139,7 +167,7 @@ def test_pool_as_context_manager_closes_on_exit(tmp_path: Path, fake_gmat_run: F
 
 
 def test_close_cancels_pending_futures(tmp_path: Path) -> None:
-    pool = LocalJoblibPool(workers=1)
+    pool = LocalJoblibPool(max_workers=1)
     f = pool.submit(_make_spec(output_dir=tmp_path / "run_0"))
     pool.close()
     assert f.cancelled()
@@ -169,11 +197,58 @@ def test_default_dispatches_run_one_directly(
         "gmat_sweep.backends.joblib.run_spec_in_subprocess", _fake_run_spec_in_subprocess
     )
 
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         f = pool.submit(_make_spec(output_dir=tmp_path / "run_0", run_id=0))
         list(pool.as_completed([f]))
 
     assert calls == [("run_one", 0)]
+
+
+def test_worker_side_exception_folds_into_failed_outcome(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A worker callable that raises is folded into a synthetic ``RunOutcome.failed``.
+
+    ``run_one`` itself catches its own exceptions internally; this exercises
+    the transport-failure path where an exception escapes the task callable
+    entirely (loky worker death, pickling fault, …). The drain loop must
+    keep the parent sweep alive and surface the traceback on the failed
+    outcome's ``stderr``.
+    """
+
+    def _boom(_spec: RunSpec) -> RunOutcome:
+        raise RuntimeError("worker exploded")
+
+    monkeypatch.setattr("gmat_sweep.backends.joblib.run_one", _boom)
+
+    with LocalJoblibPool(max_workers=1) as pool:
+        f = pool.submit(_make_spec(output_dir=tmp_path / "run_0", run_id=0))
+        outcomes = list(pool.as_completed([f]))
+
+    assert len(outcomes) == 1
+    assert outcomes[0].run_id == 0
+    assert outcomes[0].status == "failed"
+    assert outcomes[0].stderr is not None
+    assert "worker exploded" in outcomes[0].stderr
+    assert f.done()
+    assert f.result() is outcomes[0]
+
+
+def test_close_cancels_pending_before_exiting_parallel(tmp_path: Path) -> None:
+    """``close`` cancels parked futures before exiting the Parallel context.
+
+    Reversed ordering used to let loky compute a parked future's outcome on
+    the way out, then silently drop it because the cancel arrived later.
+    Inspecting the order is awkward; the cancellation contract — every
+    parked future is cancelled by the time ``close`` returns — is what we
+    pin here.
+    """
+    pool = LocalJoblibPool(max_workers=1)
+    f0 = pool.submit(_make_spec(output_dir=tmp_path / "run_0", run_id=0))
+    f1 = pool.submit(_make_spec(output_dir=tmp_path / "run_1", run_id=1))
+    pool.close()
+    assert f0.cancelled()
+    assert f1.cancelled()
 
 
 def test_reuse_gmat_context_false_dispatches_subprocess_hop(
@@ -195,7 +270,7 @@ def test_reuse_gmat_context_false_dispatches_subprocess_hop(
         "gmat_sweep.backends.joblib.run_spec_in_subprocess", _fake_run_spec_in_subprocess
     )
 
-    with LocalJoblibPool(workers=1, reuse_gmat_context=False) as pool:
+    with LocalJoblibPool(max_workers=1, reuse_gmat_context=False) as pool:
         f = pool.submit(_make_spec(output_dir=tmp_path / "run_0", run_id=0))
         list(pool.as_completed([f]))
 

--- a/tests/test_backends_mpi.py
+++ b/tests/test_backends_mpi.py
@@ -55,7 +55,12 @@ class _StubMPIPoolExecutor:
     def submit(self, fn: Any, spec: RunSpec) -> Future[RunOutcome]:
         self.submitted.append((fn, spec))
         future: Future[RunOutcome] = Future()
-        future.set_result(fn(spec))
+        try:
+            future.set_result(fn(spec))
+        except Exception as exc:
+            # Mirror MPIPoolExecutor's behaviour: a worker-side exception
+            # is parked on the future and surfaces from ``.result()``.
+            future.set_exception(exc)
         return future
 
     def shutdown(self, *, wait: bool = True) -> None:
@@ -256,6 +261,67 @@ def test_as_completed_rejects_unknown_future(
     with pytest.raises(BackendError):
         list(pool.as_completed([f]))
     pool.close()
+
+
+def test_worker_side_exception_folds_into_failed_outcome(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A rank-side exception is folded into a synthetic ``RunOutcome.failed``.
+
+    Simulates the MPI rank-crash path where the executor's future surfaces
+    an exception instead of an outcome. The drain loop must keep the sweep
+    alive and capture the traceback on the synthetic failed outcome's
+    ``stderr``.
+    """
+    from gmat_sweep.backends.mpi import MPIPool
+
+    _install_stub_executor(monkeypatch, _StubMPIPoolExecutor())
+
+    def _boom(_spec: RunSpec) -> RunOutcome:
+        raise RuntimeError("rank exploded")
+
+    monkeypatch.setattr("gmat_sweep.backends.mpi.run_one", _boom)
+
+    pool = MPIPool()
+    f = pool.submit(_make_spec(output_dir=tmp_path / "run_0", run_id=0))
+    outcomes = list(pool.as_completed([f]))
+    pool.close()
+
+    assert len(outcomes) == 1
+    assert outcomes[0].run_id == 0
+    assert outcomes[0].status == "failed"
+    assert outcomes[0].stderr is not None
+    assert "rank exploded" in outcomes[0].stderr
+    assert f.done()
+    assert f.result() is outcomes[0]
+
+
+def test_one_failed_rank_does_not_abort_other_runs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Mix one rank-crashing task with two successful ones — sweep yields all three."""
+    from gmat_sweep.backends.mpi import MPIPool
+
+    _install_stub_executor(monkeypatch, _StubMPIPoolExecutor())
+
+    def _maybe_boom(spec: RunSpec) -> RunOutcome:
+        if spec.run_id == 1:
+            raise RuntimeError("rank 1 down")
+        return _ok_outcome(spec.run_id)
+
+    monkeypatch.setattr("gmat_sweep.backends.mpi.run_one", _maybe_boom)
+
+    pool = MPIPool()
+    futures = [
+        pool.submit(_make_spec(output_dir=tmp_path / f"run_{i}", run_id=i)) for i in range(3)
+    ]
+    outcomes = sorted(pool.as_completed(futures), key=lambda o: o.run_id)
+    pool.close()
+
+    assert [o.run_id for o in outcomes] == [0, 1, 2]
+    assert [o.status for o in outcomes] == ["ok", "failed", "ok"]
+    assert outcomes[1].stderr is not None
+    assert "rank 1 down" in outcomes[1].stderr
 
 
 def test_mpi_run_one_delegates_to_subprocess_helper(

--- a/tests/test_backends_process_pool.py
+++ b/tests/test_backends_process_pool.py
@@ -30,7 +30,6 @@ from concurrent.futures import Future, ProcessPoolExecutor
 from datetime import datetime, timezone
 from pathlib import Path
 
-from gmat_sweep.backends._subprocess import run_spec_in_subprocess
 from gmat_sweep.backends.base import Pool
 from gmat_sweep.backends.process_pool import ProcessPoolExecutorPool
 from gmat_sweep.errors import BackendError
@@ -203,10 +202,18 @@ def test_default_dispatches_run_one_directly(
     assert captured[0][0] is run_one
 
 
-def test_reuse_gmat_context_false_dispatches_subprocess_hop(
+def test_reuse_gmat_context_false_still_dispatches_run_one_directly(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """``reuse_gmat_context=False`` dispatches ``run_spec_in_subprocess`` per task."""
+    """``reuse_gmat_context=False`` still dispatches ``run_one`` directly.
+
+    The pool hardcodes ``max_tasks_per_child=1``, so every task already
+    runs in a fresh interpreter. Routing through
+    ``run_spec_in_subprocess`` for the ``reuse_gmat_context=False`` mode
+    would just double-pay the subprocess hop without changing the
+    contract; the pool collapses both modes onto the direct ``run_one``
+    path.
+    """
     captured: _StubCapture = []
 
     def _stub_submit(
@@ -226,4 +233,72 @@ def test_reuse_gmat_context_false_dispatches_subprocess_hop(
         list(pool.as_completed([f]))
 
     assert len(captured) == 1
-    assert captured[0][0] is run_spec_in_subprocess
+    assert captured[0][0] is run_one
+
+
+def test_worker_side_exception_folds_into_failed_outcome(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A task whose future ``.result()`` raises is folded into ``RunOutcome.failed``.
+
+    Simulates the transport-failure path (e.g. ``BrokenProcessPool``)
+    where the executor's future surfaces an exception instead of the
+    expected outcome. The drain loop must keep the sweep alive and
+    capture the traceback on the synthetic failed outcome's ``stderr``.
+    """
+
+    def _stub_submit(
+        self: ProcessPoolExecutor,
+        fn: Callable[[RunSpec], RunOutcome],
+        spec: RunSpec,
+    ) -> Future[RunOutcome]:
+        f: Future[RunOutcome] = Future()
+        f.set_exception(RuntimeError("worker exploded"))
+        return f
+
+    monkeypatch.setattr(ProcessPoolExecutor, "submit", _stub_submit)
+
+    with ProcessPoolExecutorPool(max_workers=1) as pool:
+        f = pool.submit(_make_spec(output_dir=tmp_path / "run_0", run_id=0))
+        outcomes = list(pool.as_completed([f]))
+
+    assert len(outcomes) == 1
+    assert outcomes[0].run_id == 0
+    assert outcomes[0].status == "failed"
+    assert outcomes[0].stderr is not None
+    assert "worker exploded" in outcomes[0].stderr
+    assert f.done()
+    assert f.result() is outcomes[0]
+
+
+def test_one_failed_run_does_not_abort_other_runs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Mixed batch: run 1 raises, runs 0 and 2 return outcomes — sweep yields all three."""
+    submitted: list[RunSpec] = []
+
+    def _stub_submit(
+        self: ProcessPoolExecutor,
+        fn: Callable[[RunSpec], RunOutcome],
+        spec: RunSpec,
+    ) -> Future[RunOutcome]:
+        submitted.append(spec)
+        f: Future[RunOutcome] = Future()
+        if spec.run_id == 1:
+            f.set_exception(RuntimeError("rank 1 down"))
+        else:
+            f.set_result(_ok_outcome(spec.run_id))
+        return f
+
+    monkeypatch.setattr(ProcessPoolExecutor, "submit", _stub_submit)
+
+    with ProcessPoolExecutorPool(max_workers=1) as pool:
+        futures = [
+            pool.submit(_make_spec(output_dir=tmp_path / f"run_{i}", run_id=i)) for i in range(3)
+        ]
+        outcomes = sorted(pool.as_completed(futures), key=lambda o: o.run_id)
+
+    assert [o.run_id for o in outcomes] == [0, 1, 2]
+    assert [o.status for o in outcomes] == ["ok", "failed", "ok"]
+    assert outcomes[1].stderr is not None
+    assert "rank 1 down" in outcomes[1].stderr

--- a/tests/test_backends_ray.py
+++ b/tests/test_backends_ray.py
@@ -40,20 +40,33 @@ def _ok_outcome(run_id: int) -> RunOutcome:
 
 
 class _ObjectRef:
-    """Stand-in for a Ray ObjectRef carrying a precomputed outcome."""
+    """Stand-in for a Ray ObjectRef carrying a precomputed outcome.
 
-    def __init__(self, value: RunOutcome) -> None:
+    ``exc`` (optional) lets the stub surface a ``ray.get``-time exception
+    — the analogue of a real ``RayTaskError`` from a remote-side raise.
+    """
+
+    def __init__(self, value: RunOutcome | None, *, exc: BaseException | None = None) -> None:
         self.value = value
+        self.exc = exc
 
 
 class _Remote:
-    """Stand-in for a `ray.remote`-decorated function."""
+    """Stand-in for a `ray.remote`-decorated function.
+
+    A remote callable that raises is captured as ``ObjectRef(exc=...)`` so
+    the surfacing happens on ``ray.get``, matching the real Ray contract
+    where remote-side exceptions surface only on retrieval.
+    """
 
     def __init__(self, fn: Any) -> None:
         self._fn = fn
 
     def remote(self, spec: RunSpec) -> _ObjectRef:
-        return _ObjectRef(self._fn(spec))
+        try:
+            return _ObjectRef(self._fn(spec))
+        except Exception as exc:
+            return _ObjectRef(None, exc=exc)
 
 
 def _patch_ray_with_stubs(
@@ -83,13 +96,18 @@ def _patch_ray_with_stubs(
         return _Remote(fn)
 
     def _wait(
-        refs: list[_ObjectRef], *, num_returns: int = 1
+        refs: list[_ObjectRef],
+        *,
+        num_returns: int = 1,
+        fetch_local: bool = True,
     ) -> tuple[list[_ObjectRef], list[_ObjectRef]]:
         ready = refs[:num_returns]
         unready = refs[num_returns:]
         return ready, unready
 
     def _get(ref: _ObjectRef) -> RunOutcome:
+        if ref.exc is not None:
+            raise ref.exc
         return ref.value
 
     monkeypatch.setattr(ray, "is_initialized", _is_initialized, raising=True)
@@ -246,6 +264,97 @@ def test_as_completed_dispatches_via_remote_and_drains(
         assert f.done()
         assert f.result().status == "ok"
     pool.close()
+
+
+def test_as_completed_uses_fetch_local_in_ray_wait(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``ray.wait`` is called with ``fetch_local=True`` to prime the local store.
+
+    The pre-fix shape paid two network round-trips per outcome:
+    ``ray.wait(num_returns=1)`` then a separate ``ray.get(ready[0])``. The
+    ``fetch_local=True`` knob collapses that into one round-trip — pinning
+    the kwarg here guards against a silent regression.
+    """
+    wait_kwargs: list[dict[str, Any]] = []
+
+    _patch_ray_with_stubs(monkeypatch, is_initialized=True)
+
+    def _spying_wait(
+        refs: list[_ObjectRef],
+        *,
+        num_returns: int = 1,
+        fetch_local: bool = False,
+    ) -> tuple[list[_ObjectRef], list[_ObjectRef]]:
+        wait_kwargs.append({"num_returns": num_returns, "fetch_local": fetch_local})
+        return refs[:num_returns], refs[num_returns:]
+
+    monkeypatch.setattr(ray, "wait", _spying_wait, raising=True)
+
+    pool = RayPool()
+    monkeypatch.setattr(pool, "_remote_run_one", _Remote(lambda spec: _ok_outcome(spec.run_id)))
+    f = pool.submit(_make_spec(output_dir=tmp_path / "run_0", run_id=0))
+    list(pool.as_completed([f]))
+    pool.close()
+
+    assert wait_kwargs, "ray.wait was not called"
+    assert all(call["fetch_local"] is True for call in wait_kwargs)
+
+
+def test_worker_side_exception_folds_into_failed_outcome(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A remote task that raises is folded into ``RunOutcome.failed``.
+
+    The drain loop wraps ``ray.get`` in ``try/except`` so a ``RayTaskError``
+    from a remote-side raise (or a Ray transport error) folds into a
+    synthetic failed outcome instead of aborting the sweep.
+    """
+
+    def _boom(_spec: RunSpec) -> RunOutcome:
+        raise RuntimeError("remote exploded")
+
+    _patch_ray_with_stubs(monkeypatch, is_initialized=True)
+    pool = RayPool()
+    monkeypatch.setattr(pool, "_remote_run_one", _Remote(_boom))
+
+    f = pool.submit(_make_spec(output_dir=tmp_path / "run_0", run_id=0))
+    outcomes = list(pool.as_completed([f]))
+    pool.close()
+
+    assert len(outcomes) == 1
+    assert outcomes[0].run_id == 0
+    assert outcomes[0].status == "failed"
+    assert outcomes[0].stderr is not None
+    assert "remote exploded" in outcomes[0].stderr
+    assert f.done()
+    assert f.result() is outcomes[0]
+
+
+def test_one_failed_run_does_not_abort_other_runs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Mix one remote-failing task with two successful ones — sweep yields all three."""
+
+    def _maybe_boom(spec: RunSpec) -> RunOutcome:
+        if spec.run_id == 1:
+            raise RuntimeError("remote 1 down")
+        return _ok_outcome(spec.run_id)
+
+    _patch_ray_with_stubs(monkeypatch, is_initialized=True)
+    pool = RayPool()
+    monkeypatch.setattr(pool, "_remote_run_one", _Remote(_maybe_boom))
+
+    futures = [
+        pool.submit(_make_spec(output_dir=tmp_path / f"run_{i}", run_id=i)) for i in range(3)
+    ]
+    outcomes = sorted(pool.as_completed(futures), key=lambda o: o.run_id)
+    pool.close()
+
+    assert [o.run_id for o in outcomes] == [0, 1, 2]
+    assert [o.status for o in outcomes] == ["ok", "failed", "ok"]
+    assert outcomes[1].stderr is not None
+    assert "remote 1 down" in outcomes[1].stderr
 
 
 def test_as_completed_rejects_unknown_future(

--- a/tests/test_backends_ray.py
+++ b/tests/test_backends_ray.py
@@ -108,6 +108,7 @@ def _patch_ray_with_stubs(
     def _get(ref: _ObjectRef) -> RunOutcome:
         if ref.exc is not None:
             raise ref.exc
+        assert ref.value is not None
         return ref.value
 
     monkeypatch.setattr(ray, "is_initialized", _is_initialized, raising=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1353,7 +1353,7 @@ def test_archive_writes_zip_and_matches_api(
     assert "script/mission.script" in names
 
     # API and CLI produce byte-equal bundles for the same manifest.
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         api_sweep = Sweep.from_manifest(
             out / "manifest.jsonl", script, backend=pool, progress=False
         )
@@ -1559,7 +1559,7 @@ def _make_recording_pool_class() -> Any:
 
         def __init__(self, **kwargs: Any) -> None:
             type(self).calls.append(dict(kwargs))
-            super().__init__(workers=1)
+            super().__init__(max_workers=1)
 
     return _RecordingPool
 

--- a/tests/test_ephemeris_contact_aggregation.py
+++ b/tests/test_ephemeris_contact_aggregation.py
@@ -104,7 +104,7 @@ def test_4_run_sweep_aggregates_ephemeris_and_contact_into_indexed_frames(
     sweep(
         script,
         grid={"Sat.SMA": [7000.0, 7100.0, 7200.0, 7300.0]},
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out,
         progress=False,
     )
@@ -140,7 +140,7 @@ def test_failed_run_lands_as_nan_row_in_both_aggregators(
     sweep(
         script,
         grid={"Sat.SMA": [7000.0, 7100.0, 7200.0, 7300.0]},
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out,
         progress=False,
     )
@@ -177,7 +177,7 @@ def test_multi_ephemeris_with_name_none_raises_listing_available_names(
     sweep(
         script,
         grid={"Sat.SMA": [7000.0, 7100.0]},
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out,
         progress=False,
     )
@@ -206,7 +206,7 @@ def test_user_ephemeris_columns_survive_round_trip_through_aggregator(
     sweep(
         script,
         grid={"Sat.SMA": [7000.0, 7100.0]},
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out,
         progress=False,
     )

--- a/tests/test_explicit_row_roundtrip.py
+++ b/tests/test_explicit_row_roundtrip.py
@@ -68,7 +68,7 @@ def test_each_row_value_observed_via_mission_setitem_before_run(
     fake_gmat_run.module.Mission = SimpleNamespace(load=_load)  # type: ignore[attr-defined]
 
     samples = pd.DataFrame({"Sat.SMA": sma_values})
-    sweep(script, samples=samples, backend=LocalJoblibPool(workers=1), out=out, progress=False)
+    sweep(script, samples=samples, backend=LocalJoblibPool(max_workers=1), out=out, progress=False)
 
     # Every run_id observed exactly its own row's Sat.SMA, set before run().
     assert set(per_run_observations.keys()) == {0, 1, 2, 3}
@@ -100,7 +100,7 @@ def test_manifest_parameter_spec_reconstructs_input_dataframe(
             "Sat.ECC": [0.001, 0.002, 0.003, 0.004],
         }
     )
-    sweep(script, samples=samples, backend=LocalJoblibPool(workers=1), out=out, progress=False)
+    sweep(script, samples=samples, backend=LocalJoblibPool(max_workers=1), out=out, progress=False)
 
     manifest = Manifest.load(out / "manifest.jsonl")
     spec = manifest.parameter_spec

--- a/tests/test_failure_modes.py
+++ b/tests/test_failure_modes.py
@@ -80,7 +80,7 @@ def test_invalid_override_yields_failed_status_and_completes_sweep(
     df = gmat_sweep.sweep(
         leo_basic_script,
         grid={"Sat.NotARealField": [1.0, 2.0]},
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out,
     )
 
@@ -102,7 +102,7 @@ def test_one_invalid_override_does_not_abort_other_runs(
     df = gmat_sweep.sweep(
         leo_basic_script,
         grid={"Sat.SMA": [7000.0, 0.0, 7100.0]},
-        backend=LocalJoblibPool(workers=2),
+        backend=LocalJoblibPool(max_workers=2),
         out=out,
     )
 

--- a/tests/test_monte_carlo_determinism.py
+++ b/tests/test_monte_carlo_determinism.py
@@ -74,7 +74,7 @@ def test_two_calls_same_seed_produce_bit_equal_dataframes(
         n=20,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
         seed=42,
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=tmp_path / "out-a",
         progress=False,
     )
@@ -83,7 +83,7 @@ def test_two_calls_same_seed_produce_bit_equal_dataframes(
         n=20,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
         seed=42,
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=tmp_path / "out-b",
         progress=False,
     )
@@ -102,7 +102,7 @@ def test_different_seeds_produce_distinct_dataframes(
         n=20,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
         seed=42,
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=tmp_path / "out-42",
         progress=False,
     )
@@ -111,7 +111,7 @@ def test_different_seeds_produce_distinct_dataframes(
         n=20,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
         seed=43,
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=tmp_path / "out-43",
         progress=False,
     )
@@ -140,7 +140,7 @@ def test_adding_a_second_perturbed_parameter_preserves_first_dataframe_draws(
         n=20,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
         seed=42,
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=tmp_path / "out-one",
         progress=False,
     )
@@ -152,7 +152,7 @@ def test_adding_a_second_perturbed_parameter_preserves_first_dataframe_draws(
             "Sat.INC": ("uniform", 0.0, 90.0),
         },
         seed=42,
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=tmp_path / "out-two",
         progress=False,
     )
@@ -179,7 +179,7 @@ def test_extend_preserves_original_run_ids_bit_for_bit(
         n=100,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
         seed=42,
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out,
         progress=False,
     )
@@ -188,7 +188,7 @@ def test_extend_preserves_original_run_ids_bit_for_bit(
         out / "manifest.jsonl",
         script,
         n=200,
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         progress=False,
     )
 
@@ -215,7 +215,7 @@ def test_extend_matches_fresh_full_size_sweep_at_overlap(
         n=100,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
         seed=42,
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=base_out,
         progress=False,
     )
@@ -223,7 +223,7 @@ def test_extend_matches_fresh_full_size_sweep_at_overlap(
         base_out / "manifest.jsonl",
         script,
         n=200,
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         progress=False,
     )
 
@@ -232,7 +232,7 @@ def test_extend_matches_fresh_full_size_sweep_at_overlap(
         n=300,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
         seed=42,
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=tmp_path / "fresh",
         progress=False,
     )

--- a/tests/test_monte_carlo_extend.py
+++ b/tests/test_monte_carlo_extend.py
@@ -137,7 +137,7 @@ def test_extension_run_count_is_zero_for_fresh_monte_carlo(
         n=10,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
         seed=42,
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out,
         progress=False,
     )
@@ -156,7 +156,7 @@ def test_extension_run_count_is_positive_after_extend(
         n=10,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
         seed=42,
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out,
         progress=False,
     )
@@ -164,7 +164,7 @@ def test_extension_run_count_is_positive_after_extend(
         out / "manifest.jsonl",
         script,
         n=15,
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         progress=False,
     )
     manifest = Manifest.load(out / "manifest.jsonl")
@@ -186,7 +186,7 @@ def test_extension_run_count_is_zero_for_grid_manifest(
     sweep(
         script,
         grid={"Sat.SMA": [7000.0, 7100.0, 7200.0]},
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out,
         progress=False,
     )
@@ -206,7 +206,7 @@ def test_extend_refuses_grid_manifest(tmp_path: Path, fake_gmat_run: FakeGmatRun
     sweep(
         script,
         grid={"Sat.SMA": [7000.0, 7100.0]},
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out,
         progress=False,
     )
@@ -215,7 +215,7 @@ def test_extend_refuses_grid_manifest(tmp_path: Path, fake_gmat_run: FakeGmatRun
             out / "manifest.jsonl",
             script,
             n=5,
-            backend=LocalJoblibPool(workers=1),
+            backend=LocalJoblibPool(max_workers=1),
             progress=False,
         )
 
@@ -254,7 +254,7 @@ def test_extend_refuses_when_base_has_failed_runs(
         n=10,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
         seed=42,
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out,
         progress=False,
     )
@@ -264,7 +264,7 @@ def test_extend_refuses_when_base_has_failed_runs(
             out / "manifest.jsonl",
             script,
             n=5,
-            backend=LocalJoblibPool(workers=1),
+            backend=LocalJoblibPool(max_workers=1),
             progress=False,
         )
 
@@ -278,7 +278,7 @@ def test_extend_validates_n_positive(tmp_path: Path, fake_gmat_run: FakeGmatRun)
         n=4,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
         seed=42,
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out,
         progress=False,
     )
@@ -287,7 +287,7 @@ def test_extend_validates_n_positive(tmp_path: Path, fake_gmat_run: FakeGmatRun)
             out / "manifest.jsonl",
             script,
             n=0,
-            backend=LocalJoblibPool(workers=1),
+            backend=LocalJoblibPool(max_workers=1),
             progress=False,
         )
 
@@ -303,7 +303,7 @@ def test_extend_refuses_on_script_drift(tmp_path: Path, fake_gmat_run: FakeGmatR
         n=4,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
         seed=42,
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out,
         progress=False,
     )
@@ -313,7 +313,7 @@ def test_extend_refuses_on_script_drift(tmp_path: Path, fake_gmat_run: FakeGmatR
             out / "manifest.jsonl",
             script,
             n=2,
-            backend=LocalJoblibPool(workers=1),
+            backend=LocalJoblibPool(max_workers=1),
             progress=False,
         )
 
@@ -334,7 +334,7 @@ def test_latin_hypercube_extend_refuses_with_clear_message(
         n=8,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0)},
         seed=42,
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out,
         progress=False,
     )
@@ -343,6 +343,6 @@ def test_latin_hypercube_extend_refuses_with_clear_message(
             out / "manifest.jsonl",
             script,
             n=4,
-            backend=LocalJoblibPool(workers=1),
+            backend=LocalJoblibPool(max_workers=1),
             progress=False,
         )

--- a/tests/test_reference_sweep.py
+++ b/tests/test_reference_sweep.py
@@ -69,7 +69,9 @@ def _frames_equal(actual: pd.DataFrame, expected: pd.DataFrame) -> None:
 
 def test_reference_sma_sweep_matches_golden_parquet(leo_basic_script: Path, tmp_path: Path) -> None:
     out = tmp_path / "out"
-    df = gmat_sweep.sweep(leo_basic_script, grid=_GRID, backend=LocalJoblibPool(workers=2), out=out)
+    df = gmat_sweep.sweep(
+        leo_basic_script, grid=_GRID, backend=LocalJoblibPool(max_workers=2), out=out
+    )
 
     flat = _normalise_for_comparison(df)
 

--- a/tests/test_repr_html.py
+++ b/tests/test_repr_html.py
@@ -74,7 +74,7 @@ def _payload_run_hook() -> Any:
 def test_sweep_repr_html_pre_run(tmp_path: Path) -> None:
     script = _write_script(tmp_path)
     runs = _make_runs(script, tmp_path / "out", n=3)
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         sweep = Sweep(
             runs=runs,
             backend=pool,
@@ -103,7 +103,7 @@ def test_sweep_repr_html_post_run(tmp_path: Path, fake_gmat_run: FakeGmatRun) ->
     script = _write_script(tmp_path)
     output_dir = tmp_path / "out"
     runs = _make_runs(script, output_dir, n=2)
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         sweep = Sweep(
             runs=runs,
             backend=pool,
@@ -128,7 +128,7 @@ def test_sweep_repr_html_handles_unreadable_script(tmp_path: Path) -> None:
     # The repr should degrade gracefully rather than blow up the notebook cell.
     script = tmp_path / "missing.script"
     runs: list[RunSpec] = []
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         sweep = Sweep(
             runs=runs,
             backend=pool,

--- a/tests/test_resume_roundtrip.py
+++ b/tests/test_resume_roundtrip.py
@@ -97,7 +97,7 @@ def test_16_run_grid_with_3_failures_resumes_to_all_ok(
     sweep(
         script,
         grid={"Sat.SMA": grid_values},
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out,
         progress=False,
     )
@@ -106,7 +106,7 @@ def test_16_run_grid_with_3_failures_resumes_to_all_ok(
 
     # Patch the failure source out and resume.
     fake_gmat_run.install_loader(run_hook=_payload_run_hook())
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         df = (
             Sweep.from_manifest(out / "manifest.jsonl", script, backend=pool, progress=False)
             .resume()
@@ -162,7 +162,7 @@ def test_monte_carlo_resume_preserves_bit_equal_draws_for_failed_runs(
         n=8,
         perturb=perturb,
         seed=1729,
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out,
         progress=False,
     )
@@ -173,7 +173,7 @@ def test_monte_carlo_resume_preserves_bit_equal_draws_for_failed_runs(
 
     # Resume with no failure source.
     fake_gmat_run.install_loader(run_hook=_payload_run_hook())
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         Sweep.from_manifest(out / "manifest.jsonl", script, backend=pool, progress=False).resume()
 
     post_resume = Manifest.load(out / "manifest.jsonl")
@@ -193,7 +193,7 @@ def test_script_drift_raises_sweep_config_error(tmp_path: Path, fake_gmat_run: F
     sweep(
         script,
         grid={"Sat.SMA": [7000.0, 7100.0]},
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out,
         progress=False,
     )
@@ -202,7 +202,7 @@ def test_script_drift_raises_sweep_config_error(tmp_path: Path, fake_gmat_run: F
     script.write_text("% mission v2\nCreate Spacecraft Sat;\n", encoding="utf-8")
 
     with (
-        LocalJoblibPool(workers=1) as pool,
+        LocalJoblibPool(max_workers=1) as pool,
         pytest.raises(SweepConfigError, match="script hash mismatch"),
     ):
         Sweep.from_manifest(out / "manifest.jsonl", script, backend=pool, progress=False)
@@ -215,7 +215,7 @@ def test_allow_script_drift_warns_and_proceeds(tmp_path: Path, fake_gmat_run: Fa
     sweep(
         script,
         grid={"Sat.SMA": [7000.0, 7100.0]},
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out,
         progress=False,
     )
@@ -224,7 +224,7 @@ def test_allow_script_drift_warns_and_proceeds(tmp_path: Path, fake_gmat_run: Fa
 
     fake_gmat_run.install_loader(run_hook=_payload_run_hook())
     with (
-        LocalJoblibPool(workers=1) as pool,
+        LocalJoblibPool(max_workers=1) as pool,
         pytest.warns(RuntimeWarning, match="script hash mismatch"),
     ):
         rebuilt = Sweep.from_manifest(
@@ -253,7 +253,7 @@ def test_resumed_dataframe_matches_unbroken_sweep_via_sma_echo(
     df_reference = sweep(
         script,
         grid={"Sat.SMA": [7000.0, 7100.0, 7200.0, 7300.0]},
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=tmp_path / "ref",
         progress=False,
     )
@@ -287,13 +287,13 @@ def test_resumed_dataframe_matches_unbroken_sweep_via_sma_echo(
     sweep(
         script,
         grid={"Sat.SMA": [7000.0, 7100.0, 7200.0, 7300.0]},
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out,
         progress=False,
     )
 
     _install_sma_echoing_loader(fake_gmat_run)
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         df_resumed = (
             Sweep.from_manifest(out / "manifest.jsonl", script, backend=pool, progress=False)
             .resume()

--- a/tests/test_run_roundtrip.py
+++ b/tests/test_run_roundtrip.py
@@ -39,7 +39,7 @@ def four_run_sweep_df(
     """Run the reference 4-run sweep once and reuse it across the module."""
     out = tmp_path_factory.mktemp("four-run-sweep")
     return gmat_sweep.sweep(
-        leo_basic_script, grid=_GRID, backend=LocalJoblibPool(workers=2), out=out
+        leo_basic_script, grid=_GRID, backend=LocalJoblibPool(max_workers=2), out=out
     )
 
 

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -62,7 +62,7 @@ def test_sweep_run_returns_self(tmp_path: Path, fake_gmat_run: FakeGmatRun) -> N
     output_dir = tmp_path / "out"
     runs = _make_runs(script, output_dir, n=1)
 
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         sweep = Sweep(
             runs=runs,
             backend=pool,
@@ -82,7 +82,7 @@ def test_sweep_run_writes_one_manifest_entry_per_run(
     output_dir = tmp_path / "out"
     runs = _make_runs(script, output_dir, n=4)
 
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         Sweep(
             runs=runs,
             backend=pool,
@@ -113,7 +113,7 @@ def test_sweep_manifest_header_carries_script_hash_seed_and_spec(
     output_dir = tmp_path / "out"
     runs = _make_runs(script, output_dir, n=1)
 
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         Sweep(
             runs=runs,
             backend=pool,
@@ -202,7 +202,7 @@ def test_sweep_manifest_parent_directory_is_created(
     output_dir = tmp_path / "deeply" / "nested" / "out"
     runs = _make_runs(script, output_dir, n=1)
 
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         Sweep(
             runs=runs,
             backend=pool,
@@ -228,7 +228,7 @@ def test_sweep_to_dataframe_returns_multiindexed_frame(
 
     fake_gmat_run.install_loader(run_hook=_payload_run_hook(rows=2))
 
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         sweep = Sweep(
             runs=runs,
             backend=pool,
@@ -257,7 +257,7 @@ def test_sweep_to_dataframe_engine_polars_returns_polars_frame(
 
     fake_gmat_run.install_loader(run_hook=_payload_run_hook(rows=2))
 
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         sweep = Sweep(
             runs=runs,
             backend=pool,
@@ -294,7 +294,7 @@ def test_sweep_to_dataframe_marks_failed_run(tmp_path: Path, fake_gmat_run: Fake
 
     fake_gmat_run.install_loader(setitem_hook=_setitem, run_hook=_payload_run_hook(rows=1))
 
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         sweep = Sweep(
             runs=runs,
             backend=pool,
@@ -331,7 +331,7 @@ def test_sweep_to_fused_reports_returns_multiindex_column_frame(
 
     fake_gmat_run.install_loader(run_hook=_run)
 
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         sweep = Sweep(
             runs=runs,
             backend=pool,
@@ -356,7 +356,7 @@ def test_sweep_to_manifest_requires_run_first(tmp_path: Path, fake_gmat_run: Fak
     output_dir = tmp_path / "out"
     runs = _make_runs(script, output_dir, n=1)
 
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         sweep = Sweep(
             runs=runs,
             backend=pool,
@@ -382,7 +382,7 @@ def test_sweep_progress_disabled_quiet_on_stderr(
     output_dir = tmp_path / "out"
     runs = _make_runs(script, output_dir, n=2)
 
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         Sweep(
             runs=runs,
             backend=pool,
@@ -488,7 +488,7 @@ def _build_grid_manifest(
     else:
         fake_gmat_run.install_loader(run_hook=_payload_run_hook(rows=1))
 
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         Sweep(
             runs=runs,
             backend=pool,
@@ -509,7 +509,7 @@ def test_from_manifest_grid_rebuilds_runs(tmp_path: Path, fake_gmat_run: FakeGma
     script, output_dir = _build_grid_manifest(tmp_path, fake_gmat_run, n=4)
     fake_gmat_run.install_loader(run_hook=_payload_run_hook(rows=1))
 
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         sweep = Sweep.from_manifest(
             output_dir / "manifest.jsonl",
             script,
@@ -536,7 +536,7 @@ def test_from_manifest_tagged_grid_kind_rebuilds_runs(
     sweep_api(
         script,
         grid={"Sat.SMA": [7000.0, 7100.0, 7200.0]},
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=output_dir,
     )
 
@@ -547,7 +547,7 @@ def test_from_manifest_tagged_grid_kind_rebuilds_runs(
     assert saved.parameter_spec["_kind"] == "grid"
 
     fake_gmat_run.install_loader(run_hook=_payload_run_hook(rows=1))
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         rebuilt = Sweep.from_manifest(
             output_dir / "manifest.jsonl",
             script,
@@ -574,10 +574,10 @@ def test_from_manifest_explicit_kind_rebuilds_runs(
     samples = pd.DataFrame({"Sat.SMA": [7000.0, 7100.0, 7200.0], "Sat.ECC": [0.001, 0.002, 0.003]})
 
     fake_gmat_run.install_loader(run_hook=_payload_run_hook(rows=1))
-    sweep_api(script, samples=samples, backend=LocalJoblibPool(workers=1), out=output_dir)
+    sweep_api(script, samples=samples, backend=LocalJoblibPool(max_workers=1), out=output_dir)
 
     fake_gmat_run.install_loader(run_hook=_payload_run_hook(rows=1))
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         rebuilt = Sweep.from_manifest(
             output_dir / "manifest.jsonl",
             script,
@@ -608,7 +608,7 @@ def test_from_manifest_monte_carlo_rebuilds_bit_equal_overrides(
         n=8,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0), "Sat.INC": ("uniform", 0.0, 90.0)},
         seed=1729,
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out,
     )
 
@@ -617,7 +617,7 @@ def test_from_manifest_monte_carlo_rebuilds_bit_equal_overrides(
     }
 
     fake_gmat_run.install_loader(run_hook=_payload_run_hook(rows=1))
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         rebuilt = Sweep.from_manifest(out / "manifest.jsonl", script, backend=pool, progress=False)
 
     rebuilt_overrides = {s.run_id: s.overrides for s in rebuilt._runs}
@@ -637,14 +637,14 @@ def test_from_manifest_latin_hypercube_rebuilds_bit_equal_overrides(
         n=8,
         perturb={"Sat.SMA": ("normal", 7100.0, 50.0), "Sat.INC": ("uniform", 0.0, 90.0)},
         seed=1729,
-        backend=LocalJoblibPool(workers=1),
+        backend=LocalJoblibPool(max_workers=1),
         out=out,
     )
 
     original = {e.run_id: e.overrides for e in Manifest.load(out / "manifest.jsonl").entries}
 
     fake_gmat_run.install_loader(run_hook=_payload_run_hook(rows=1))
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         rebuilt = Sweep.from_manifest(out / "manifest.jsonl", script, backend=pool, progress=False)
 
     assert {s.run_id: s.overrides for s in rebuilt._runs} == original
@@ -655,7 +655,7 @@ def test_from_manifest_script_drift_raises(tmp_path: Path, fake_gmat_run: FakeGm
     # Mutate the script: same path, different bytes ⇒ different canonical hash.
     script.write_text("% GMAT script v2\nCreate Spacecraft Sat;\n", encoding="utf-8")
 
-    with LocalJoblibPool(workers=1) as pool:  # noqa: SIM117 — context manager scope is intentional
+    with LocalJoblibPool(max_workers=1) as pool:  # noqa: SIM117 — context manager scope is intentional
         with pytest.raises(SweepConfigError, match="script hash mismatch"):
             Sweep.from_manifest(output_dir / "manifest.jsonl", script, backend=pool, progress=False)
 
@@ -668,7 +668,7 @@ def test_from_manifest_script_drift_allowed_warns_and_proceeds(
 
     fake_gmat_run.install_loader(run_hook=_payload_run_hook(rows=1))
     with (
-        LocalJoblibPool(workers=1) as pool,
+        LocalJoblibPool(max_workers=1) as pool,
         pytest.warns(RuntimeWarning, match="script hash mismatch"),
     ):
         sweep = Sweep.from_manifest(
@@ -686,7 +686,7 @@ def test_from_manifest_missing_output_dir_raises(tmp_path: Path) -> None:
     Parquet files are gone — raise rather than silently produce a sweep
     that would re-execute everything."""
     fake_path = tmp_path / "vanished" / "manifest.jsonl"
-    with LocalJoblibPool(workers=1) as pool:  # noqa: SIM117
+    with LocalJoblibPool(max_workers=1) as pool:  # noqa: SIM117
         with pytest.raises(SweepConfigError, match="output directory does not exist"):
             Sweep.from_manifest(
                 fake_path, tmp_path / "mission.script", backend=pool, progress=False
@@ -705,7 +705,7 @@ def test_from_manifest_unknown_kind_raises(tmp_path: Path, fake_gmat_run: FakeGm
     raw[0] = _json.dumps(header, sort_keys=True) + "\n"
     manifest_path.write_text("".join(raw), encoding="utf-8")
 
-    with LocalJoblibPool(workers=1) as pool:  # noqa: SIM117
+    with LocalJoblibPool(max_workers=1) as pool:  # noqa: SIM117
         with pytest.raises(SweepConfigError, match="unknown parameter_spec _kind"):
             Sweep.from_manifest(manifest_path, script, backend=pool, progress=False)
 
@@ -720,7 +720,7 @@ def test_resume_requires_from_manifest(tmp_path: Path, fake_gmat_run: FakeGmatRu
     script = _write_script(tmp_path)
     output_dir = tmp_path / "out"
     runs = _make_runs(script, output_dir, n=1)
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         sweep = Sweep(
             runs=runs,
             backend=pool,
@@ -748,7 +748,7 @@ def test_resume_only_runs_failed_and_missing_run_ids(
         second_pass_overrides.append(value)
 
     fake_gmat_run.install_loader(setitem_hook=_setitem, run_hook=_payload_run_hook(rows=1))
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         Sweep.from_manifest(
             output_dir / "manifest.jsonl", script, backend=pool, progress=False
         ).resume()
@@ -778,7 +778,7 @@ def test_resume_acceptance_16_runs_with_3_failures(
             raise ValueError("rejected by GMAT")
 
     fake_gmat_run.install_loader(setitem_hook=_setitem, run_hook=_payload_run_hook(rows=1))
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         Sweep(
             runs=runs,
             backend=pool,
@@ -794,7 +794,7 @@ def test_resume_acceptance_16_runs_with_3_failures(
 
     # Patch the override out, resume.
     fake_gmat_run.install_loader(run_hook=_payload_run_hook(rows=1))
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         df = (
             Sweep.from_manifest(output_dir / "manifest.jsonl", script, backend=pool, progress=False)
             .resume()
@@ -816,7 +816,7 @@ def test_resume_writes_duplicate_lines_but_load_dedups(
     raw_lines_before = manifest_path.read_text(encoding="utf-8").splitlines()
 
     fake_gmat_run.install_loader(run_hook=_payload_run_hook(rows=1))
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         Sweep.from_manifest(manifest_path, script, backend=pool, progress=False).resume()
 
     raw_lines_after = manifest_path.read_text(encoding="utf-8").splitlines()
@@ -838,7 +838,7 @@ def test_resume_with_no_failures_or_missing_is_a_noop(
     bytes_before = manifest_path.read_bytes()
 
     fake_gmat_run.install_loader(run_hook=_payload_run_hook(rows=1))
-    with LocalJoblibPool(workers=1) as pool:
+    with LocalJoblibPool(max_workers=1) as pool:
         Sweep.from_manifest(manifest_path, script, backend=pool, progress=False).resume()
 
     assert manifest_path.read_bytes() == bytes_before


### PR DESCRIPTION
## Summary

- Every backend pool now folds worker-side transport failures (loky / `ProcessPoolExecutor` / Dask / MPI rank / Ray worker death, `RayTaskError`, pickling fault, …) into a synthetic `RunOutcome.failed` at the drain site instead of letting `.result()` raise and abort the sweep.
- `RayPool` uses `ray.wait(..., fetch_local=True)` so the per-ref `ray.get` is now in-store, dropping the second network trip per outcome. `DaskPool` switches to `distributed.as_completed(..., with_results=True, raise_errors=False)` so the completion event, the result, and worker-side exception folding all share one round-trip.
- `ProcessPoolExecutorPool` dispatches `run_one` directly on both `reuse_gmat_context` values — `max_tasks_per_child=1` already gives every task a fresh interpreter, so the old `run_spec_in_subprocess` hop was double-paying the subprocess cost.
- `LocalJoblibPool.close()` now cancels parked futures **before** exiting the `Parallel` context (the old order let loky compute an outcome on the way out and silently drop it), and `workers=` is deprecated in favour of `max_workers=` (kept as alias with `DeprecationWarning`). Docs / README / notebooks / CLI / internal callsites switched.
- Per-pool unit tests grow a worker-exception case (`status="failed"`, traceback on `stderr`, other runs in the batch still succeed). Ray gets a guard pinning `fetch_local=True`. Joblib gets a close-ordering test.

## Test plan

- [x] `uv run ruff check src/ tests/`
- [x] `uv run ruff format --check src/ tests/`
- [x] `uv run mypy src/`
- [x] `uv run pytest tests/ -m "not integration and not slow"` — 748 passed, no `DeprecationWarning`s
- [ ] `tests/test_backend_equivalence.py` and `tests/test_backend_throughput.py` (the `integration and slow` cell on real GMAT) — exercise the new drain paths against actual Dask / Ray / MPI / ProcessPool workers
- [ ] Throughput floor re-baseline: left unchanged for this PR; the new code is no slower per outcome, so the existing floor still holds. Once the integration cell prints fresh numbers, a follow-up can tighten `tests/data/throughput_floor.json` against the new round-trip-trimmed baseline.

Closes #132