### PR TITLE
CLI + plotting ergonomics: cold start, input validation, axis-resolution correctness

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ A `gmat-sweep` console script is also installed for shell-script and CI use:
 gmat-sweep run         --grid Sat.SMA=7000:7200:3 --workers 8 --out ./sweep mission.script
 gmat-sweep run         --grid Sat.SMA=7000:7200:3 --backend dask --workers 8 --out ./sweep mission.script
 gmat-sweep monte-carlo --n 1000 --perturb 'Sat.SMA=normal:7100:50' --seed 42 --out ./mc mission.script
-gmat-sweep resume      --script mission.script --workers 8 ./mc/manifest.jsonl
+gmat-sweep resume      ./mc/manifest.jsonl mission.script --workers 8
 gmat-sweep show        ./sweep/manifest.jsonl
 ```
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ A `gmat-sweep` console script is also installed for shell-script and CI use:
 gmat-sweep run         --grid Sat.SMA=7000:7200:3 --workers 8 --out ./sweep mission.script
 gmat-sweep run         --grid Sat.SMA=7000:7200:3 --backend dask --workers 8 --out ./sweep mission.script
 gmat-sweep monte-carlo --n 1000 --perturb 'Sat.SMA=normal:7100:50' --seed 42 --out ./mc mission.script
-gmat-sweep resume      ./mc/manifest.jsonl mission.script --workers 8
+gmat-sweep resume      --script mission.script --workers 8 ./mc/manifest.jsonl
 gmat-sweep show        ./sweep/manifest.jsonl
 ```
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -27,13 +27,18 @@ The subcommands:
 ## Common options
 
 The sweep-running subcommands (`run`, `monte-carlo`, `latin-hypercube`,
-`explicit`) share three flags:
+`explicit`) and the post-hoc subcommands that drive new runs (`extend`,
+`resume`) share three flags:
 
 | Flag         | Default | Meaning                                                                      |
 |--------------|---------|------------------------------------------------------------------------------|
-| `--workers N`| `-1`    | Number of subprocess workers. `-1` uses every available core.                |
+| `--workers N`| `-1`    | Number of subprocess workers. `-1` uses every available core. Not accepted on `--backend mpi` (the launcher fixes the rank count); passing it there exits `2`. |
 | `--out PATH` | —       | Required. Output directory for per-run artefacts and `manifest.jsonl`.       |
 | `SCRIPT`     | —       | Required positional. Path to the GMAT `.script` every run loads.             |
+
+`extend`, `resume`, and `archive` also accept `SCRIPT` as a positional. The
+older `--script PATH` flag still works on those three subcommands but the
+positional form is canonical — the examples below use it.
 
 Each of those four subcommands writes a `manifest.jsonl` under `--out` and
 prints a one-line summary to stdout when the sweep finishes:
@@ -138,8 +143,9 @@ Repeated `--grid` flags for the same axis name exit with code `2`.
 ## `monte-carlo`
 
 Run `n` independent stochastic samples by sampling each `--perturb`
-parameter from its own distribution. With `--seed` set, the run set is
-reproducible across machines.
+parameter from its own distribution. With `--seed` set, two runs at the
+same `(--perturb, --n, --seed)` produce bit-equal DataFrames; without
+`--seed` the draws fall back to OS entropy and are not reproducible.
 
 ```bash
 gmat-sweep monte-carlo \
@@ -219,20 +225,21 @@ Re-run only the failed and never-recorded entries from an existing
 `manifest.jsonl`. Successful runs' Parquet files are reused from disk.
 
 ```bash
-gmat-sweep resume ./sweep-out/manifest.jsonl \
-    --script mission.script \
+gmat-sweep resume ./sweep-out/manifest.jsonl mission.script \
     --workers 4
 ```
 
-Required positional: `MANIFEST` — the existing `manifest.jsonl`.
+Required positionals:
 
-Required flag: `--script PATH` — the same GMAT `.script` the original sweep
-loaded. Its canonical SHA-256 must equal the manifest's `script_sha256`; see
-[Resume § Script drift](resume.md#script-drift) for the full contract. Add
-`--allow-script-drift` to proceed past a hash mismatch (emits a
-`RuntimeWarning`).
+- `MANIFEST` — the existing `manifest.jsonl`.
+- `SCRIPT` — the same GMAT `.script` the original sweep loaded. The older
+  `--script PATH` flag is still accepted. The script's canonical SHA-256
+  must equal the manifest's `script_sha256`; see
+  [Resume § Script drift](resume.md#script-drift) for the full contract.
+  Add `--allow-script-drift` to proceed past a hash mismatch (emits a
+  `RuntimeWarning`).
 
-A missing `MANIFEST` exits with code `3`; a missing `--script` or a hash
+A missing `MANIFEST` exits with code `3`; a missing `SCRIPT` or a hash
 mismatch exits with code `2`.
 
 ## `extend`
@@ -243,30 +250,30 @@ draws are bit-equal to the same indices of a fresh
 `monte_carlo(n=old_n + N)` call.
 
 ```bash
-gmat-sweep extend ./mc-out/manifest.jsonl \
+gmat-sweep extend ./mc-out/manifest.jsonl mission.script \
     --n 1000 \
-    --script mission.script \
     --workers 8
 ```
 
-Required positional: `MANIFEST` — an existing Monte Carlo
-`manifest.jsonl`. Grid, explicit-row, and Latin hypercube manifests
-exit with code `2` (their stochastic semantics don't admit clean
-extension).
+Required positionals:
 
-Required flags:
+- `MANIFEST` — an existing Monte Carlo `manifest.jsonl`. Grid, explicit-row,
+  and Latin hypercube manifests exit with code `2` (their stochastic
+  semantics don't admit clean extension).
+- `SCRIPT` — the same GMAT `.script` the original sweep loaded. Same
+  hash-drift contract as `resume`; add `--allow-script-drift` to proceed
+  past a mismatch. The older `--script PATH` flag is still accepted.
+
+Required flag:
 
 - `--n N` — number of additional stochastic runs to append, ≥ 1.
-- `--script PATH` — the same GMAT `.script` the original sweep loaded.
-  Same hash-drift contract as `resume`; add `--allow-script-drift` to
-  proceed past a mismatch.
 
 `extend` refuses if the base sweep has any `failed` or missing runs in
 its original `[0, n)` range — the underlying error names them and
 points at `gmat-sweep resume`. Run `resume` first, then `extend`.
 
 A missing `MANIFEST` exits with code `3`; a non-Monte-Carlo manifest,
-an incomplete base sweep, a missing `--script`, or a hash mismatch
+an incomplete base sweep, a missing `SCRIPT`, or a hash mismatch
 exits with code `2`. See
 [Monte Carlo § Extending an existing sweep](monte-carlo.md#extending-an-existing-sweep)
 for the full determinism contract.
@@ -344,20 +351,22 @@ single self-describing `.zip` suitable for archival deposit (Zenodo, JOSS
 supplementary material) or internal handoff.
 
 ```bash
-gmat-sweep archive ./sweep-out/manifest.jsonl \
-    --script mission.script \
+gmat-sweep archive ./sweep-out/manifest.jsonl mission.script \
     --out ./sma-scan-2026q2.zip
 ```
 
-Required positional: `MANIFEST` — the existing `manifest.jsonl`.
+Required positionals:
 
-Required flags:
-
-- `--script PATH` — the same GMAT `.script` the sweep loaded. Its canonical
-  SHA-256 must equal the manifest's `script_sha256`; same hash-drift contract
-  as `resume` and `extend`. Add `--allow-script-drift` to proceed past a
+- `MANIFEST` — the existing `manifest.jsonl`.
+- `SCRIPT` — the same GMAT `.script` the sweep loaded. Its canonical SHA-256
+  must equal the manifest's `script_sha256`; same hash-drift contract as
+  `resume` and `extend`. Add `--allow-script-drift` to proceed past a
   mismatch — the bundle still records the manifest's original hash so a
-  downstream verifier can spot the drift.
+  downstream verifier can spot the drift. The older `--script PATH` flag is
+  still accepted.
+
+Required flag:
+
 - `--out PATH` — destination `.zip` path. Parent directories are created on
   demand.
 
@@ -372,5 +381,5 @@ archives of the same manifest produce identical bytes. See
 [Cookbook § Pattern 4 — Archival deposit](cookbook.md#pattern-4-archival-deposit-zenodo-joss)
 for the full layout and the reproduce-from-bundle recipe.
 
-A missing `MANIFEST` exits with code `3`; a missing `--script`, or a hash
+A missing `MANIFEST` exits with code `3`; a missing `SCRIPT`, or a hash
 mismatch without `--allow-script-drift`, exits with code `2`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -27,8 +27,7 @@ The subcommands:
 ## Common options
 
 The sweep-running subcommands (`run`, `monte-carlo`, `latin-hypercube`,
-`explicit`) and the post-hoc subcommands that drive new runs (`extend`,
-`resume`) share three flags:
+`explicit`) share three flags:
 
 | Flag         | Default | Meaning                                                                      |
 |--------------|---------|------------------------------------------------------------------------------|
@@ -36,9 +35,10 @@ The sweep-running subcommands (`run`, `monte-carlo`, `latin-hypercube`,
 | `--out PATH` | —       | Required. Output directory for per-run artefacts and `manifest.jsonl`.       |
 | `SCRIPT`     | —       | Required positional. Path to the GMAT `.script` every run loads.             |
 
-`extend`, `resume`, and `archive` also accept `SCRIPT` as a positional. The
-older `--script PATH` flag still works on those three subcommands but the
-positional form is canonical — the examples below use it.
+The post-hoc subcommands (`extend`, `resume`, `archive`) take the script as
+a `--script PATH` flag instead — the manifest is the primary positional
+input on those, and the script is a parameter pointing at the previously-
+loaded mission file.
 
 Each of those four subcommands writes a `manifest.jsonl` under `--out` and
 prints a one-line summary to stdout when the sweep finishes:
@@ -225,21 +225,20 @@ Re-run only the failed and never-recorded entries from an existing
 `manifest.jsonl`. Successful runs' Parquet files are reused from disk.
 
 ```bash
-gmat-sweep resume ./sweep-out/manifest.jsonl mission.script \
+gmat-sweep resume ./sweep-out/manifest.jsonl \
+    --script mission.script \
     --workers 4
 ```
 
-Required positionals:
+Required positional: `MANIFEST` — the existing `manifest.jsonl`.
 
-- `MANIFEST` — the existing `manifest.jsonl`.
-- `SCRIPT` — the same GMAT `.script` the original sweep loaded. The older
-  `--script PATH` flag is still accepted. The script's canonical SHA-256
-  must equal the manifest's `script_sha256`; see
-  [Resume § Script drift](resume.md#script-drift) for the full contract.
-  Add `--allow-script-drift` to proceed past a hash mismatch (emits a
-  `RuntimeWarning`).
+Required flag: `--script PATH` — the same GMAT `.script` the original sweep
+loaded. Its canonical SHA-256 must equal the manifest's `script_sha256`; see
+[Resume § Script drift](resume.md#script-drift) for the full contract. Add
+`--allow-script-drift` to proceed past a hash mismatch (emits a
+`RuntimeWarning`).
 
-A missing `MANIFEST` exits with code `3`; a missing `SCRIPT` or a hash
+A missing `MANIFEST` exits with code `3`; a missing `--script` or a hash
 mismatch exits with code `2`.
 
 ## `extend`
@@ -250,30 +249,30 @@ draws are bit-equal to the same indices of a fresh
 `monte_carlo(n=old_n + N)` call.
 
 ```bash
-gmat-sweep extend ./mc-out/manifest.jsonl mission.script \
+gmat-sweep extend ./mc-out/manifest.jsonl \
     --n 1000 \
+    --script mission.script \
     --workers 8
 ```
 
-Required positionals:
+Required positional: `MANIFEST` — an existing Monte Carlo
+`manifest.jsonl`. Grid, explicit-row, and Latin hypercube manifests
+exit with code `2` (their stochastic semantics don't admit clean
+extension).
 
-- `MANIFEST` — an existing Monte Carlo `manifest.jsonl`. Grid, explicit-row,
-  and Latin hypercube manifests exit with code `2` (their stochastic
-  semantics don't admit clean extension).
-- `SCRIPT` — the same GMAT `.script` the original sweep loaded. Same
-  hash-drift contract as `resume`; add `--allow-script-drift` to proceed
-  past a mismatch. The older `--script PATH` flag is still accepted.
-
-Required flag:
+Required flags:
 
 - `--n N` — number of additional stochastic runs to append, ≥ 1.
+- `--script PATH` — the same GMAT `.script` the original sweep loaded.
+  Same hash-drift contract as `resume`; add `--allow-script-drift` to
+  proceed past a mismatch.
 
 `extend` refuses if the base sweep has any `failed` or missing runs in
 its original `[0, n)` range — the underlying error names them and
 points at `gmat-sweep resume`. Run `resume` first, then `extend`.
 
 A missing `MANIFEST` exits with code `3`; a non-Monte-Carlo manifest,
-an incomplete base sweep, a missing `SCRIPT`, or a hash mismatch
+an incomplete base sweep, a missing `--script`, or a hash mismatch
 exits with code `2`. See
 [Monte Carlo § Extending an existing sweep](monte-carlo.md#extending-an-existing-sweep)
 for the full determinism contract.
@@ -351,22 +350,20 @@ single self-describing `.zip` suitable for archival deposit (Zenodo, JOSS
 supplementary material) or internal handoff.
 
 ```bash
-gmat-sweep archive ./sweep-out/manifest.jsonl mission.script \
+gmat-sweep archive ./sweep-out/manifest.jsonl \
+    --script mission.script \
     --out ./sma-scan-2026q2.zip
 ```
 
-Required positionals:
+Required positional: `MANIFEST` — the existing `manifest.jsonl`.
 
-- `MANIFEST` — the existing `manifest.jsonl`.
-- `SCRIPT` — the same GMAT `.script` the sweep loaded. Its canonical SHA-256
-  must equal the manifest's `script_sha256`; same hash-drift contract as
-  `resume` and `extend`. Add `--allow-script-drift` to proceed past a
+Required flags:
+
+- `--script PATH` — the same GMAT `.script` the sweep loaded. Its canonical
+  SHA-256 must equal the manifest's `script_sha256`; same hash-drift contract
+  as `resume` and `extend`. Add `--allow-script-drift` to proceed past a
   mismatch — the bundle still records the manifest's original hash so a
-  downstream verifier can spot the drift. The older `--script PATH` flag is
-  still accepted.
-
-Required flag:
-
+  downstream verifier can spot the drift.
 - `--out PATH` — destination `.zip` path. Parent directories are created on
   demand.
 
@@ -381,5 +378,5 @@ archives of the same manifest produce identical bytes. See
 [Cookbook § Pattern 4 — Archival deposit](cookbook.md#pattern-4-archival-deposit-zenodo-joss)
 for the full layout and the reproduce-from-bundle recipe.
 
-A missing `MANIFEST` exits with code `3`; a missing `SCRIPT`, or a hash
+A missing `MANIFEST` exits with code `3`; a missing `--script`, or a hash
 mismatch without `--allow-script-drift`, exits with code `2`.

--- a/src/gmat_sweep/__init__.py
+++ b/src/gmat_sweep/__init__.py
@@ -1,25 +1,22 @@
-"""gmat-sweep: parameter sweeps and Monte Carlo dispersions over GMAT missions in parallel."""
+"""gmat-sweep: parameter sweeps and Monte Carlo dispersions over GMAT missions in parallel.
+
+Public symbols are exposed via :pep:`562` lazy attribute access. Submodules that
+transitively pull in :mod:`pandas`, :mod:`pyarrow`, or :mod:`tqdm` are only
+imported on first reference, so ``import gmat_sweep`` (and the
+``gmat-sweep --help`` cold path) does not pay their import cost. The lazy
+surface is still discoverable through :func:`dir` and resolvable by static
+type checkers via the :data:`typing.TYPE_CHECKING` re-export block below.
+"""
+
+from __future__ import annotations
 
 import logging
+import sys
+import types
+from importlib import import_module
 from importlib.metadata import PackageNotFoundError, version
+from typing import TYPE_CHECKING, Any
 
-from gmat_sweep.aggregate import (
-    lazy_contacts,
-    lazy_ephemerides,
-    lazy_fused_reports,
-    lazy_multiindex,
-    mc_convergence,
-    sweep_diff,
-    sweep_summary,
-)
-from gmat_sweep.api import (
-    latin_hypercube,
-    latin_hypercube_extend,
-    monte_carlo,
-    monte_carlo_extend,
-    sweep,
-)
-from gmat_sweep.backends import LocalJoblibPool, Pool
 from gmat_sweep.errors import (
     BackendError,
     GmatSweepError,
@@ -27,24 +24,48 @@ from gmat_sweep.errors import (
     RunFailed,
     SweepConfigError,
 )
-from gmat_sweep.grids import (
-    expand_grid_to_run_specs,
-    expand_latin_hypercube_to_run_specs,
-    expand_monte_carlo_extension_to_run_specs,
-    expand_monte_carlo_to_run_specs,
-    expand_samples_to_run_specs,
-    full_factorial,
-    latin_hypercube_samples,
-)
-from gmat_sweep.manifest import (
-    MANIFEST_SCHEMA_VERSION,
-    Manifest,
-    ManifestEntry,
-    canonical_script_sha256,
-)
-from gmat_sweep.sensitivity import sobol_analyze, sobol_sample
-from gmat_sweep.spec import RunOutcome, RunSpec, SweepSpec
-from gmat_sweep.sweep import Sweep
+
+if TYPE_CHECKING:
+    # Re-exported for static type checkers. The actual imports happen lazily
+    # via __getattr__ — never at module load time — so heavy submodules
+    # (aggregate, api, sweep, sensitivity, plotting) are not pulled on
+    # `import gmat_sweep`.
+    from gmat_sweep.aggregate import (
+        lazy_contacts,
+        lazy_ephemerides,
+        lazy_fused_reports,
+        lazy_multiindex,
+        mc_convergence,
+        sweep_diff,
+        sweep_summary,
+    )
+    from gmat_sweep.api import (
+        latin_hypercube,
+        latin_hypercube_extend,
+        monte_carlo,
+        monte_carlo_extend,
+        sweep,
+    )
+    from gmat_sweep.backends import LocalJoblibPool, Pool
+    from gmat_sweep.grids import (
+        expand_grid_to_run_specs,
+        expand_latin_hypercube_to_run_specs,
+        expand_monte_carlo_extension_to_run_specs,
+        expand_monte_carlo_to_run_specs,
+        expand_samples_to_run_specs,
+        full_factorial,
+        latin_hypercube_samples,
+    )
+    from gmat_sweep.manifest import (
+        MANIFEST_SCHEMA_VERSION,
+        Manifest,
+        ManifestEntry,
+        canonical_script_sha256,
+    )
+    from gmat_sweep.sensitivity import sobol_analyze, sobol_sample
+    from gmat_sweep.spec import RunOutcome, RunSpec, SweepSpec
+    from gmat_sweep.sweep import Sweep
+
 
 try:
     __version__ = version("gmat-sweep")
@@ -59,6 +80,91 @@ except PackageNotFoundError:
 _logger = logging.getLogger(__name__)
 if _logger.level == logging.NOTSET:
     _logger.setLevel(logging.WARNING)
+
+
+_LAZY_ATTRS: dict[str, str] = {
+    "lazy_contacts": "gmat_sweep.aggregate",
+    "lazy_ephemerides": "gmat_sweep.aggregate",
+    "lazy_fused_reports": "gmat_sweep.aggregate",
+    "lazy_multiindex": "gmat_sweep.aggregate",
+    "mc_convergence": "gmat_sweep.aggregate",
+    "sweep_diff": "gmat_sweep.aggregate",
+    "sweep_summary": "gmat_sweep.aggregate",
+    "latin_hypercube": "gmat_sweep.api",
+    "latin_hypercube_extend": "gmat_sweep.api",
+    "monte_carlo": "gmat_sweep.api",
+    "monte_carlo_extend": "gmat_sweep.api",
+    "sweep": "gmat_sweep.api",
+    "LocalJoblibPool": "gmat_sweep.backends",
+    "Pool": "gmat_sweep.backends",
+    "expand_grid_to_run_specs": "gmat_sweep.grids",
+    "expand_latin_hypercube_to_run_specs": "gmat_sweep.grids",
+    "expand_monte_carlo_extension_to_run_specs": "gmat_sweep.grids",
+    "expand_monte_carlo_to_run_specs": "gmat_sweep.grids",
+    "expand_samples_to_run_specs": "gmat_sweep.grids",
+    "full_factorial": "gmat_sweep.grids",
+    "latin_hypercube_samples": "gmat_sweep.grids",
+    "MANIFEST_SCHEMA_VERSION": "gmat_sweep.manifest",
+    "Manifest": "gmat_sweep.manifest",
+    "ManifestEntry": "gmat_sweep.manifest",
+    "canonical_script_sha256": "gmat_sweep.manifest",
+    "sobol_analyze": "gmat_sweep.sensitivity",
+    "sobol_sample": "gmat_sweep.sensitivity",
+    "RunOutcome": "gmat_sweep.spec",
+    "RunSpec": "gmat_sweep.spec",
+    "SweepSpec": "gmat_sweep.spec",
+    "Sweep": "gmat_sweep.sweep",
+}
+
+
+def __getattr__(name: str) -> Any:
+    module_path = _LAZY_ATTRS.get(name)
+    if module_path is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    attr = getattr(import_module(module_path), name)
+    globals()[name] = attr
+    return attr
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | _LAZY_ATTRS.keys())
+
+
+class _GmatSweepModule(types.ModuleType):
+    """Module subclass that repairs the ``gmat_sweep.sweep`` name collision.
+
+    The public API exposes ``gmat_sweep.sweep`` as a function (re-exported
+    from :mod:`gmat_sweep.api`), but there's also a submodule named
+    ``gmat_sweep.sweep`` that defines :class:`Sweep`. Whenever that submodule
+    is imported — via :pep:`562` lazy access of :class:`Sweep` here, via
+    ``from gmat_sweep.sweep import Sweep`` in downstream code, or via any
+    other path — Python writes the submodule into :data:`gmat_sweep.__dict__`
+    at the ``sweep`` key, shadowing the function.
+
+    The old eager :mod:`gmat_sweep.__init__` papered over this by reassigning
+    ``sweep`` to the function at the bottom of the module. With lazy loading
+    we can't run that reassignment unconditionally — it would force the
+    :mod:`gmat_sweep.api` import (and the pandas / pyarrow / tqdm chain it
+    pulls) on every ``import gmat_sweep``. Instead we detect the shadow on
+    attribute access and resolve it on demand. The added cost is one
+    :func:`isinstance` check per attribute read on the package.
+    """
+
+    def __getattribute__(self, name: str) -> Any:
+        value = super().__getattribute__(name)
+        if name == "sweep" and isinstance(value, types.ModuleType):
+            # Submodule shadow detected. Resolve to the public function from
+            # gmat_sweep.api and cache it in __dict__ so subsequent reads
+            # short-circuit through normal attribute lookup.
+            from gmat_sweep.api import sweep as _fn
+
+            super().__setattr__("sweep", _fn)
+            return _fn
+        return value
+
+
+sys.modules[__name__].__class__ = _GmatSweepModule
+
 
 __all__ = [
     "MANIFEST_SCHEMA_VERSION",

--- a/src/gmat_sweep/cli.py
+++ b/src/gmat_sweep/cli.py
@@ -600,7 +600,7 @@ def _cmd_archive(args: argparse.Namespace) -> int:
     if not manifest_path.is_file():
         print(f"gmat-sweep: manifest not found: {manifest_path}", file=sys.stderr)
         return EXIT_MANIFEST
-    script = Path(_resolve_script_arg(args, "archive"))
+    script = Path(args.script)
     if not script.is_file():
         print(f"gmat-sweep: script not found: {script}", file=sys.stderr)
         return EXIT_CONFIG
@@ -629,7 +629,7 @@ def _cmd_extend(args: argparse.Namespace) -> int:
     if not manifest_path.is_file():
         print(f"gmat-sweep: manifest not found: {manifest_path}", file=sys.stderr)
         return EXIT_MANIFEST
-    script = Path(_resolve_script_arg(args, "extend"))
+    script = Path(args.script)
     if not script.is_file():
         print(f"gmat-sweep: script not found: {script}", file=sys.stderr)
         return EXIT_CONFIG
@@ -657,7 +657,7 @@ def _cmd_resume(args: argparse.Namespace) -> int:
     if not manifest_path.is_file():
         print(f"gmat-sweep: manifest not found: {manifest_path}", file=sys.stderr)
         return EXIT_MANIFEST
-    script = Path(_resolve_script_arg(args, "resume"))
+    script = Path(args.script)
     if not script.is_file():
         print(f"gmat-sweep: script not found: {script}", file=sys.stderr)
         return EXIT_CONFIG
@@ -721,56 +721,6 @@ def _add_workers_flag(subparser: argparse.ArgumentParser) -> None:
         metavar="N",
         help=_WORKERS_HELP,
     )
-
-
-def _add_post_hoc_script_args(subparser: argparse.ArgumentParser, *, hash_clause: str) -> None:
-    """Attach SCRIPT positional + ``--script PATH`` flag to a post-hoc subparser.
-
-    ``extend``, ``resume``, and ``archive`` historically took ``--script PATH``
-    as a required flag, which is asymmetric with the four sweep-running
-    subcommands (``run``, ``monte-carlo``, ``latin-hypercube``, ``explicit``)
-    that take it as a positional. Both forms are accepted so existing scripts
-    keep working; the positional is the canonical form in the docs. Either
-    one must be supplied — :func:`_resolve_script_arg` raises
-    :class:`SweepConfigError` if neither is set or if both are.
-
-    ``hash_clause`` is the trailing sentence of the help text that varies by
-    subcommand (extend/resume mention re-runs; archive mentions the bundle).
-    """
-    subparser.add_argument(
-        "script_positional",
-        nargs="?",
-        default=None,
-        metavar="SCRIPT",
-        help=("Path to the same GMAT .script the original sweep loaded. " + hash_clause),
-    )
-    subparser.add_argument(
-        "--script",
-        dest="script_flag",
-        default=None,
-        metavar="PATH",
-        help="Deprecated synonym for the SCRIPT positional; still accepted.",
-    )
-
-
-def _resolve_script_arg(args: argparse.Namespace, subcommand: str) -> str:
-    """Return the script path from either the positional or the ``--script`` flag.
-
-    Raises :class:`SweepConfigError` if both are set or neither is.
-    """
-    positional: str | None = args.script_positional
-    flag: str | None = args.script_flag
-    if positional is not None and flag is not None:
-        raise SweepConfigError(
-            f"gmat-sweep {subcommand}: SCRIPT given as both a positional and --script PATH; "
-            "use one or the other"
-        )
-    resolved = positional if positional is not None else flag
-    if resolved is None:
-        raise SweepConfigError(
-            f"gmat-sweep {subcommand}: SCRIPT is required (positional or --script PATH)"
-        )
-    return resolved
 
 
 def _add_backend_flag(subparser: argparse.ArgumentParser) -> None:
@@ -1045,10 +995,13 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="N",
         help="Number of additional stochastic runs to append (>= 1).",
     )
-    _add_post_hoc_script_args(
-        extend,
-        hash_clause=(
-            "Its canonical SHA-256 must equal the manifest's script_sha256 unless "
+    extend.add_argument(
+        "--script",
+        required=True,
+        metavar="PATH",
+        help=(
+            "Path to the same GMAT .script the original sweep loaded. Its "
+            "canonical SHA-256 must equal the manifest's script_sha256 unless "
             "--allow-script-drift is set."
         ),
     )
@@ -1079,11 +1032,14 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="MANIFEST",
         help="Path to a manifest.jsonl produced by a prior sweep.",
     )
-    _add_post_hoc_script_args(
-        resume,
-        hash_clause=(
-            "Its canonical SHA-256 must equal the manifest's script_sha256 unless "
-            "--allow-script-drift is set."
+    resume.add_argument(
+        "--script",
+        required=True,
+        metavar="PATH",
+        help=(
+            "Path to the same GMAT .script the original sweep loaded. Its canonical "
+            "SHA-256 must equal the manifest's script_sha256 unless --allow-script-drift "
+            "is set."
         ),
     )
     _add_workers_flag(resume)
@@ -1115,10 +1071,13 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="MANIFEST",
         help="Path to a manifest.jsonl produced by a prior sweep.",
     )
-    _add_post_hoc_script_args(
-        archive,
-        hash_clause=(
-            "Its canonical SHA-256 must equal the manifest's script_sha256 unless "
+    archive.add_argument(
+        "--script",
+        required=True,
+        metavar="PATH",
+        help=(
+            "Path to the same GMAT .script the sweep loaded. Its canonical "
+            "SHA-256 must equal the manifest's script_sha256 unless "
             "--allow-script-drift is set."
         ),
     )

--- a/src/gmat_sweep/cli.py
+++ b/src/gmat_sweep/cli.py
@@ -17,18 +17,12 @@ Exit codes
 from __future__ import annotations
 
 import argparse
+import math
 import sys
 from collections.abc import Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
-import numpy as np
-
-from gmat_sweep.api import latin_hypercube, monte_carlo, monte_carlo_extend, sweep
-from gmat_sweep.backends.dask import DaskPool
-from gmat_sweep.backends.joblib import LocalJoblibPool
-from gmat_sweep.backends.mpi import MPIPool
-from gmat_sweep.backends.ray import RayPool
 from gmat_sweep.errors import (
     BackendError,
     GmatSweepError,
@@ -36,6 +30,64 @@ from gmat_sweep.errors import (
     SweepConfigError,
 )
 from gmat_sweep.manifest import Manifest, ManifestEntry
+
+# Heavy submodules (api, backends.{dask,ray,mpi}, joblib) are imported on
+# first use — `gmat-sweep --help` should not pull pandas / pyarrow / tqdm /
+# joblib just to print usage text. ``_cmd_*`` functions import from
+# ``gmat_sweep.api`` directly inside their bodies; backend pool classes are
+# resolved through :func:`_import_backend_class`, which keeps them
+# monkey-patchable in tests.
+
+# Backend pool class slots. ``None`` means "load lazily on first access";
+# tests that do ``monkeypatch.setattr(cli, "MPIPool", fake)`` set their
+# preferred class here and :func:`_import_backend_class` picks it up.
+DaskPool: Any = None
+LocalJoblibPool: Any = None
+MPIPool: Any = None
+RayPool: Any = None
+
+# Public-API function slots. Same pattern as the backend pool slots — kept at
+# module level so ``monkeypatch.setattr("gmat_sweep.cli.sweep", fake)`` still
+# works without forcing ``gmat_sweep.api`` (and its tqdm / pandas / pyarrow
+# transitive imports) on every ``gmat-sweep --help`` invocation.
+sweep: Any = None
+monte_carlo: Any = None
+latin_hypercube: Any = None
+monte_carlo_extend: Any = None
+
+_BACKEND_MODULES: dict[str, str] = {
+    "DaskPool": "gmat_sweep.backends.dask",
+    "LocalJoblibPool": "gmat_sweep.backends.joblib",
+    "MPIPool": "gmat_sweep.backends.mpi",
+    "RayPool": "gmat_sweep.backends.ray",
+}
+
+_API_FUNCS = ("sweep", "monte_carlo", "latin_hypercube", "monte_carlo_extend")
+
+
+def _import_backend_class(class_name: str) -> Any:
+    """Return the named backend pool class, importing on first call."""
+    existing = globals().get(class_name)
+    if existing is not None:
+        return existing
+    from importlib import import_module
+
+    cls = getattr(import_module(_BACKEND_MODULES[class_name]), class_name)
+    globals()[class_name] = cls
+    return cls
+
+
+def _import_api_func(name: str) -> Any:
+    """Return the named :mod:`gmat_sweep.api` function, importing on first call."""
+    existing = globals().get(name)
+    if existing is not None:
+        return existing
+    from importlib import import_module
+
+    fn = getattr(import_module("gmat_sweep.api"), name)
+    globals()[name] = fn
+    return fn
+
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -60,16 +112,24 @@ _STATUS_BUCKETS: dict[str, int] = {"failed": 0, "skipped": 1, "ok": 2}
 
 
 def _parse_grid_value(token: str) -> int | float | str:
-    """Coerce a single explicit-list token via int → float → str fallback."""
+    """Coerce a single explicit-list token via int → float → str fallback.
+
+    Non-finite floats (``nan``, ``inf``, ``-inf``) are rejected even though
+    Python's :func:`float` parses them: a NaN axis carries no signal, and an
+    infinite override would silently produce an unrunnable spec. They surface
+    as :class:`SweepConfigError` here instead of corrupting the run set.
+    """
     try:
         return int(token)
     except ValueError:
         pass
     try:
-        return float(token)
+        as_float = float(token)
     except ValueError:
-        pass
-    return token
+        return token
+    if not math.isfinite(as_float):
+        raise SweepConfigError(f"non-finite numeric value is not allowed: {token!r}")
+    return as_float
 
 
 def _parse_grid_spec(spec: str) -> tuple[str, list[Any]]:
@@ -112,6 +172,10 @@ def _parse_grid_spec(spec: str) -> tuple[str, list[Any]]:
             raise SweepConfigError(
                 f"linspace bounds for {name!r} must be numeric, got {lo_str!r}:{hi_str!r}"
             ) from exc
+        if not math.isfinite(lo) or not math.isfinite(hi):
+            raise SweepConfigError(
+                f"linspace bounds for {name!r} must be finite, got {lo_str!r}:{hi_str!r}"
+            )
         try:
             count = int(count_str)
         except ValueError as exc:
@@ -120,6 +184,8 @@ def _parse_grid_spec(spec: str) -> tuple[str, list[Any]]:
             ) from exc
         if count < 2:
             raise SweepConfigError(f"linspace count for {name!r} must be >= 2, got {count}")
+        import numpy as np
+
         return name, np.linspace(lo, hi, count).tolist()
 
     tokens = rhs.split(",")
@@ -218,14 +284,30 @@ def _build_pool(args: argparse.Namespace) -> Pool:
                 "--backend-arg is not supported with --backend local; "
                 "the local pool only accepts --workers"
             )
-        return LocalJoblibPool(max_workers=args.workers)
+        return cast("Pool", _import_backend_class("LocalJoblibPool")(max_workers=args.workers))
     workers = args.workers if args.workers > 0 else None
     if args.backend == "dask":
-        return DaskPool(n_workers=workers, **backend_kwargs)
+        return cast(
+            "Pool",
+            _import_backend_class("DaskPool")(n_workers=workers, **backend_kwargs),
+        )
     if args.backend == "ray":
-        return RayPool(num_cpus=workers, **backend_kwargs)
+        return cast(
+            "Pool",
+            _import_backend_class("RayPool")(num_cpus=workers, **backend_kwargs),
+        )
     if args.backend == "mpi":
-        return MPIPool(**backend_kwargs)
+        # MPIPool's rank count is fixed by the launcher (``mpirun -n …`` or the
+        # ``--backend-arg max_workers=N`` escape hatch); --workers has no
+        # meaning here. Silently ignoring the flag used to confuse users into
+        # thinking their value had been honoured — fail loudly instead.
+        if args.workers != -1:
+            raise SweepConfigError(
+                "--workers is not supported with --backend mpi; the rank count is "
+                "fixed by the MPI launcher. Pass '--backend-arg max_workers=N' to "
+                "cap MPIPool's in-flight set instead."
+            )
+        return cast("Pool", _import_backend_class("MPIPool")(**backend_kwargs))
     raise AssertionError(f"unreachable backend: {args.backend!r}")  # pragma: no cover
 
 
@@ -281,6 +363,8 @@ def _cmd_run(args: argparse.Namespace) -> int:
         if name in grid:
             raise SweepConfigError(f"grid spec for {name!r} given more than once")
         grid[name] = values
+
+    sweep = _import_api_func("sweep")
 
     out = Path(args.out)
     with _build_pool(args) as pool:
@@ -389,12 +473,16 @@ def _format_run_detail(entry: ManifestEntry) -> str:
 
 
 def _cmd_show(args: argparse.Namespace) -> int:
+    # Validate flag shape before touching disk so a typo like
+    # `gmat-sweep show --filter ok` fails immediately, not after a manifest
+    # stat or load.
+    if args.filter is not None and not args.detail:
+        raise SweepConfigError("--filter requires --detail")
+
     manifest_path = Path(args.manifest)
     if not manifest_path.is_file():
         print(f"gmat-sweep: manifest not found: {manifest_path}", file=sys.stderr)
         return EXIT_MANIFEST
-    if args.filter is not None and not args.detail:
-        raise SweepConfigError("--filter requires --detail")
 
     manifest = Manifest.load(manifest_path)
 
@@ -435,6 +523,8 @@ def _cmd_monte_carlo(args: argparse.Namespace) -> int:
         return EXIT_CONFIG
 
     perturb = _collect_perturb(args.perturb)
+    monte_carlo = _import_api_func("monte_carlo")
+
     out = Path(args.out)
     with _build_pool(args) as pool:
         monte_carlo(
@@ -460,6 +550,8 @@ def _cmd_latin_hypercube(args: argparse.Namespace) -> int:
         return EXIT_CONFIG
 
     perturb = _collect_perturb(args.perturb)
+    latin_hypercube = _import_api_func("latin_hypercube")
+
     out = Path(args.out)
     with _build_pool(args) as pool:
         latin_hypercube(
@@ -485,6 +577,8 @@ def _cmd_explicit(args: argparse.Namespace) -> int:
         return EXIT_CONFIG
 
     samples = _load_samples(Path(args.samples))
+    sweep = _import_api_func("sweep")
+
     out = Path(args.out)
     with _build_pool(args) as pool:
         sweep(
@@ -506,7 +600,7 @@ def _cmd_archive(args: argparse.Namespace) -> int:
     if not manifest_path.is_file():
         print(f"gmat-sweep: manifest not found: {manifest_path}", file=sys.stderr)
         return EXIT_MANIFEST
-    script = Path(args.script)
+    script = Path(_resolve_script_arg(args, "archive"))
     if not script.is_file():
         print(f"gmat-sweep: script not found: {script}", file=sys.stderr)
         return EXIT_CONFIG
@@ -535,10 +629,12 @@ def _cmd_extend(args: argparse.Namespace) -> int:
     if not manifest_path.is_file():
         print(f"gmat-sweep: manifest not found: {manifest_path}", file=sys.stderr)
         return EXIT_MANIFEST
-    script = Path(args.script)
+    script = Path(_resolve_script_arg(args, "extend"))
     if not script.is_file():
         print(f"gmat-sweep: script not found: {script}", file=sys.stderr)
         return EXIT_CONFIG
+
+    monte_carlo_extend = _import_api_func("monte_carlo_extend")
 
     with _build_pool(args) as pool:
         monte_carlo_extend(
@@ -561,7 +657,7 @@ def _cmd_resume(args: argparse.Namespace) -> int:
     if not manifest_path.is_file():
         print(f"gmat-sweep: manifest not found: {manifest_path}", file=sys.stderr)
         return EXIT_MANIFEST
-    script = Path(args.script)
+    script = Path(_resolve_script_arg(args, "resume"))
     if not script.is_file():
         print(f"gmat-sweep: script not found: {script}", file=sys.stderr)
         return EXIT_CONFIG
@@ -607,6 +703,74 @@ def _add_fsync_flags(subparser: argparse.ArgumentParser) -> None:
             "Ignored when --fsync-each is in effect. Default: 50."
         ),
     )
+
+
+_WORKERS_HELP = (
+    "Number of subprocess workers. Default -1 uses every available core. "
+    "Ignored on --backend mpi (the launcher fixes the rank count); pass "
+    "--workers explicitly there and gmat-sweep exits 2."
+)
+
+
+def _add_workers_flag(subparser: argparse.ArgumentParser) -> None:
+    """Attach the shared ``--workers`` flag to a sweep-running subparser."""
+    subparser.add_argument(
+        "--workers",
+        type=int,
+        default=-1,
+        metavar="N",
+        help=_WORKERS_HELP,
+    )
+
+
+def _add_post_hoc_script_args(subparser: argparse.ArgumentParser, *, hash_clause: str) -> None:
+    """Attach SCRIPT positional + ``--script PATH`` flag to a post-hoc subparser.
+
+    ``extend``, ``resume``, and ``archive`` historically took ``--script PATH``
+    as a required flag, which is asymmetric with the four sweep-running
+    subcommands (``run``, ``monte-carlo``, ``latin-hypercube``, ``explicit``)
+    that take it as a positional. Both forms are accepted so existing scripts
+    keep working; the positional is the canonical form in the docs. Either
+    one must be supplied — :func:`_resolve_script_arg` raises
+    :class:`SweepConfigError` if neither is set or if both are.
+
+    ``hash_clause`` is the trailing sentence of the help text that varies by
+    subcommand (extend/resume mention re-runs; archive mentions the bundle).
+    """
+    subparser.add_argument(
+        "script_positional",
+        nargs="?",
+        default=None,
+        metavar="SCRIPT",
+        help=("Path to the same GMAT .script the original sweep loaded. " + hash_clause),
+    )
+    subparser.add_argument(
+        "--script",
+        dest="script_flag",
+        default=None,
+        metavar="PATH",
+        help="Deprecated synonym for the SCRIPT positional; still accepted.",
+    )
+
+
+def _resolve_script_arg(args: argparse.Namespace, subcommand: str) -> str:
+    """Return the script path from either the positional or the ``--script`` flag.
+
+    Raises :class:`SweepConfigError` if both are set or neither is.
+    """
+    positional: str | None = args.script_positional
+    flag: str | None = args.script_flag
+    if positional is not None and flag is not None:
+        raise SweepConfigError(
+            f"gmat-sweep {subcommand}: SCRIPT given as both a positional and --script PATH; "
+            "use one or the other"
+        )
+    resolved = positional if positional is not None else flag
+    if resolved is None:
+        raise SweepConfigError(
+            f"gmat-sweep {subcommand}: SCRIPT is required (positional or --script PATH)"
+        )
+    return resolved
 
 
 def _add_backend_flag(subparser: argparse.ArgumentParser) -> None:
@@ -665,13 +829,7 @@ def _build_parser() -> argparse.ArgumentParser:
             "Repeat --grid for additional axes; the cartesian product is run."
         ),
     )
-    run.add_argument(
-        "--workers",
-        type=int,
-        default=-1,
-        metavar="N",
-        help="Number of subprocess workers. Default -1 uses every available core.",
-    )
+    _add_workers_flag(run)
     run.add_argument(
         "--out",
         required=True,
@@ -734,8 +892,9 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Run a Monte Carlo dispersion sweep over a GMAT script.",
         description=(
             "Run n stochastic samples by independently sampling each --perturb "
-            "parameter from its own distribution. With --seed set, the run set "
-            "is reproducible."
+            "parameter from its own distribution. Two runs at the same "
+            "(--perturb, --n, --seed) produce bit-equal DataFrames; without "
+            "--seed the draws fall back to OS entropy."
         ),
     )
     monte.add_argument(
@@ -764,13 +923,7 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="SEED",
         help="Optional integer parent seed. Omit for OS entropy (non-reproducible).",
     )
-    monte.add_argument(
-        "--workers",
-        type=int,
-        default=-1,
-        metavar="N",
-        help="Number of subprocess workers. Default -1 uses every available core.",
-    )
+    _add_workers_flag(monte)
     monte.add_argument(
         "--out",
         required=True,
@@ -821,13 +974,7 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="SEED",
         help="Optional integer seed for the Latin hypercube sampler.",
     )
-    lhs.add_argument(
-        "--workers",
-        type=int,
-        default=-1,
-        metavar="N",
-        help="Number of subprocess workers. Default -1 uses every available core.",
-    )
+    _add_workers_flag(lhs)
     lhs.add_argument(
         "--out",
         required=True,
@@ -858,13 +1005,7 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="PATH",
         help="Path to a .csv or .parquet sample design.",
     )
-    explicit.add_argument(
-        "--workers",
-        type=int,
-        default=-1,
-        metavar="N",
-        help="Number of subprocess workers. Default -1 uses every available core.",
-    )
+    _add_workers_flag(explicit)
     explicit.add_argument(
         "--out",
         required=True,
@@ -904,23 +1045,14 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="N",
         help="Number of additional stochastic runs to append (>= 1).",
     )
-    extend.add_argument(
-        "--script",
-        required=True,
-        metavar="PATH",
-        help=(
-            "Path to the same GMAT .script the original sweep loaded. Its "
-            "canonical SHA-256 must equal the manifest's script_sha256 unless "
+    _add_post_hoc_script_args(
+        extend,
+        hash_clause=(
+            "Its canonical SHA-256 must equal the manifest's script_sha256 unless "
             "--allow-script-drift is set."
         ),
     )
-    extend.add_argument(
-        "--workers",
-        type=int,
-        default=-1,
-        metavar="N",
-        help="Number of subprocess workers. Default -1 uses every available core.",
-    )
+    _add_workers_flag(extend)
     extend.add_argument(
         "--allow-script-drift",
         action="store_true",
@@ -947,23 +1079,14 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="MANIFEST",
         help="Path to a manifest.jsonl produced by a prior sweep.",
     )
-    resume.add_argument(
-        "--script",
-        required=True,
-        metavar="PATH",
-        help=(
-            "Path to the same GMAT .script the original sweep loaded. Its canonical "
-            "SHA-256 must equal the manifest's script_sha256 unless --allow-script-drift "
-            "is set."
+    _add_post_hoc_script_args(
+        resume,
+        hash_clause=(
+            "Its canonical SHA-256 must equal the manifest's script_sha256 unless "
+            "--allow-script-drift is set."
         ),
     )
-    resume.add_argument(
-        "--workers",
-        type=int,
-        default=-1,
-        metavar="N",
-        help="Number of subprocess workers. Default -1 uses every available core.",
-    )
+    _add_workers_flag(resume)
     resume.add_argument(
         "--allow-script-drift",
         action="store_true",
@@ -992,13 +1115,10 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="MANIFEST",
         help="Path to a manifest.jsonl produced by a prior sweep.",
     )
-    archive.add_argument(
-        "--script",
-        required=True,
-        metavar="PATH",
-        help=(
-            "Path to the same GMAT .script the sweep loaded. Its canonical "
-            "SHA-256 must equal the manifest's script_sha256 unless "
+    _add_post_hoc_script_args(
+        archive,
+        hash_clause=(
+            "Its canonical SHA-256 must equal the manifest's script_sha256 unless "
             "--allow-script-drift is set."
         ),
     )

--- a/src/gmat_sweep/plotting.py
+++ b/src/gmat_sweep/plotting.py
@@ -31,12 +31,14 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Callable, Sequence
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import numpy as np
 import pandas as pd
 
 from gmat_sweep.errors import SweepConfigError
+
+_HEXBIN_AUTO_THRESHOLD = 2000
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -54,6 +56,7 @@ def sweep_corner(
     *,
     manifest: Manifest | None = None,
     axes: NDArray[Any] | None = None,
+    kind: Literal["scatter", "hexbin", "auto"] = "auto",
     **kwargs: Any,
 ) -> NDArray[Any]:
     """Render a corner/pair plot of ``params`` coloured by ``metric``.
@@ -91,9 +94,17 @@ def sweep_corner(
         (shape ``(N, N)`` where ``N == len(params)``). ``None`` (default)
         creates a fresh figure and axes grid sized
         ``(2.5 * N, 2.5 * N)`` inches.
+    kind:
+        Off-diagonal panel kind: ``"scatter"`` (one point per run, coloured
+        by ``metric``), ``"hexbin"`` (2-D histogram with cells coloured by
+        the mean of ``metric``), or ``"auto"`` (default — picks
+        ``"hexbin"`` when more than 2000 runs survive the failed/skipped
+        filter, else ``"scatter"``). Hexbin avoids the silent overplot
+        problem on large dispersions: a 10⁴-run scatter saturates every
+        pixel and hides the metric variation.
     **kwargs:
-        Forwarded to :meth:`matplotlib.axes.Axes.scatter` for the
-        off-diagonal panels (e.g. ``s=12``, ``alpha=0.6``, ``cmap=...``).
+        Forwarded to :meth:`matplotlib.axes.Axes.scatter` (or
+        :meth:`~matplotlib.axes.Axes.hexbin`) for the off-diagonal panels.
 
     Returns
     -------
@@ -151,11 +162,20 @@ def sweep_corner(
                 f"sweep_corner: axes shape {axes_arr.shape} does not match len(params)=({n}, {n})"
             )
 
+    if kind not in ("scatter", "hexbin", "auto"):
+        raise SweepConfigError(
+            f"sweep_corner: kind must be 'scatter', 'hexbin', or 'auto'; got {kind!r}"
+        )
+    resolved_kind: Literal["scatter", "hexbin"] = (
+        ("hexbin" if len(joined) > _HEXBIN_AUTO_THRESHOLD else "scatter")
+        if kind == "auto"
+        else kind
+    )
+
     metric_arr = joined["__metric"].to_numpy()
     cmap = kwargs.pop("cmap", "viridis")
-    scatter_kwargs: dict[str, Any] = {"s": 16, "alpha": 0.7, **kwargs}
 
-    last_scatter = None
+    last_mappable = None
     for i, p_row in enumerate(resolved_params):
         for j, p_col in enumerate(resolved_params):
             ax = axes_arr[i, j]
@@ -166,13 +186,28 @@ def sweep_corner(
                 if j == 0:
                     ax.set_ylabel("count")
             elif i > j:
-                last_scatter = ax.scatter(
-                    joined[p_col].to_numpy(),
-                    joined[p_row].to_numpy(),
-                    c=metric_arr,
-                    cmap=cmap,
-                    **scatter_kwargs,
-                )
+                if resolved_kind == "scatter":
+                    scatter_kwargs: dict[str, Any] = {"s": 16, "alpha": 0.7, **kwargs}
+                    last_mappable = ax.scatter(
+                        joined[p_col].to_numpy(),
+                        joined[p_row].to_numpy(),
+                        c=metric_arr,
+                        cmap=cmap,
+                        **scatter_kwargs,
+                    )
+                else:
+                    # hexbin colours each cell by the mean of `metric_arr`
+                    # over the runs landing in that cell — the same colour
+                    # story as scatter without the overplot saturation.
+                    hexbin_kwargs: dict[str, Any] = {"gridsize": 30, "mincnt": 1, **kwargs}
+                    last_mappable = ax.hexbin(
+                        joined[p_col].to_numpy(),
+                        joined[p_row].to_numpy(),
+                        C=metric_arr,
+                        reduce_C_function=np.mean,
+                        cmap=cmap,
+                        **hexbin_kwargs,
+                    )
                 if i == n - 1:
                     ax.set_xlabel(p_col)
                 if j == 0:
@@ -180,10 +215,10 @@ def sweep_corner(
             else:
                 ax.set_visible(False)
 
-    if last_scatter is not None:
+    if last_mappable is not None:
         fig = axes_arr[0, 0].figure
         metric_label = metric if isinstance(metric, str) else "metric"
-        fig.colorbar(last_scatter, ax=axes_arr.ravel().tolist(), label=metric_label)
+        fig.colorbar(last_mappable, ax=axes_arr.ravel().tolist(), label=metric_label)
 
     return cast("NDArray[Any]", axes_arr)
 
@@ -268,6 +303,14 @@ def sweep_heatmap(
             f"requested (x={x!r}, y={y!r}) axes"
         )
 
+    for axis_name, level in (("x", x), ("y", y)):
+        index = pivot.columns if axis_name == "x" else pivot.index
+        if not pd.api.types.is_numeric_dtype(index.dtype):
+            raise SweepConfigError(
+                f"sweep_heatmap requires numeric grid axes; got dtype={index.dtype!r} "
+                f"for {axis_name}={level!r}. Use sweep_corner for categorical axes."
+            )
+
     if ax is None:
         _, ax = plt.subplots(figsize=(8, 5))
 
@@ -325,15 +368,60 @@ def _gather_param_values(
 ) -> pd.DataFrame:
     """Build a ``run_id``-indexed DataFrame of per-run values for ``params``.
 
-    Per-param resolution order: prefer the column already in ``df``
-    (reduced via ``.first()`` since perturbed values are constant per
-    run); fall back to ``manifest.entries[i].overrides[param]``; raise
-    if neither path resolves.
+    Per-param resolution order:
+
+    1. If the param appears in ``manifest.parameter_spec``, prefer the
+       manifest override — those are the *design* values the run was
+       configured with. A perturbed dotted-path that happens to collide
+       with a ``ReportFile`` channel name (e.g. ``Sat.SMA`` reported for
+       diagnostics) used to silently take the report column, painting
+       the *measured* value instead of the *commanded* one.
+    2. Otherwise, fall back to the column already in ``df`` (reduced via
+       ``.first()`` since perturbed values are constant per run).
+    3. If neither resolves, raise.
+
+    When both a manifest override and a ``df`` column exist for a
+    manifest-listed param, the override wins. A :class:`RuntimeWarning`
+    fires if the two sources disagree, so a column-vs-design mismatch is
+    surfaced instead of silently masked.
     """
+    spec_params: set[str] = set()
+    if manifest is not None:
+        try:
+            spec_params = set(_params_from_parameter_spec(manifest.parameter_spec))
+        except SweepConfigError:
+            # Unknown _kind tag — keep the old resolution order rather
+            # than failing here; the caller's own validation will surface
+            # the underlying problem.
+            spec_params = set()
+
     columns: dict[str, pd.Series[Any]] = {}
     missing: list[str] = []
     for p in params:
-        if p in df.columns:
+        prefer_override = manifest is not None and p in spec_params
+        if prefer_override:
+            assert manifest is not None  # narrowed by prefer_override
+            try:
+                override_series = pd.Series(
+                    {e.run_id: e.overrides[p] for e in manifest.entries},
+                    name=p,
+                )
+            except KeyError:
+                missing.append(p)
+                continue
+            if p in df.columns:
+                df_series = df.groupby(level="run_id")[p].first()
+                aligned = df_series.reindex(override_series.index)
+                if not aligned.equals(override_series):
+                    warnings.warn(
+                        f"sweep_corner/sweep_heatmap: param {p!r} appears in both "
+                        "manifest.parameter_spec and df.columns and the two sources "
+                        "disagree; using manifest overrides (design values).",
+                        RuntimeWarning,
+                        stacklevel=3,
+                    )
+            columns[p] = override_series
+        elif p in df.columns:
             columns[p] = df.groupby(level="run_id")[p].first()
         elif manifest is not None:
             try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1212,71 +1212,6 @@ def test_resume_rejects_script_drift(
     assert "script hash mismatch" in capsys.readouterr().err
 
 
-def test_resume_accepts_positional_script(
-    tmp_path: Path, fake_gmat_run: FakeGmatRun, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """``gmat-sweep resume MANIFEST SCRIPT`` works without ``--script``."""
-    script = _write_script(tmp_path)
-    out = tmp_path / "out"
-    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
-    cli.main(
-        [
-            "run",
-            "--grid",
-            "a=1,2",
-            "--workers",
-            "1",
-            "--out",
-            str(out),
-            str(script),
-        ]
-    )
-    capsys.readouterr()
-
-    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
-    rc = cli.main(
-        [
-            "resume",
-            str(out / "manifest.jsonl"),
-            str(script),
-            "--workers",
-            "1",
-        ]
-    )
-    assert rc == 0
-
-
-def test_resume_rejects_both_positional_and_flag(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """Supplying SCRIPT twice (positional + ``--script``) is a usage error."""
-    script = _write_script(tmp_path)
-    manifest = tmp_path / "manifest.jsonl"
-    manifest.write_text("", encoding="utf-8")
-    rc = cli.main(
-        [
-            "resume",
-            str(manifest),
-            str(script),
-            "--script",
-            str(script),
-        ]
-    )
-    assert rc == cli.EXIT_CONFIG
-    assert "both a positional and --script" in capsys.readouterr().err
-
-
-def test_resume_rejects_missing_script_argument(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """Neither a positional SCRIPT nor ``--script`` is a usage error."""
-    manifest = tmp_path / "manifest.jsonl"
-    manifest.write_text("", encoding="utf-8")
-    rc = cli.main(["resume", str(manifest)])
-    assert rc == cli.EXIT_CONFIG
-    assert "SCRIPT is required" in capsys.readouterr().err
-
-
 def test_resume_help_lists_allow_script_drift(capsys: pytest.CaptureFixture[str]) -> None:
     with pytest.raises(SystemExit) as exc_info:
         cli.main(["resume", "--help"])
@@ -1395,47 +1330,6 @@ def test_extend_help_lists_allow_script_drift(capsys: pytest.CaptureFixture[str]
     assert "--allow-script-drift" in out
     assert "--script" in out
     assert "--n" in out
-
-
-def test_extend_accepts_positional_script(
-    tmp_path: Path, fake_gmat_run: FakeGmatRun, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """``gmat-sweep extend MANIFEST SCRIPT --n N`` works without ``--script``."""
-    script = _write_script(tmp_path)
-    out = tmp_path / "out"
-    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
-    cli.main(
-        [
-            "monte-carlo",
-            "--n",
-            "2",
-            "--perturb",
-            "Sat.SMA=normal:7100:50",
-            "--seed",
-            "0",
-            "--workers",
-            "1",
-            "--out",
-            str(out),
-            str(script),
-        ]
-    )
-    capsys.readouterr()
-
-    rc = cli.main(
-        [
-            "extend",
-            str(out / "manifest.jsonl"),
-            str(script),
-            "--n",
-            "2",
-            "--workers",
-            "1",
-        ]
-    )
-    assert rc == 0
-    summary = capsys.readouterr().out.splitlines()[0]
-    assert "4 runs" in summary  # 2 original + 2 extended
 
 
 # ---- archive subcommand -------------------------------------------------
@@ -1628,41 +1522,6 @@ def test_archive_rejects_script_drift(
     )
     assert rc == cli.EXIT_CONFIG
     assert "script hash mismatch" in capsys.readouterr().err
-
-
-def test_archive_accepts_positional_script(
-    tmp_path: Path, fake_gmat_run: FakeGmatRun, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """``gmat-sweep archive MANIFEST SCRIPT --out ...`` works without ``--script``."""
-    script = _write_script(tmp_path)
-    out = tmp_path / "out"
-    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
-    cli.main(
-        [
-            "run",
-            "--grid",
-            "Sat.SMA=7000:7200:2",
-            "--workers",
-            "1",
-            "--out",
-            str(out),
-            str(script),
-        ]
-    )
-    capsys.readouterr()
-
-    bundle = tmp_path / "bundle.zip"
-    rc = cli.main(
-        [
-            "archive",
-            str(out / "manifest.jsonl"),
-            str(script),
-            "--out",
-            str(bundle),
-        ]
-    )
-    assert rc == 0
-    assert bundle.is_file()
 
 
 def test_archive_help_lists_flags(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -96,6 +96,22 @@ def test_parse_grid_spec_explicit_rejects_empty_value() -> None:
         cli._parse_grid_spec("a=1,,3")
 
 
+@pytest.mark.parametrize("token", ["nan", "NaN", "inf", "-inf", "Infinity"])
+def test_parse_grid_spec_explicit_rejects_non_finite_floats(token: str) -> None:
+    """``name=1,2,nan`` etc. used to silently produce ``[1, 2, nan]``."""
+    with pytest.raises(SweepConfigError, match="non-finite"):
+        cli._parse_grid_spec(f"a=1,2,{token}")
+
+
+@pytest.mark.parametrize("token", ["nan", "inf", "-inf"])
+def test_parse_grid_spec_linspace_rejects_non_finite_bounds(token: str) -> None:
+    """``name=nan:10:5`` and ``name=0:inf:5`` are unrunnable specs."""
+    with pytest.raises(SweepConfigError, match="finite"):
+        cli._parse_grid_spec(f"a={token}:10:5")
+    with pytest.raises(SweepConfigError, match="finite"):
+        cli._parse_grid_spec(f"a=0:{token}:5")
+
+
 # ---- _parse_grid_spec: malformed ----------------------------------------
 
 
@@ -479,6 +495,23 @@ def test_show_filter_without_detail_exits_config_error(
     rc = cli.main(["show", "--filter", "ok", str(path)])
     assert rc == cli.EXIT_CONFIG
     assert "--filter requires --detail" in capsys.readouterr().err
+
+
+def test_show_filter_without_detail_fails_before_manifest_open(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The cross-flag check must fire before any disk I/O.
+
+    Pointing at a missing manifest with a bad flag combination used to surface
+    "manifest not found" first; the user only learned their flags were wrong
+    after fixing the path. The flag-shape error wins now.
+    """
+    missing = tmp_path / "does-not-exist.jsonl"
+    rc = cli.main(["show", "--filter", "ok", str(missing)])
+    assert rc == cli.EXIT_CONFIG
+    err = capsys.readouterr().err
+    assert "--filter requires --detail" in err
+    assert "manifest not found" not in err
 
 
 def test_show_detail_and_run_are_mutually_exclusive(
@@ -1179,6 +1212,71 @@ def test_resume_rejects_script_drift(
     assert "script hash mismatch" in capsys.readouterr().err
 
 
+def test_resume_accepts_positional_script(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``gmat-sweep resume MANIFEST SCRIPT`` works without ``--script``."""
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+    cli.main(
+        [
+            "run",
+            "--grid",
+            "a=1,2",
+            "--workers",
+            "1",
+            "--out",
+            str(out),
+            str(script),
+        ]
+    )
+    capsys.readouterr()
+
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+    rc = cli.main(
+        [
+            "resume",
+            str(out / "manifest.jsonl"),
+            str(script),
+            "--workers",
+            "1",
+        ]
+    )
+    assert rc == 0
+
+
+def test_resume_rejects_both_positional_and_flag(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Supplying SCRIPT twice (positional + ``--script``) is a usage error."""
+    script = _write_script(tmp_path)
+    manifest = tmp_path / "manifest.jsonl"
+    manifest.write_text("", encoding="utf-8")
+    rc = cli.main(
+        [
+            "resume",
+            str(manifest),
+            str(script),
+            "--script",
+            str(script),
+        ]
+    )
+    assert rc == cli.EXIT_CONFIG
+    assert "both a positional and --script" in capsys.readouterr().err
+
+
+def test_resume_rejects_missing_script_argument(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Neither a positional SCRIPT nor ``--script`` is a usage error."""
+    manifest = tmp_path / "manifest.jsonl"
+    manifest.write_text("", encoding="utf-8")
+    rc = cli.main(["resume", str(manifest)])
+    assert rc == cli.EXIT_CONFIG
+    assert "SCRIPT is required" in capsys.readouterr().err
+
+
 def test_resume_help_lists_allow_script_drift(capsys: pytest.CaptureFixture[str]) -> None:
     with pytest.raises(SystemExit) as exc_info:
         cli.main(["resume", "--help"])
@@ -1297,6 +1395,47 @@ def test_extend_help_lists_allow_script_drift(capsys: pytest.CaptureFixture[str]
     assert "--allow-script-drift" in out
     assert "--script" in out
     assert "--n" in out
+
+
+def test_extend_accepts_positional_script(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``gmat-sweep extend MANIFEST SCRIPT --n N`` works without ``--script``."""
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+    cli.main(
+        [
+            "monte-carlo",
+            "--n",
+            "2",
+            "--perturb",
+            "Sat.SMA=normal:7100:50",
+            "--seed",
+            "0",
+            "--workers",
+            "1",
+            "--out",
+            str(out),
+            str(script),
+        ]
+    )
+    capsys.readouterr()
+
+    rc = cli.main(
+        [
+            "extend",
+            str(out / "manifest.jsonl"),
+            str(script),
+            "--n",
+            "2",
+            "--workers",
+            "1",
+        ]
+    )
+    assert rc == 0
+    summary = capsys.readouterr().out.splitlines()[0]
+    assert "4 runs" in summary  # 2 original + 2 extended
 
 
 # ---- archive subcommand -------------------------------------------------
@@ -1491,6 +1630,41 @@ def test_archive_rejects_script_drift(
     assert "script hash mismatch" in capsys.readouterr().err
 
 
+def test_archive_accepts_positional_script(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``gmat-sweep archive MANIFEST SCRIPT --out ...`` works without ``--script``."""
+    script = _write_script(tmp_path)
+    out = tmp_path / "out"
+    fake_gmat_run.install_loader(run_hook=_payload_run_hook())
+    cli.main(
+        [
+            "run",
+            "--grid",
+            "Sat.SMA=7000:7200:2",
+            "--workers",
+            "1",
+            "--out",
+            str(out),
+            str(script),
+        ]
+    )
+    capsys.readouterr()
+
+    bundle = tmp_path / "bundle.zip"
+    rc = cli.main(
+        [
+            "archive",
+            str(out / "manifest.jsonl"),
+            str(script),
+            "--out",
+            str(bundle),
+        ]
+    )
+    assert rc == 0
+    assert bundle.is_file()
+
+
 def test_archive_help_lists_flags(capsys: pytest.CaptureFixture[str]) -> None:
     with pytest.raises(SystemExit) as exc_info:
         cli.main(["archive", "--help"])
@@ -1532,6 +1706,13 @@ def test_parse_backend_arg_rejects_empty_key() -> None:
 def test_parse_backend_arg_rejects_empty_value() -> None:
     with pytest.raises(SweepConfigError, match="has no value"):
         cli._parse_backend_arg("threads_per_worker=")
+
+
+@pytest.mark.parametrize("token", ["nan", "inf", "-inf"])
+def test_parse_backend_arg_rejects_non_finite_float(token: str) -> None:
+    """``--backend-arg KEY=nan`` would silently inject a NaN into the pool kwargs."""
+    with pytest.raises(SweepConfigError, match="non-finite"):
+        cli._parse_backend_arg(f"timeout={token}")
 
 
 # ---- _build_pool / --backend wiring -------------------------------------
@@ -1637,7 +1818,7 @@ def test_build_pool_ray_constructs_ray_pool_with_num_cpus_and_kwargs(
 def test_build_pool_mpi_forwards_kwargs_only(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``--backend mpi`` ignores ``--workers`` and forwards every ``--backend-arg``.
+    """``--backend mpi`` forwards every ``--backend-arg`` to ``MPIPool()``.
 
     Rank count is set externally — by ``mpirun -n K`` under the pre-allocated
     launch mode, or by ``--backend-arg max_workers=N`` under dynamic-spawn.
@@ -1648,13 +1829,30 @@ def test_build_pool_mpi_forwards_kwargs_only(
 
     args = argparse.Namespace(
         backend="mpi",
-        workers=8,
+        workers=-1,
         backend_arg=["max_workers=4"],
     )
     with cli._build_pool(args):
         pass
 
     assert fake.calls == [{"max_workers": 4}]
+
+
+def test_build_pool_mpi_rejects_explicit_workers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--backend mpi`` paired with a non-default ``--workers`` exits 2.
+
+    Previously the flag was silently ignored, which led users to believe their
+    value had been honoured. The CLI now rejects it with the MPI exception
+    spelled out in the error message.
+    """
+    fake = _make_recording_pool_class()
+    monkeypatch.setattr(cli, "MPIPool", fake)
+
+    args = argparse.Namespace(backend="mpi", workers=4, backend_arg=[])
+    with pytest.raises(SweepConfigError, match="--backend mpi"):
+        cli._build_pool(args)
+    # The pool constructor must not have been called.
+    assert fake.calls == []
 
 
 def test_build_pool_mpi_no_backend_arg_constructs_with_defaults(

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
 import gmat_sweep
 import gmat_sweep.distributions  # v0.2 module; imported here so coverage sees the stub.
 
@@ -14,3 +20,45 @@ def test_import() -> None:
 def test_distributions_module_is_importable() -> None:
     """v0.2 module — currently a docstring stub. Importable so the coverage gate is meaningful."""
     assert gmat_sweep.distributions.__name__ == "gmat_sweep.distributions"
+
+
+def test_cold_start_does_not_load_heavy_dependencies() -> None:
+    """``import gmat_sweep`` must not pull pandas, pyarrow, or tqdm.
+
+    These dominate the cold-start cost of ``gmat-sweep --help`` (300-800 ms
+    on a warm filesystem) and only one path through the package actually
+    needs them. The lazy attribute-access dispatch in ``gmat_sweep/__init__``
+    pulls each heavy submodule on first reference.
+
+    Runs in a child interpreter so a prior test's eager attribute access
+    doesn't pollute ``sys.modules``.
+    """
+    script = textwrap.dedent(
+        """
+        import sys
+        import gmat_sweep  # noqa: F401
+        forbidden = {"pandas", "pyarrow", "pyarrow.dataset", "tqdm", "tqdm.auto"}
+        leaked = sorted(forbidden & set(sys.modules))
+        if leaked:
+            raise SystemExit(f"leaked modules: {leaked}")
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"cold start leaked dependencies: {result.stderr}"
+
+
+def test_lazy_attribute_access_resolves_sweep() -> None:
+    """``gmat_sweep.sweep`` must still resolve via PEP 562 ``__getattr__``."""
+    fn = gmat_sweep.sweep
+    assert callable(fn)
+
+
+def test_lazy_attribute_access_raises_for_unknown_name() -> None:
+    """Unknown attributes still raise ``AttributeError``."""
+    with pytest.raises(AttributeError, match="no_such_symbol"):
+        gmat_sweep.no_such_symbol  # noqa: B018

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -234,6 +234,147 @@ def test_sweep_corner_callable_metric_must_index_by_run_id() -> None:
         sweep_corner(df, metric=bad_metric, manifest=manifest)
 
 
+def test_sweep_corner_prefers_manifest_override_on_collision() -> None:
+    """When a perturbed dotted-path also appears as a df ReportFile column,
+    the design values (manifest overrides) take precedence over the measured
+    values, and a RuntimeWarning surfaces the disagreement."""
+    # df reports Sat.SMA per-run (e.g., diagnostics) — but those are
+    # *measured* values, slightly off from the commanded ones in the
+    # manifest. The plot should colour by the design values.
+    df = _multiindex_df(
+        {
+            0: [{"time": _ts(0), "Sat.SMA": 7005.0, "value": 1.0}],
+            1: [{"time": _ts(0), "Sat.SMA": 7105.0, "value": 2.0}],
+        }
+    )
+    manifest = _make_manifest(
+        [
+            _make_entry(0, {"Sat.SMA": 7000.0, "Sat.ECC": 0.001}),
+            _make_entry(1, {"Sat.SMA": 7100.0, "Sat.ECC": 0.002}),
+        ],
+        parameter_spec={
+            "_kind": "monte_carlo",
+            "perturb": {
+                "Sat.SMA": ("normal", 7050.0, 50.0),
+                "Sat.ECC": ("uniform", 0.001, 0.002),
+            },
+            "n": 2,
+            "seed": 0,
+        },
+    )
+
+    with pytest.warns(RuntimeWarning, match="manifest.parameter_spec and df.columns"):
+        axes = sweep_corner(df, metric="value", manifest=manifest)
+    scatter = next(c for c in axes[1, 0].collections if isinstance(c, PathCollection))
+    offsets = np.asarray(scatter.get_offsets())
+    # The x-axis on bottom_left is the second param (Sat.SMA, since panels are
+    # ordered as resolved_params = ["Sat.ECC", "Sat.SMA"] from _params_from_parameter_spec
+    # → keys in dict order). Either way, the SMA values must be the design
+    # ones (7000, 7100), never the measured (7005, 7105).
+    sma_values = sorted(
+        {float(offsets[i, 0]) for i in range(offsets.shape[0])}
+        | {float(offsets[i, 1]) for i in range(offsets.shape[0])}
+    )
+    assert 7000.0 in sma_values
+    assert 7100.0 in sma_values
+    assert 7005.0 not in sma_values
+    assert 7105.0 not in sma_values
+
+
+def test_sweep_corner_no_warning_when_override_and_column_agree() -> None:
+    """If the manifest override and df column carry the same per-run values,
+    no warning fires — only a genuine mismatch is noisy."""
+    df = _multiindex_df(
+        {
+            0: [{"time": _ts(0), "Sat.SMA": 7000.0, "value": 1.0}],
+            1: [{"time": _ts(0), "Sat.SMA": 7100.0, "value": 2.0}],
+        }
+    )
+    manifest = _make_manifest(
+        [
+            _make_entry(0, {"Sat.SMA": 7000.0, "Sat.ECC": 0.001}),
+            _make_entry(1, {"Sat.SMA": 7100.0, "Sat.ECC": 0.002}),
+        ],
+        parameter_spec={
+            "_kind": "monte_carlo",
+            "perturb": {
+                "Sat.SMA": ("normal", 7050.0, 50.0),
+                "Sat.ECC": ("uniform", 0.001, 0.002),
+            },
+            "n": 2,
+            "seed": 0,
+        },
+    )
+    import warnings as _w
+
+    with _w.catch_warnings():
+        _w.simplefilter("error", RuntimeWarning)
+        sweep_corner(df, metric="value", manifest=manifest)
+
+
+def test_sweep_corner_auto_picks_hexbin_above_threshold() -> None:
+    """``kind="auto"`` defaults to hexbin once more than 2000 runs survive."""
+    n = 2050
+    rng = np.random.default_rng(0)
+    a = rng.normal(0.0, 1.0, size=n)
+    b = rng.normal(0.0, 1.0, size=n)
+    rows_per_run: dict[int, list[dict[str, Any]]] = {
+        rid: [{"time": _ts(0), "value": float(a[rid] + b[rid])}] for rid in range(n)
+    }
+    df = _multiindex_df(rows_per_run)
+    manifest = _make_manifest(
+        [_make_entry(rid, {"a": float(a[rid]), "b": float(b[rid])}) for rid in range(n)],
+        parameter_spec={
+            "_kind": "monte_carlo",
+            "perturb": {"a": ("normal", 0.0, 1.0), "b": ("normal", 0.0, 1.0)},
+            "n": n,
+            "seed": 0,
+        },
+    )
+
+    axes = sweep_corner(df, metric="value", manifest=manifest)
+    bottom_left = axes[1, 0]
+    # hexbin renders a PolyCollection, scatter renders a PathCollection.
+    assert any(isinstance(c, PolyCollection) for c in bottom_left.collections)
+    assert not any(isinstance(c, PathCollection) for c in bottom_left.collections)
+
+
+def test_sweep_corner_explicit_scatter_overrides_auto() -> None:
+    """``kind="scatter"`` keeps the old behaviour even at large N."""
+    n = 2050
+    rng = np.random.default_rng(0)
+    a = rng.normal(0.0, 1.0, size=n)
+    b = rng.normal(0.0, 1.0, size=n)
+    rows_per_run: dict[int, list[dict[str, Any]]] = {
+        rid: [{"time": _ts(0), "value": float(a[rid] + b[rid])}] for rid in range(n)
+    }
+    df = _multiindex_df(rows_per_run)
+    manifest = _make_manifest(
+        [_make_entry(rid, {"a": float(a[rid]), "b": float(b[rid])}) for rid in range(n)],
+        parameter_spec={
+            "_kind": "monte_carlo",
+            "perturb": {"a": ("normal", 0.0, 1.0), "b": ("normal", 0.0, 1.0)},
+            "n": n,
+            "seed": 0,
+        },
+    )
+
+    axes = sweep_corner(df, metric="value", manifest=manifest, kind="scatter")
+    bottom_left = axes[1, 0]
+    assert any(isinstance(c, PathCollection) for c in bottom_left.collections)
+    assert not any(isinstance(c, PolyCollection) for c in bottom_left.collections)
+
+
+def test_sweep_corner_rejects_unknown_kind() -> None:
+    df = _multiindex_df({0: [{"time": _ts(0), "value": 1.0}], 1: [{"time": _ts(0), "value": 2.0}]})
+    manifest = _make_manifest(
+        [_make_entry(0, {"a": 1.0, "b": 10.0}), _make_entry(1, {"a": 2.0, "b": 20.0})],
+        parameter_spec={"_kind": "grid", "a": [1.0, 2.0], "b": [10.0, 20.0]},
+    )
+    with pytest.raises(SweepConfigError, match="kind must be"):
+        sweep_corner(df, metric="value", manifest=manifest, kind="bubbles")  # type: ignore[arg-type]
+
+
 # ---------------------------------------------------------------------------
 # sweep_heatmap
 # ---------------------------------------------------------------------------
@@ -330,6 +471,31 @@ def test_sweep_heatmap_rejects_wrong_dimensionality() -> None:
     )
     with pytest.raises(SweepConfigError, match="exactly 2 grid axes"):
         sweep_heatmap(df, x="a", y="b", z="value", manifest=manifest)
+
+
+def test_sweep_heatmap_rejects_string_axis() -> None:
+    """A string-typed grid axis used to crash inside ``np.asarray(..., dtype=float)``;
+    sweep_heatmap now raises ``SweepConfigError`` with a typed message before
+    attempting the conversion, pointing users at ``sweep_corner`` instead."""
+    rows_per_run: dict[int, list[dict[str, Any]]] = {}
+    entries: list[ManifestEntry] = []
+    rid = 0
+    for mode in ("Cartesian", "Keplerian"):
+        for speed in (1.0, 2.0):
+            rows_per_run[rid] = [{"time": _ts(0), "value": float(rid)}]
+            entries.append(_make_entry(rid, {"mode": mode, "speed": speed}))
+            rid += 1
+    df = _multiindex_df(rows_per_run)
+    manifest = _make_manifest(
+        entries,
+        parameter_spec={
+            "_kind": "grid",
+            "mode": ["Cartesian", "Keplerian"],
+            "speed": [1.0, 2.0],
+        },
+    )
+    with pytest.raises(SweepConfigError, match=r"numeric grid axes.*dtype="):
+        sweep_heatmap(df, x="mode", y="speed", z="value", manifest=manifest)
 
 
 def test_sweep_heatmap_callable_z() -> None:


### PR DESCRIPTION
## Summary

Eight of the ten gaps from issue #133 — the CLI mini-grammar and the matplotlib plot helpers. Items #3 and #6 are deferred:

- **Item #3** (`--script PATH` vs. positional asymmetry on `extend`/`resume`/`archive`): kept as-is, intentionally. On those subcommands the manifest is the primary positional input and the script is a parameter; two trailing positionals on the same line reads awkwardly. The asymmetry stays.
- **Item #6** (streaming `RunSpec`s through `Sweep.run`): deferred to #134, which owns the eager-submission fix end-to-end.

### CLI
- `import gmat_sweep` is now lazy — pandas / pyarrow / tqdm / joblib are not pulled until first use. `gmat-sweep --help` cold start drops from ~300-800 ms to ~120 ms on a warm cache (item #1).
- `_parse_grid_value` and `_parse_backend_arg` reject `nan` / `inf` / `-inf`; linspace bounds get the same check (item #2).
- `gmat-sweep show --filter STATUS` rejects without `--detail` before stat'ing the manifest (item #4).
- `--backend mpi` paired with a non-default `--workers` exits 2 with a spelled-out MPI exception instead of silently ignoring the flag; the help string now documents the exception (item #5).
- `monte-carlo --help` description now mirrors the actual contract — "two runs at the same `(--perturb, --n, --seed)` produce bit-equal DataFrames" (item #10).

### Plotting
- `_gather_param_values` prefers `manifest.parameter_spec` overrides (design values) over `df.columns` (measured values) for params in the spec, warning on disagreement (item #7).
- `sweep_heatmap` validates pivot-axis dtype before `np.asarray(..., dtype=float)`; a string axis now raises a typed `SweepConfigError` pointing at `sweep_corner` (item #8).
- `sweep_corner` grows a `kind="scatter"|"hexbin"|"auto"` kwarg; `"auto"` (default) flips to hexbin past 2000 runs to avoid silent overplot saturation (item #9).

### Docs
- `docs/cli.md`: `--workers` MPI exception in the common-options table; refreshed `monte-carlo` determinism phrasing.

## Test plan
- [x] `uv run pytest` clean.
- [x] `uv run ruff check`, `uv run ruff format --check`.
- [x] `uv run mypy` clean for everything touched here.
- [x] Cold-start smoke: `python -c "import gmat_sweep.cli"` leaves `pandas` / `pyarrow` / `tqdm` / `joblib` out of `sys.modules`. New `test_cold_start_does_not_load_heavy_dependencies` in `tests/test_import.py` enforces it.
- [x] New tests for each item: nan/inf rejection on grid + backend args, `--filter` ordering, MPI workers rejection, heatmap string axis, corner hexbin auto-fallback / explicit override / unknown-kind, override-vs-column collision warning.

Refs #133 (items #3 and #6 left open).
