### PR TITLE
Spec / worker / orchestration: tighten contracts and close work-loss paths

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -14,8 +14,6 @@ auto-generated from docstrings via
 
 ::: gmat_sweep.latin_hypercube
 
-::: gmat_sweep.latin_hypercube_extend
-
 ::: gmat_sweep.Sweep
 
 ## Execution backend
@@ -48,7 +46,11 @@ auto-generated from docstrings via
 
 ::: gmat_sweep.full_factorial
 
+::: gmat_sweep.full_factorial_size
+
 ::: gmat_sweep.expand_grid_to_run_specs
+
+::: gmat_sweep.iter_grid_run_specs
 
 ::: gmat_sweep.expand_samples_to_run_specs
 

--- a/docs/manifest-schema.md
+++ b/docs/manifest-schema.md
@@ -24,10 +24,20 @@ file is bit-for-bit deterministic across processes and trivially
 line by dropping it (a partial write loses one entry; the rest of the file
 parses cleanly).
 
-The header's `run_count` field is the *expected* run count at sweep launch
-time. It is **not rewritten** as entries arrive, so the on-disk header may
-report more runs than the file actually contains during and after a
-`Ctrl-C`'d sweep. Read `len(manifest.entries)` for the actual count.
+The header's `run_count` field is the *expected* run count at the time of
+first save, and is **frozen on disk for the life of the manifest** — the
+header is append-only by design, so a torn last line costs exactly one
+entry and the header stays valid. Consequences worth knowing:
+
+- During a `Ctrl-C`'d sweep, `run_count` reports more runs than the file
+  actually contains. Read `len(manifest.entries)` (or `manifest.find_missing(...)`)
+  for the actual count and the gap.
+- After [`Sweep.extend(n=K)`][gmat_sweep.Sweep.extend], `run_count` still
+  reports the *original* size — it does not gain `K`. Read
+  [`manifest.total_run_count`][gmat_sweep.Manifest.total_run_count]
+  for the live total (original + extensions), or
+  [`manifest.extension_run_count`][gmat_sweep.Manifest.extension_run_count]
+  for just the extension delta.
 
 ## Header fields
 
@@ -58,7 +68,7 @@ report more runs than the file actually contains during and after a
 | `os_platform`          | `platform.platform()` — same string `gmat-run` records.                                          |
 | `sweep_seed`           | The seed passed to [`sweep(seed=...)`][gmat_sweep.sweep], [`monte_carlo(seed=...)`][gmat_sweep.monte_carlo], or [`latin_hypercube(seed=...)`][gmat_sweep.latin_hypercube], or `null`. |
 | `parameter_spec`       | The run set the sweep expanded, tagged with a `_kind` discriminator. One of four shapes — see [`parameter_spec` shapes](#parameter_spec-shapes) below. |
-| `run_count`            | The number of runs in the sweep at launch.                                                       |
+| `run_count`            | The number of runs in the sweep at launch. Frozen on disk — does not change after [`Sweep.extend()`][gmat_sweep.Sweep.extend]; read [`Manifest.total_run_count`][gmat_sweep.Manifest.total_run_count] for the live total. |
 | `backend`              | The execution backend's class name (`pool.__class__.__name__`) — e.g. `"LocalJoblibPool"`, `"DaskPool"`, `"RayPool"`, or any third-party `Pool` subclass. Optional on load: manifests written before this field landed report `"unknown"`. |
 
 ### `parameter_spec` shapes
@@ -167,7 +177,9 @@ print(manifest.script_sha256, manifest.run_count, len(manifest.entries))
 
 # Streaming tail-only scans (do not materialise the entry list):
 failed_ids = Manifest.find_failed(manifest_path)
-missing_ids = Manifest.find_missing(manifest_path, range(manifest.run_count))
+# Use total_run_count rather than the frozen header run_count when iterating
+# expected ids on an extended manifest — see "Header fields" above.
+missing_ids = Manifest.find_missing(manifest_path, range(manifest.total_run_count))
 
 # Lazy iteration if you need each entry but not all at once:
 for entry in Manifest.iter_entries(manifest_path):
@@ -254,12 +266,14 @@ recoverable from the entries themselves; the convenience accessor is:
 ```python
 manifest = Manifest.load("./sweep/manifest.jsonl")
 manifest.extension_run_count  # 0 for fresh sweeps; N after extend(n=N)
+manifest.total_run_count      # original n + extension_run_count
 ```
 
-The total run count on disk after any number of extensions is
-`max(e.run_id for e in manifest.entries) + 1`, the same expression
-that already covers `Ctrl-C`'d sweeps where `len(entries) <
-parameter_spec["n"]`.
+`manifest.run_count` is the frozen header value (original size at first
+save); `manifest.total_run_count` is the live total derived from the
+entries, and is the right value to feed into
+[`find_missing`][gmat_sweep.Manifest.find_missing] when iterating
+expected run ids on an extended manifest.
 
 The `_kind` of a Monte Carlo manifest stays `"monte_carlo"` after
 extension; only Monte Carlo manifests support extension at all

--- a/docs/monte-carlo.md
+++ b/docs/monte-carlo.md
@@ -146,10 +146,9 @@ on disk.
 
 ### Why Latin hypercube can't be extended
 
-[`latin_hypercube_extend()`][gmat_sweep.latin_hypercube_extend] exists
-to refuse the operation cleanly. Extending a Latin hypercube sweep
-would change the per-axis stratification of every sample (the `n` bins
-under [`scipy.stats.qmc.LatinHypercube`][scipy-lh] repartition when `n`
+Extending a Latin hypercube sweep would change the per-axis
+stratification of every sample (the `n` bins under
+[`scipy.stats.qmc.LatinHypercube`][scipy-lh] repartition when `n`
 changes), so there is no slice of a larger LH draw that reproduces the
 original `n` samples bit-for-bit. If you need more samples for an LH
 study, run a fresh `latin_hypercube(n=old_n + new)` from scratch.

--- a/src/gmat_sweep/__init__.py
+++ b/src/gmat_sweep/__init__.py
@@ -41,7 +41,6 @@ if TYPE_CHECKING:
     )
     from gmat_sweep.api import (
         latin_hypercube,
-        latin_hypercube_extend,
         monte_carlo,
         monte_carlo_extend,
         sweep,
@@ -54,6 +53,8 @@ if TYPE_CHECKING:
         expand_monte_carlo_to_run_specs,
         expand_samples_to_run_specs,
         full_factorial,
+        full_factorial_size,
+        iter_grid_run_specs,
         latin_hypercube_samples,
     )
     from gmat_sweep.manifest import (
@@ -91,7 +92,6 @@ _LAZY_ATTRS: dict[str, str] = {
     "sweep_diff": "gmat_sweep.aggregate",
     "sweep_summary": "gmat_sweep.aggregate",
     "latin_hypercube": "gmat_sweep.api",
-    "latin_hypercube_extend": "gmat_sweep.api",
     "monte_carlo": "gmat_sweep.api",
     "monte_carlo_extend": "gmat_sweep.api",
     "sweep": "gmat_sweep.api",
@@ -103,6 +103,8 @@ _LAZY_ATTRS: dict[str, str] = {
     "expand_monte_carlo_to_run_specs": "gmat_sweep.grids",
     "expand_samples_to_run_specs": "gmat_sweep.grids",
     "full_factorial": "gmat_sweep.grids",
+    "full_factorial_size": "gmat_sweep.grids",
+    "iter_grid_run_specs": "gmat_sweep.grids",
     "latin_hypercube_samples": "gmat_sweep.grids",
     "MANIFEST_SCHEMA_VERSION": "gmat_sweep.manifest",
     "Manifest": "gmat_sweep.manifest",
@@ -189,8 +191,9 @@ __all__ = [
     "expand_monte_carlo_to_run_specs",
     "expand_samples_to_run_specs",
     "full_factorial",
+    "full_factorial_size",
+    "iter_grid_run_specs",
     "latin_hypercube",
-    "latin_hypercube_extend",
     "latin_hypercube_samples",
     "lazy_contacts",
     "lazy_ephemerides",

--- a/src/gmat_sweep/_run_subprocess.py
+++ b/src/gmat_sweep/_run_subprocess.py
@@ -31,7 +31,14 @@ not produce an outcome JSON at all:
 - ``2`` — bad CLI arguments (argparse default).
 - ``3`` — unreadable ``--spec`` file (missing, permission denied, malformed
   JSON, or a payload that fails :meth:`gmat_sweep.spec.RunSpec.from_dict`).
-- ``4`` — unwriteable ``--outcome`` file.
+- ``4`` — unwriteable ``--outcome`` file. Two flavours:
+  fail-fast — the ``--outcome`` path is probed with a touch + unlink
+  before ``run_one`` is invoked, so a bad path doesn't cost a 30-minute
+  GMAT run; and post-run — if ``run_one`` completed but the outcome JSON
+  fails to land on disk, the outcome is printed to stdout as a single
+  JSON line before exiting ``4``. The parent
+  (:func:`gmat_sweep.backends._subprocess.run_spec_in_subprocess`)
+  recovers the outcome from stdout in that case.
 - Anything else — the OS killed the process (signal, OOM, segfault). The
   parent classifies non-zero exits as transport failures and folds the
   captured stderr into a synthetic
@@ -83,11 +90,34 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         return _EXIT_BAD_SPEC
 
+    # Fail-fast on a bad --outcome path. A 30-minute GMAT run that then
+    # discovers it cannot write the outcome JSON is the work-loss path
+    # this probe closes; we'd rather find out now and exit 4 before
+    # paying for run_one. The post-run write below still has its own
+    # exception handling for races (disk fills mid-run, path made
+    # read-only between probe and write, …).
+    try:
+        outcome_path.parent.mkdir(parents=True, exist_ok=True)
+        outcome_path.touch()
+        outcome_path.unlink()
+    except OSError as exc:
+        print(
+            f"_run_subprocess: --outcome path is not writable {outcome_path}: {exc}",
+            file=sys.stderr,
+        )
+        return _EXIT_BAD_OUTCOME
+
     outcome = run_one(spec)
 
     try:
-        outcome_path.write_text(json.dumps(outcome.to_dict()), encoding="utf-8")
+        with outcome_path.open("w", encoding="utf-8") as f:
+            json.dump(outcome.to_dict(), f)
     except OSError as exc:
+        # Race after the writability probe (disk filled mid-run, fs
+        # remounted read-only, …): emit the outcome on stdout so the
+        # parent backend can recover it instead of synthesising a
+        # failed outcome that drops the worker's actual run.
+        print(json.dumps(outcome.to_dict()))
         print(
             f"_run_subprocess: cannot write outcome {outcome_path}: {exc}",
             file=sys.stderr,

--- a/src/gmat_sweep/api.py
+++ b/src/gmat_sweep/api.py
@@ -14,10 +14,11 @@ from gmat_sweep.backends.joblib import LocalJoblibPool
 from gmat_sweep.distributions import DistSpec, _serialise_perturb
 from gmat_sweep.errors import SweepConfigError
 from gmat_sweep.grids import (
-    expand_grid_to_run_specs,
     expand_latin_hypercube_to_run_specs,
     expand_monte_carlo_to_run_specs,
     expand_samples_to_run_specs,
+    full_factorial_size,
+    iter_grid_run_specs,
 )
 from gmat_sweep.spec import RunSpec
 from gmat_sweep.sweep import Sweep
@@ -30,7 +31,6 @@ if TYPE_CHECKING:
 
 __all__ = [
     "latin_hypercube",
-    "latin_hypercube_extend",
     "monte_carlo",
     "monte_carlo_extend",
     "sweep",
@@ -199,21 +199,26 @@ def sweep(
     mission_path = Path(mission)
 
     parameter_spec: dict[str, Any]
-    build_runs: Callable[[Path], list[RunSpec]]
+    build_runs: Callable[[Path], Iterable[RunSpec]]
+    expected_run_count: int | None = None
     if grid is not None:
-        # Materialise grid values once: expand_grid_to_run_specs would do it
-        # for the cartesian product, but we also need the materialised dict
-        # for the manifest header (generators don't survive json.dumps), so
-        # do it up front and reuse the same object.
+        # Materialise grid values once: iter_grid_run_specs would do it for
+        # the cartesian product, but we also need the materialised dict for
+        # the manifest header (generators don't survive json.dumps), so do
+        # it up front and reuse the same object.
         materialised_grid: dict[str, list[Any]] = {k: list(v) for k, v in grid.items()}
         # Every parameter_spec shape carries a ``_kind`` discriminator so a
         # downstream reader doesn't have to infer the sweep kind from the
         # keys present. Older grid manifests omit the tag, and
         # ``Manifest.load`` keeps loading them as if ``_kind="grid"``.
         parameter_spec = {"_kind": "grid", **materialised_grid}
+        expected_run_count = full_factorial_size(materialised_grid)
 
-        def build_runs(output_dir: Path) -> list[RunSpec]:
-            return expand_grid_to_run_specs(materialised_grid, mission_path, output_dir)
+        def build_runs(output_dir: Path) -> Iterable[RunSpec]:
+            # Streaming: the cartesian product is generated lazily and the
+            # pool's bounded imap dispatcher caps in-flight specs to
+            # ~4 * workers. A 10⁵-row factorial never materialises in full.
+            return iter_grid_run_specs(materialised_grid, mission_path, output_dir)
     else:
         assert samples is not None  # narrowed by the XOR check above
         # ``rows`` is a list-of-lists in column order so the round-trip is a
@@ -224,7 +229,7 @@ def sweep(
             "rows": samples.values.tolist(),
         }
 
-        def build_runs(output_dir: Path) -> list[RunSpec]:
+        def build_runs(output_dir: Path) -> Iterable[RunSpec]:
             return expand_samples_to_run_specs(samples, mission_path, output_dir)
 
     return _run_sweep(
@@ -238,6 +243,7 @@ def sweep(
         engine=engine,
         fsync_each=fsync_each,
         fsync_batch=fsync_batch,
+        expected_run_count=expected_run_count,
     )
 
 
@@ -651,6 +657,10 @@ def latin_hypercube_extend(
     :func:`monte_carlo_extend` so a caller writing a generic
     "extend whatever sweep this is" wrapper gets a clear error rather
     than an :class:`AttributeError`.
+
+    Not in :data:`__all__` and not in the user-facing docs: it is a typed
+    refusal sentinel for advanced wrappers, not a feature. Import it
+    directly from :mod:`gmat_sweep.api` if you need it.
     """
     raise SweepConfigError(
         "latin_hypercube_extend is unsupported: extending a Latin hypercube sweep "
@@ -678,7 +688,7 @@ def _resolve_pool(backend: Pool | None) -> Iterator[Pool]:
 def _run_sweep(
     *,
     mission_path: Path,
-    build_runs: Callable[[Path], list[RunSpec]],
+    build_runs: Callable[[Path], Iterable[RunSpec]],
     parameter_spec: dict[str, Any],
     sweep_seed: int | None,
     backend: Pool | None,
@@ -687,6 +697,7 @@ def _run_sweep(
     engine: str,
     fsync_each: bool = True,
     fsync_batch: int = 50,
+    expected_run_count: int | None = None,
 ) -> DataFrame:
     """Shared orchestration for the public entry points.
 
@@ -729,6 +740,7 @@ def _run_sweep(
                 progress=progress,
                 fsync_each=fsync_each,
                 fsync_batch=fsync_batch,
+                expected_run_count=expected_run_count,
             )
             .run()
             .to_dataframe(engine=engine)

--- a/src/gmat_sweep/backends/_subprocess.py
+++ b/src/gmat_sweep/backends/_subprocess.py
@@ -32,6 +32,7 @@ import json
 import subprocess
 import sys
 import tempfile
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -65,6 +66,7 @@ def run_spec_in_subprocess(
     """
     interpreter = python or sys.executable
     started_at = datetime.now(timezone.utc)
+    start_monotonic = time.monotonic()
 
     with tempfile.TemporaryDirectory(prefix="gmat-sweep-spec-") as td:
         spec_path = Path(td) / "spec.json"
@@ -95,6 +97,7 @@ def run_spec_in_subprocess(
                 stderr=f"_run_subprocess timed out after {timeout}s\n{captured}".strip(),
                 started_at=started_at,
                 ended_at=ended_at,
+                duration_s=time.monotonic() - start_monotonic,
             )
         except OSError as exc:
             ended_at = datetime.now(timezone.utc)
@@ -103,9 +106,18 @@ def run_spec_in_subprocess(
                 stderr=f"_run_subprocess could not be spawned: {exc}",
                 started_at=started_at,
                 ended_at=ended_at,
+                duration_s=time.monotonic() - start_monotonic,
             )
 
         if result.returncode != 0:
+            # The child may have completed its run but failed to write the
+            # outcome JSON (exit=4): the worker now falls back to printing
+            # the outcome to stdout. Try to recover that before folding a
+            # synthetic failure — losing a 30-minute GMAT run because the
+            # outcome path was bad is the work-loss path issue #134 closes.
+            recovered = _recover_outcome_from_stdout(result.stdout, spec.run_id)
+            if recovered is not None:
+                return recovered
             ended_at = datetime.now(timezone.utc)
             return RunOutcome.failed(
                 run_id=spec.run_id,
@@ -114,6 +126,35 @@ def run_spec_in_subprocess(
                 ).rstrip(),
                 started_at=started_at,
                 ended_at=ended_at,
+                duration_s=time.monotonic() - start_monotonic,
             )
 
         return RunOutcome.from_dict(json.loads(outcome_path.read_text(encoding="utf-8")))
+
+
+def _recover_outcome_from_stdout(stdout: str, expected_run_id: int) -> RunOutcome | None:
+    """Try to parse a worker-printed outcome JSON from ``stdout``.
+
+    The worker emits the outcome as a single line on stdout when its
+    ``--outcome`` write fails post-``run_one``. Returns the parsed
+    outcome on success; ``None`` on any parse failure or run_id mismatch
+    so the caller falls back to its synthetic-failed path.
+    """
+    if not stdout:
+        return None
+    # The worker prints exactly one JSON line for the outcome; scan from
+    # the tail so unrelated chatter on stdout (warnings, etc.) doesn't
+    # block recovery.
+    for line in reversed(stdout.splitlines()):
+        line = line.strip()
+        if not line or not line.startswith("{"):
+            continue
+        try:
+            data = json.loads(line)
+            outcome = RunOutcome.from_dict(data)
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+            continue
+        if outcome.run_id != expected_run_id:
+            return None
+        return outcome
+    return None

--- a/src/gmat_sweep/backends/base.py
+++ b/src/gmat_sweep/backends/base.py
@@ -97,6 +97,70 @@ class Pool(ABC):
     def close(self) -> None:
         """Release backend resources. Idempotent."""
 
+    @property
+    def max_workers(self) -> int:
+        """Best-effort worker count for sizing the in-flight cap.
+
+        Subclasses should override to expose their actual worker count
+        (loky's ``n_jobs`` resolved against ``cpu_count``, Ray's
+        cluster size, …). Returning ``1`` is the safe fallback when
+        the backend cannot answer — the caller's bounded-submit loop
+        will dispatch sequentially, which is correct (if slow) for
+        every backend.
+        """
+        return 1
+
+    def imap(
+        self,
+        specs: Iterable[RunSpec],
+        *,
+        in_flight: int | None = None,
+    ) -> Iterator[tuple[RunSpec, RunOutcome]]:
+        """Stream ``specs`` through the pool, yielding ``(spec, outcome)`` pairs.
+
+        Outcomes are yielded in completion order, paired with the
+        :class:`RunSpec` that produced them. Bounds the in-flight set
+        to ``in_flight`` (default ``4 * self.max_workers``) so a 10⁵-spec
+        iterator does not pin 10⁵ payloads + 10⁵ futures in driver memory.
+        Specs are pulled from the iterator lazily — only ``in_flight``
+        specs are materialised at any one time.
+
+        Each yielded pair carries the :class:`RunSpec` that produced
+        the :class:`RunOutcome`: the caller does not need to maintain a
+        side-table from ``outcome.run_id`` back to the spec, and the
+        spec object becomes garbage-collectable the moment the caller
+        finishes processing it.
+
+        Default implementation: chunked submit / drain. Specs are
+        consumed ``in_flight`` at a time, each chunk drained through
+        :meth:`as_completed` before the next chunk is submitted. This
+        bounds RSS but loses pipelining within a chunk — backends with
+        true future-by-future progress (e.g. those backed by
+        :class:`concurrent.futures.Executor`) should override with a
+        sliding-window submit/wait loop for better throughput.
+        """
+        if in_flight is None:
+            in_flight = max(1, 4 * self.max_workers)
+        if in_flight < 1:
+            raise ValueError(f"in_flight must be >= 1, got {in_flight}")
+
+        iterator = iter(specs)
+        while True:
+            chunk_specs: list[RunSpec] = []
+            chunk_futures: list[Future[RunOutcome]] = []
+            for _ in range(in_flight):
+                try:
+                    spec = next(iterator)
+                except StopIteration:
+                    break
+                chunk_specs.append(spec)
+                chunk_futures.append(self.submit(spec))
+            if not chunk_specs:
+                return
+            spec_by_run_id: dict[int, RunSpec] = {s.run_id: s for s in chunk_specs}
+            for outcome in self.as_completed(chunk_futures):
+                yield spec_by_run_id[outcome.run_id], outcome
+
     def __enter__(self) -> Pool:
         return self
 

--- a/src/gmat_sweep/backends/dask.py
+++ b/src/gmat_sweep/backends/dask.py
@@ -130,12 +130,21 @@ class DaskPool(Pool):
             self._client = _distributed.Client(self._cluster)
             self._owns_client = True
             self._owns_cluster = True
+            self._resolved_max_workers: int = workers
         else:
             self._client = client
+            # User-supplied client: cluster size is unknown without an RPC;
+            # ``1`` is the conservative fallback for the imap in-flight cap.
+            # Pass ``in_flight=...`` to :meth:`imap` explicitly to override.
+            self._resolved_max_workers = 1
 
         self._pending: dict[Future[RunOutcome], RunSpec] = {}
         self._closed = False
         self._distributed = _distributed
+
+    @property
+    def max_workers(self) -> int:
+        return self._resolved_max_workers
 
     def submit(self, spec: RunSpec) -> Future[RunOutcome]:
         if self._closed:
@@ -199,4 +208,10 @@ class DaskPool(Pool):
 
 def _failed_outcome(run_id: int, stderr: str) -> RunOutcome:
     now = datetime.now(timezone.utc)
-    return RunOutcome.failed(run_id=run_id, stderr=stderr, started_at=now, ended_at=now)
+    return RunOutcome.failed(
+        run_id=run_id,
+        stderr=stderr,
+        started_at=now,
+        ended_at=now,
+        duration_s=0.0,
+    )

--- a/src/gmat_sweep/backends/joblib.py
+++ b/src/gmat_sweep/backends/joblib.py
@@ -31,6 +31,7 @@ See :class:`gmat_sweep.backends.base.Pool` for the semantics of
 
 from __future__ import annotations
 
+import os
 import traceback
 import warnings
 from collections.abc import Callable, Iterable, Iterator
@@ -101,6 +102,9 @@ class LocalJoblibPool(Pool):
             )
         self._workers = resolved
         self._reuse_gmat_context = reuse_gmat_context
+        # Resolve -1 ("all cores") to a concrete count for max_workers — the
+        # Pool.imap default uses this for the in-flight cap.
+        self._resolved_max_workers: int = (os.cpu_count() or 1) if resolved == -1 else resolved
         self._pending: dict[Future[RunOutcome], RunSpec] = {}
         self._closed = False
         self._parallel = joblib.Parallel(
@@ -109,6 +113,10 @@ class LocalJoblibPool(Pool):
             return_as="generator_unordered",
         )
         self._parallel.__enter__()
+
+    @property
+    def max_workers(self) -> int:
+        return self._resolved_max_workers
 
     def submit(self, spec: RunSpec) -> Future[RunOutcome]:
         if self._closed:
@@ -177,4 +185,10 @@ class LocalJoblibPool(Pool):
 
 def _failed_outcome(run_id: int, stderr: str) -> RunOutcome:
     now = datetime.now(timezone.utc)
-    return RunOutcome.failed(run_id=run_id, stderr=stderr, started_at=now, ended_at=now)
+    return RunOutcome.failed(
+        run_id=run_id,
+        stderr=stderr,
+        started_at=now,
+        ended_at=now,
+        duration_s=0.0,
+    )

--- a/src/gmat_sweep/backends/kubernetes.py
+++ b/src/gmat_sweep/backends/kubernetes.py
@@ -560,6 +560,7 @@ class KubernetesJobPool(Pool):
             ),
             started_at=started_at,
             ended_at=ended_at,
+            duration_s=max(0.0, (ended_at - started_at).total_seconds()),
         )
 
     def _read_outcome(self, spec: RunSpec, job_name: str, *, started_at: datetime) -> RunOutcome:
@@ -574,6 +575,7 @@ class KubernetesJobPool(Pool):
                     stderr=f"unreadable outcome JSON at {outcome_path}: {exc}",
                     started_at=started_at,
                     ended_at=ended_at,
+                    duration_s=max(0.0, (ended_at - started_at).total_seconds()),
                 )
         return self._fold_unknown_failure(spec, job_name, started_at)
 
@@ -590,6 +592,7 @@ class KubernetesJobPool(Pool):
             ).rstrip(),
             started_at=started_at,
             ended_at=ended_at,
+            duration_s=max(0.0, (ended_at - started_at).total_seconds()),
         )
 
     def _fetch_pod_logs(self, job_name: str) -> str:

--- a/src/gmat_sweep/backends/mpi.py
+++ b/src/gmat_sweep/backends/mpi.py
@@ -132,8 +132,16 @@ class MPIPool(Pool):
         self._executor = _mpi_futures.MPIPoolExecutor(
             max_workers=max_workers, **mpi_executor_kwargs
         )
+        # User-supplied max_workers is the only signal we have driver-side
+        # (the MPI universe size is set by mpiexec). Conservative fallback
+        # of 1 when None — pass in_flight= to :meth:`imap` to tune.
+        self._resolved_max_workers: int = max_workers if max_workers is not None else 1
         self._pending: dict[Future[RunOutcome], RunSpec] = {}
         self._closed = False
+
+    @property
+    def max_workers(self) -> int:
+        return self._resolved_max_workers
 
     def submit(self, spec: RunSpec) -> Future[RunOutcome]:
         if self._closed:
@@ -188,4 +196,10 @@ class MPIPool(Pool):
 
 def _failed_outcome(run_id: int, stderr: str) -> RunOutcome:
     now = datetime.now(timezone.utc)
-    return RunOutcome.failed(run_id=run_id, stderr=stderr, started_at=now, ended_at=now)
+    return RunOutcome.failed(
+        run_id=run_id,
+        stderr=stderr,
+        started_at=now,
+        ended_at=now,
+        duration_s=0.0,
+    )

--- a/src/gmat_sweep/backends/process_pool.py
+++ b/src/gmat_sweep/backends/process_pool.py
@@ -38,6 +38,7 @@ message pointing at :class:`LocalJoblibPool` for the 3.10 path.
 
 from __future__ import annotations
 
+import os
 import sys
 from typing import TYPE_CHECKING
 
@@ -109,8 +110,21 @@ class ProcessPoolExecutorPool(Pool):
             max_workers=max_workers,
             max_tasks_per_child=1,
         )
+        # Cache the resolved worker count for max_workers. The
+        # ProcessPoolExecutor doesn't expose its own count publicly, so
+        # we mirror its resolution rule: caller-supplied value if set,
+        # otherwise os.process_cpu_count() (3.13+) / os.cpu_count().
+        self._resolved_max_workers: int = (
+            max_workers
+            if max_workers is not None
+            else (getattr(os, "process_cpu_count", os.cpu_count)() or 1)
+        )
         self._pending: dict[Future[RunOutcome], RunSpec] = {}
         self._closed = False
+
+    @property
+    def max_workers(self) -> int:
+        return self._resolved_max_workers
 
     def submit(self, spec: RunSpec) -> Future[RunOutcome]:
         if self._closed:
@@ -164,4 +178,10 @@ class ProcessPoolExecutorPool(Pool):
 
 def _failed_outcome(run_id: int, stderr: str) -> RunOutcome:
     now = datetime.now(timezone.utc)
-    return RunOutcome.failed(run_id=run_id, stderr=stderr, started_at=now, ended_at=now)
+    return RunOutcome.failed(
+        run_id=run_id,
+        stderr=stderr,
+        started_at=now,
+        ended_at=now,
+        duration_s=0.0,
+    )

--- a/src/gmat_sweep/backends/ray.py
+++ b/src/gmat_sweep/backends/ray.py
@@ -198,4 +198,10 @@ class RayPool(Pool):
 
 def _failed_outcome(run_id: int, stderr: str) -> RunOutcome:
     now = datetime.now(timezone.utc)
-    return RunOutcome.failed(run_id=run_id, stderr=stderr, started_at=now, ended_at=now)
+    return RunOutcome.failed(
+        run_id=run_id,
+        stderr=stderr,
+        started_at=now,
+        ended_at=now,
+        duration_s=0.0,
+    )

--- a/src/gmat_sweep/grids.py
+++ b/src/gmat_sweep/grids.py
@@ -35,6 +35,8 @@ __all__ = [
     "expand_monte_carlo_to_run_specs",
     "expand_samples_to_run_specs",
     "full_factorial",
+    "full_factorial_size",
+    "iter_grid_run_specs",
     "latin_hypercube_samples",
 ]
 
@@ -85,13 +87,39 @@ def expand_grid_to_run_specs(
     :func:`full_factorial` carries through unchanged: ``specs[i].run_id == i``
     and the override dicts appear in cartesian-product order.
 
+    Materialises the full cartesian product up front — fine for small
+    grids but spends O(N) memory on the spec list before the first
+    worker starts. Prefer :func:`iter_grid_run_specs` when the
+    cartesian product is large (10⁴+ runs): the streaming variant
+    yields the same specs one at a time.
+
     Raises :class:`SweepConfigError` for the same reasons as
     :func:`full_factorial`.
     """
+    return list(iter_grid_run_specs(grid, script_path, output_dir))
+
+
+def iter_grid_run_specs(
+    grid: Mapping[str, Iterable[Any]],
+    script_path: str | Path,
+    output_dir: str | Path,
+) -> Iterator[RunSpec]:
+    """Stream :class:`RunSpec` instances from a full-factorial expansion of ``grid``.
+
+    Same per-spec shape as :func:`expand_grid_to_run_specs` (sequential
+    ``run_id``, per-run ``output_dir``, ``seed=None``, ``run_options={}``)
+    but yields lazily — for a 10⁵-row factorial the driver never holds
+    more than one :class:`RunSpec` plus :func:`full_factorial`'s
+    iterator state in memory.
+
+    Validation (string keys, non-empty values) still runs eagerly at
+    the start of iteration via :func:`full_factorial`, so malformed
+    grids fail loudly before any spec is yielded.
+    """
     script_path_obj = Path(script_path)
     base_output_dir = Path(output_dir)
-    return [
-        RunSpec(
+    for run_id, overrides in enumerate(full_factorial(grid)):
+        yield RunSpec(
             script_path=script_path_obj,
             overrides=overrides,
             output_dir=base_output_dir / f"run-{run_id}",
@@ -99,8 +127,31 @@ def expand_grid_to_run_specs(
             seed=None,
             run_options={},
         )
-        for run_id, overrides in enumerate(full_factorial(grid))
-    ]
+
+
+def full_factorial_size(grid: Mapping[str, Iterable[Any]]) -> int:
+    """Return the number of runs a :func:`full_factorial` expansion of ``grid`` produces.
+
+    ``prod(len(list(v)) for v in grid.values())`` — but tolerant of
+    generators (materialises each axis once) and aware that the empty
+    mapping is the identity (one empty-override run, matching
+    :func:`full_factorial`).
+
+    Used by :func:`gmat_sweep.sweep` to size the manifest header's
+    ``run_count`` and the progress bar without materialising the
+    cartesian product itself.
+    """
+    materialised: list[tuple[Any, ...]] = []
+    for key, values in grid.items():
+        if not isinstance(key, str):
+            raise SweepConfigError(f"grid keys must be strings, got {type(key).__name__}: {key!r}")
+        materialised.append(tuple(values))
+        if not materialised[-1]:
+            raise SweepConfigError(f"grid value for {key!r} is empty")
+    n = 1
+    for axis in materialised:
+        n *= len(axis)
+    return n
 
 
 def expand_samples_to_run_specs(

--- a/src/gmat_sweep/manifest.py
+++ b/src/gmat_sweep/manifest.py
@@ -516,6 +516,27 @@ class Manifest:
         max_run_id = max(e.run_id for e in self.entries)
         return max(0, max_run_id + 1 - original_n_raw)
 
+    @property
+    def total_run_count(self) -> int:
+        """The live run count — the on-disk header's ``run_count`` plus any extensions.
+
+        The header's ``run_count`` field is frozen at first
+        :meth:`save` and is not rewritten on :meth:`Sweep.extend`
+        (append-only manifest header — see ``docs/manifest-schema.md``).
+        Reading ``run_count`` alone therefore lags the actual run set
+        after every extend; this property is what callers want when
+        they ask "how many runs are now in this sweep, including
+        extensions?".
+
+        Implementation: ``max(header.run_count, max(e.run_id) + 1)`` so
+        a mid-sweep ``Ctrl-C`` (entries < run_count) still reports the
+        expected total, and an extended manifest (max_run_id ≥
+        run_count) reports the post-extend total.
+        """
+        if not self.entries:
+            return self.run_count
+        return max(self.run_count, max(e.run_id for e in self.entries) + 1)
+
 
 def _fsync_dir(directory: Path) -> None:
     # Directory fsync ensures the new file's metadata (existence, size) is

--- a/src/gmat_sweep/spec.py
+++ b/src/gmat_sweep/spec.py
@@ -25,12 +25,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import Any, Literal, cast, get_args
 
 __all__ = ["RunOutcome", "RunSpec", "RunStatus", "SweepSpec"]
 
 
 RunStatus = Literal["ok", "failed", "skipped"]
+_RUN_STATUS_VALUES: frozenset[str] = frozenset(get_args(RunStatus))
 
 
 @dataclass(frozen=True, slots=True)
@@ -53,22 +54,43 @@ class RunSpec:
     def to_dict(self) -> dict[str, Any]:
         return {
             "script_path": str(self.script_path),
-            "overrides": dict(self.overrides),
+            "overrides": self.overrides,
             "output_dir": str(self.output_dir),
             "run_id": self.run_id,
             "seed": self.seed,
-            "run_options": dict(self.run_options),
+            "run_options": self.run_options,
         }
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> RunSpec:
+        script_path = data["script_path"]
+        if not isinstance(script_path, str):
+            raise ValueError(f"RunSpec.script_path must be str, got {type(script_path).__name__}")
+        overrides = data["overrides"]
+        if not isinstance(overrides, dict):
+            raise ValueError(f"RunSpec.overrides must be a dict, got {type(overrides).__name__}")
+        output_dir = data["output_dir"]
+        if not isinstance(output_dir, str):
+            raise ValueError(f"RunSpec.output_dir must be str, got {type(output_dir).__name__}")
+        run_id = data["run_id"]
+        # bool is an int subclass — reject it explicitly so True doesn't sneak through as 1.
+        if type(run_id) is not int:
+            raise ValueError(f"RunSpec.run_id must be int, got {type(run_id).__name__}")
+        seed = data["seed"]
+        if seed is not None and type(seed) is not int:
+            raise ValueError(f"RunSpec.seed must be int or None, got {type(seed).__name__}")
+        run_options = data["run_options"]
+        if not isinstance(run_options, dict):
+            raise ValueError(
+                f"RunSpec.run_options must be a dict, got {type(run_options).__name__}"
+            )
         return cls(
-            script_path=Path(data["script_path"]),
-            overrides=dict(data["overrides"]),
-            output_dir=Path(data["output_dir"]),
-            run_id=int(data["run_id"]),
-            seed=None if data["seed"] is None else int(data["seed"]),
-            run_options=dict(data["run_options"]),
+            script_path=Path(script_path),
+            overrides=dict(overrides),
+            output_dir=Path(output_dir),
+            run_id=run_id,
+            seed=seed,
+            run_options=dict(run_options),
         )
 
 
@@ -95,7 +117,7 @@ class SweepSpec:
             "mission_script_path": str(self.mission_script_path),
             "runs": [r.to_dict() for r in self.runs],
             "backend": self.backend,
-            "backend_kwargs": dict(self.backend_kwargs),
+            "backend_kwargs": self.backend_kwargs,
             "output_dir": str(self.output_dir),
             "manifest_path": str(self.manifest_path),
             "sweep_seed": self.sweep_seed,
@@ -122,9 +144,15 @@ class RunOutcome:
     ReportFile resource name) to the on-disk Parquet artefact written
     under :attr:`RunSpec.output_dir`. Empty for failed and skipped runs.
     ``stderr`` is ``None`` for successful runs and the captured worker
-    stderr / traceback string for failed runs. ``duration_s`` is computed
-    by the :meth:`ok` / :meth:`failed` helpers from the bookend timestamps
-    so the three values cannot disagree.
+    stderr / traceback string for failed runs.
+
+    ``duration_s`` is measured from a :func:`time.monotonic` bookend
+    pair around the run body, not from
+    ``(ended_at - started_at).total_seconds()``: a wall-clock
+    correction (NTP step) mid-run would otherwise drive ``duration_s``
+    negative or zero. ``started_at`` / ``ended_at`` remain wall-clock
+    audit timestamps. Callers pass the monotonic delta in via the
+    :meth:`ok` / :meth:`failed` helpers.
     """
 
     run_id: int
@@ -143,12 +171,13 @@ class RunOutcome:
         output_paths: dict[str, Path],
         started_at: datetime,
         ended_at: datetime,
+        duration_s: float,
     ) -> RunOutcome:
         return cls(
             run_id=run_id,
             status="ok",
             output_paths=dict(output_paths),
-            duration_s=(ended_at - started_at).total_seconds(),
+            duration_s=duration_s,
             stderr=None,
             started_at=started_at,
             ended_at=ended_at,
@@ -162,12 +191,13 @@ class RunOutcome:
         stderr: str,
         started_at: datetime,
         ended_at: datetime,
+        duration_s: float,
     ) -> RunOutcome:
         return cls(
             run_id=run_id,
             status="failed",
             output_paths={},
-            duration_s=(ended_at - started_at).total_seconds(),
+            duration_s=duration_s,
             stderr=stderr,
             started_at=started_at,
             ended_at=ended_at,
@@ -186,9 +216,14 @@ class RunOutcome:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> RunOutcome:
+        status = data["status"]
+        if status not in _RUN_STATUS_VALUES:
+            raise ValueError(
+                f"RunOutcome.status must be one of {sorted(_RUN_STATUS_VALUES)}, got {status!r}"
+            )
         return cls(
             run_id=int(data["run_id"]),
-            status=cast(RunStatus, data["status"]),
+            status=cast(RunStatus, status),
             output_paths={k: Path(v) for k, v in data["output_paths"].items()},
             duration_s=float(data["duration_s"]),
             stderr=None if data["stderr"] is None else str(data["stderr"]),

--- a/src/gmat_sweep/sweep.py
+++ b/src/gmat_sweep/sweep.py
@@ -16,8 +16,7 @@ from __future__ import annotations
 
 import platform
 import warnings
-from collections.abc import Mapping, Sequence
-from concurrent.futures import Future
+from collections.abc import Iterable, Mapping, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, overload
 
@@ -38,7 +37,7 @@ if TYPE_CHECKING:
 
     from gmat_sweep.aggregate import DataFrame
     from gmat_sweep.backends.base import Pool
-    from gmat_sweep.spec import RunOutcome, RunSpec
+    from gmat_sweep.spec import RunSpec
 
 __all__ = ["Sweep"]
 
@@ -56,7 +55,16 @@ class Sweep:
     runs:
         The :class:`RunSpec` instances to dispatch. ``run_id`` values must be
         unique. Order is preserved on the submission side; outcomes return in
-        completion order.
+        completion order. Pass an :class:`Iterable` (e.g. the streaming
+        generator from :func:`gmat_sweep.grids.iter_grid_run_specs`) to keep a
+        large factorial out of driver memory; in that case
+        ``expected_run_count`` is required for the manifest header.
+    expected_run_count:
+        Total run count for the manifest header and progress bar. Required
+        when ``runs`` is a non-:class:`Sequence` iterable (no ``__len__``);
+        derived as ``len(runs)`` otherwise. The :meth:`resume` and
+        :meth:`extend` paths always pass a finite :class:`Sequence` so this
+        stays ``None`` for them.
     backend:
         A constructed :class:`Pool`. The caller owns its lifecycle — typically
         a ``with LocalJoblibPool(...) as pool:`` block.
@@ -109,7 +117,7 @@ class Sweep:
     def __init__(
         self,
         *,
-        runs: Sequence[RunSpec],
+        runs: Iterable[RunSpec],
         backend: Pool,
         manifest_path: Path,
         output_dir: Path,
@@ -120,6 +128,7 @@ class Sweep:
         allow_unisolated_pool: bool = False,
         fsync_each: bool = True,
         fsync_batch: int = 50,
+        expected_run_count: int | None = None,
     ) -> None:
         if backend.subprocess_isolated is not True and not allow_unisolated_pool:
             raise BackendError(
@@ -130,7 +139,33 @@ class Sweep:
             )
         if fsync_batch < 1:
             raise SweepConfigError(f"fsync_batch must be >= 1, got {fsync_batch}")
-        self._runs: list[RunSpec] = list(runs)
+        # Two modes:
+        # * Sequence in → materialise as ``self._runs`` for the
+        #   :meth:`resume`/:meth:`extend`/:meth:`_repr_html_` lookups that
+        #   need the full list. ``run()`` still streams through
+        #   :meth:`Pool.imap` for the bounded-in-flight benefit.
+        # * Iterable (non-Sequence) in → keep as ``self._runs_stream``;
+        #   ``run()`` is the only path that consumes it. resume/extend
+        #   are not valid in this mode (they need the spec lookup).
+        if isinstance(runs, Sequence):
+            self._runs: list[RunSpec] | None = list(runs)
+            self._runs_stream: Iterable[RunSpec] = self._runs
+            derived_count = len(self._runs)
+        else:
+            self._runs = None
+            self._runs_stream = runs
+            derived_count = -1  # sentinel — must be supplied via expected_run_count
+        if expected_run_count is None:
+            if derived_count < 0:
+                raise SweepConfigError(
+                    "Sweep(runs=...) needs expected_run_count when runs is an "
+                    "iterator (no __len__); pass the count or hand in a Sequence."
+                )
+            self._run_count: int = derived_count
+        else:
+            if expected_run_count < 0:
+                raise SweepConfigError(f"expected_run_count must be >= 0, got {expected_run_count}")
+            self._run_count = expected_run_count
         self._backend = backend
         self._manifest_path = Path(manifest_path)
         self._output_dir = Path(output_dir)
@@ -155,26 +190,40 @@ class Sweep:
         between any two iterations leaves a parseable file containing exactly
         the runs that finished.
 
+        Dispatch streams the run iterable through :meth:`Pool.imap`, which
+        bounds the in-flight set to roughly ``4 * max_workers`` so a 10⁵-run
+        sweep does not pin 10⁵ :class:`RunSpec` payloads + 10⁵ futures in
+        driver memory. The grid expansion is itself lazy
+        (:func:`gmat_sweep.grids.iter_grid_run_specs`), so on a large
+        factorial neither the spec list nor the future list materialises in
+        full.
+
         :exc:`KeyboardInterrupt` is not caught; it propagates so the caller's
         ``with``-managed pool exits and cancels still-pending futures.
         """
-        self._enforce_debug_pool_single_spec(self._runs)
+        # DebugPool requires a known finite count of exactly 1; defer the
+        # check to the materialised-list path (it can't run a streaming
+        # iterator anyway).
+        if self._runs is not None:
+            self._enforce_debug_pool_single_spec(self._runs)
+        elif self._backend.subprocess_isolated == "debug":
+            raise BackendError(
+                "DebugPool dispatches a single spec in-process; streaming "
+                "Sweep(runs=<iterator>) is incompatible. Pass a length-1 list "
+                "instead."
+            )
         manifest = self._build_manifest()
         manifest.save(self._manifest_path)
         self._manifest = manifest
 
-        specs_by_run_id: dict[int, RunSpec] = {s.run_id: s for s in self._runs}
-        futures: list[Future[RunOutcome]] = [self._backend.submit(s) for s in self._runs]
-
         progress_bar = tqdm(
-            total=len(self._runs),
+            total=self._run_count,
             disable=not self._progress,
             desc="gmat-sweep",
             unit="run",
         )
         try:
-            for outcome in self._backend.as_completed(futures):
-                spec = specs_by_run_id[outcome.run_id]
+            for spec, outcome in self._backend.imap(self._runs_stream):
                 entry = ManifestEntry.from_outcome(
                     outcome,
                     overrides=spec.overrides,
@@ -314,6 +363,11 @@ class Sweep:
         """
         if not self._loaded_from_manifest or self._manifest is None:
             raise RuntimeError("Sweep.resume requires a Sweep built via Sweep.from_manifest")
+        if self._runs is None:
+            raise RuntimeError(
+                "Sweep.resume requires a materialised runs list — streaming "
+                "Sweep(runs=<iterator>) is incompatible with resume."
+            )
         manifest = self._manifest
 
         expected_run_ids = [s.run_id for s in self._runs]
@@ -327,8 +381,6 @@ class Sweep:
         runs_to_submit: list[RunSpec] = [specs_by_run_id[rid] for rid in sorted(to_retry)]
         self._enforce_debug_pool_single_spec(runs_to_submit)
 
-        futures: list[Future[RunOutcome]] = [self._backend.submit(s) for s in runs_to_submit]
-
         progress_bar = tqdm(
             total=len(runs_to_submit),
             disable=not self._progress,
@@ -336,8 +388,7 @@ class Sweep:
             unit="run",
         )
         try:
-            for outcome in self._backend.as_completed(futures):
-                spec = specs_by_run_id[outcome.run_id]
+            for spec, outcome in self._backend.imap(runs_to_submit):
                 entry = ManifestEntry.from_outcome(
                     outcome,
                     overrides=spec.overrides,
@@ -377,6 +428,11 @@ class Sweep:
         """
         if not self._loaded_from_manifest or self._manifest is None:
             raise RuntimeError("Sweep.extend requires a Sweep built via Sweep.from_manifest")
+        if self._runs is None:
+            raise RuntimeError(
+                "Sweep.extend requires a materialised runs list — streaming "
+                "Sweep(runs=<iterator>) is incompatible with extend."
+            )
         manifest = self._manifest
 
         kind = manifest.parameter_spec.get("_kind")
@@ -424,9 +480,6 @@ class Sweep:
         )
         self._enforce_debug_pool_single_spec(new_runs)
 
-        specs_by_run_id: dict[int, RunSpec] = {s.run_id: s for s in new_runs}
-        futures: list[Future[RunOutcome]] = [self._backend.submit(s) for s in new_runs]
-
         progress_bar = tqdm(
             total=len(new_runs),
             disable=not self._progress,
@@ -434,8 +487,7 @@ class Sweep:
             unit="run",
         )
         try:
-            for outcome in self._backend.as_completed(futures):
-                spec = specs_by_run_id[outcome.run_id]
+            for spec, outcome in self._backend.imap(new_runs):
                 entry = ManifestEntry.from_outcome(
                     outcome,
                     overrides=spec.overrides,
@@ -450,6 +502,7 @@ class Sweep:
         # Track the new specs on the Sweep so a follow-up resume() (e.g. if
         # a worker in this batch failed) can find them in self._runs.
         self._runs.extend(new_runs)
+        self._run_count += len(new_runs)
 
         # Reload to dedupe by run_id last-wins, matching resume().
         self._manifest = Manifest.load(self._manifest_path)
@@ -601,7 +654,7 @@ class Sweep:
         rows: list[tuple[str, str]] = [
             ("script", f"<code>{_html.escape(str(self._script_path))}</code>"),
             ("script_sha256", sha_cell),
-            ("run_count", str(len(self._runs))),
+            ("run_count", str(self._run_count)),
             ("parameter_spec._kind", _html.escape(str(kind))),
             ("backend", _html.escape(type(self._backend).__name__)),
         ]
@@ -611,11 +664,17 @@ class Sweep:
         if self._manifest is None:
             rows.append(("status", "<em>not yet executed</em>"))
         else:
-            counts = {"ok": 0, "failed": 0, "skipped": 0}
+            from collections import Counter
+
+            counts: Counter[str] = Counter()
             for entry in self._manifest.entries:
                 counts[entry.status] += 1
-            tally = ", ".join(f"{counts[k]} {k}" for k in ("ok", "failed", "skipped"))
-            rows.append(("outcomes", _html.escape(tally)))
+            known = ("ok", "failed", "skipped")
+            other = sum(v for k, v in counts.items() if k not in known)
+            parts = [f"{counts.get(k, 0)} {k}" for k in known]
+            if other:
+                parts.append(f"{other} other")
+            rows.append(("outcomes", _html.escape(", ".join(parts))))
 
         return build_kv_table("Sweep", rows)
 
@@ -646,7 +705,7 @@ class Sweep:
             os_platform=platform.platform(),
             sweep_seed=self._sweep_seed,
             parameter_spec=self._parameter_spec,
-            run_count=len(self._runs),
+            run_count=self._run_count,
             backend=self._backend.__class__.__name__,
             fsync_each=self._fsync_each,
             fsync_batch=self._fsync_batch,

--- a/src/gmat_sweep/sweep.py
+++ b/src/gmat_sweep/sweep.py
@@ -144,16 +144,19 @@ class Sweep:
         #   :meth:`resume`/:meth:`extend`/:meth:`_repr_html_` lookups that
         #   need the full list. ``run()`` still streams through
         #   :meth:`Pool.imap` for the bounded-in-flight benefit.
-        # * Iterable (non-Sequence) in → keep as ``self._runs_stream``;
-        #   ``run()`` is the only path that consumes it. resume/extend
-        #   are not valid in this mode (they need the spec lookup).
+        # * Iterable (non-Sequence) in → ``self._runs`` is an empty list
+        #   and ``_materialised`` is False. ``run()`` consumes the
+        #   provided iterator via ``self._runs_stream``; resume/extend
+        #   refuse, since they need the spec lookup.
         if isinstance(runs, Sequence):
-            self._runs: list[RunSpec] | None = list(runs)
+            self._runs: list[RunSpec] = list(runs)
             self._runs_stream: Iterable[RunSpec] = self._runs
+            self._materialised: bool = True
             derived_count = len(self._runs)
         else:
-            self._runs = None
+            self._runs = []
             self._runs_stream = runs
+            self._materialised = False
             derived_count = -1  # sentinel — must be supplied via expected_run_count
         if expected_run_count is None:
             if derived_count < 0:
@@ -204,7 +207,7 @@ class Sweep:
         # DebugPool requires a known finite count of exactly 1; defer the
         # check to the materialised-list path (it can't run a streaming
         # iterator anyway).
-        if self._runs is not None:
+        if self._materialised:
             self._enforce_debug_pool_single_spec(self._runs)
         elif self._backend.subprocess_isolated == "debug":
             raise BackendError(
@@ -363,7 +366,7 @@ class Sweep:
         """
         if not self._loaded_from_manifest or self._manifest is None:
             raise RuntimeError("Sweep.resume requires a Sweep built via Sweep.from_manifest")
-        if self._runs is None:
+        if not self._materialised:
             raise RuntimeError(
                 "Sweep.resume requires a materialised runs list — streaming "
                 "Sweep(runs=<iterator>) is incompatible with resume."
@@ -428,7 +431,7 @@ class Sweep:
         """
         if not self._loaded_from_manifest or self._manifest is None:
             raise RuntimeError("Sweep.extend requires a Sweep built via Sweep.from_manifest")
-        if self._runs is None:
+        if not self._materialised:
             raise RuntimeError(
                 "Sweep.extend requires a materialised runs list — streaming "
                 "Sweep(runs=<iterator>) is incompatible with extend."

--- a/src/gmat_sweep/worker.py
+++ b/src/gmat_sweep/worker.py
@@ -16,6 +16,7 @@ cost exactly once on its first call, in its own subprocess.
 from __future__ import annotations
 
 import logging
+import time
 import traceback
 from datetime import datetime, timezone
 from pathlib import Path
@@ -57,17 +58,23 @@ def run_one(spec: RunSpec) -> RunOutcome:
     it via :attr:`gmat_sweep.manifest.ManifestEntry.log_path`.
     """
     started_at = datetime.now(timezone.utc)
-    spec.output_dir.mkdir(parents=True, exist_ok=True)
-    log_path = spec.output_dir / _WORKER_LOG_NAME
+    start_monotonic = time.monotonic()
 
+    # FileHandler init (and the mkdir that precedes it) can raise on a bad
+    # output_dir (EROFS, ENOSPC, permission denied). Keep both inside the
+    # try so the worker's "never raises" contract holds — a FileHandler
+    # failure here is reported as RunOutcome.failed, not propagated.
     logger = logging.getLogger(f"gmat_sweep.worker.run_{spec.run_id}")
     logger.setLevel(logging.DEBUG)
     logger.propagate = False
-    handler = logging.FileHandler(log_path, mode="a", encoding="utf-8")
-    handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
-    logger.addHandler(handler)
-
+    handler: logging.FileHandler | None = None
     try:
+        spec.output_dir.mkdir(parents=True, exist_ok=True)
+        log_path = spec.output_dir / _WORKER_LOG_NAME
+        handler = logging.FileHandler(log_path, mode="a", encoding="utf-8")
+        handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
+        logger.addHandler(handler)
+
         logger.info("run_id=%d script=%s", spec.run_id, spec.script_path)
         logger.info("overrides=%s", spec.overrides)
         if spec.seed is not None:
@@ -115,30 +122,36 @@ def run_one(spec: RunSpec) -> RunOutcome:
             logger.info("--- GMAT engine log ---\n%s", results.log)
 
         ended_at = datetime.now(timezone.utc)
-        logger.info("status=ok duration_s=%.3f", (ended_at - started_at).total_seconds())
+        duration_s = time.monotonic() - start_monotonic
+        logger.info("status=ok duration_s=%.3f", duration_s)
         return RunOutcome.ok(
             run_id=spec.run_id,
             output_paths=output_paths,
             started_at=started_at,
             ended_at=ended_at,
+            duration_s=duration_s,
         )
     except KeyboardInterrupt:  # pragma: no cover - propagates to the driver
         raise
     except Exception as exc:
         ended_at = datetime.now(timezone.utc)
+        duration_s = time.monotonic() - start_monotonic
         tb = traceback.format_exc()
         engine_log = getattr(exc, "log", None)
         stderr = tb if not engine_log else f"{tb}\n--- GMAT engine log ---\n{engine_log}"
-        logger.error("status=failed\n%s", stderr)
+        if handler is not None:
+            logger.error("status=failed\n%s", stderr)
         return RunOutcome.failed(
             run_id=spec.run_id,
             stderr=stderr,
             started_at=started_at,
             ended_at=ended_at,
+            duration_s=duration_s,
         )
     finally:
-        logger.removeHandler(handler)
-        handler.close()
+        if handler is not None:
+            logger.removeHandler(handler)
+            handler.close()
 
 
 def _write_one(

--- a/tests/test_backends_base.py
+++ b/tests/test_backends_base.py
@@ -135,3 +135,146 @@ def test_pool_works_as_context_manager() -> None:
         assert p is pool
         assert not pool.closed
     assert pool.closed
+
+
+# ---- Pool.imap default implementation (issue #134 item 2) -----------------
+
+
+class _RecordingPool(Pool):
+    """Concrete Pool that records peak in-flight specs so imap behaviour is testable."""
+
+    def __init__(self, *, max_workers: int = 2) -> None:
+        self._max_workers = max_workers
+        self.submitted: list[RunSpec] = []
+        self.peak_in_flight = 0
+        self._pending: dict[Future[RunOutcome], RunSpec] = {}
+        self.closed = False
+
+    @property
+    def max_workers(self) -> int:
+        return self._max_workers
+
+    def submit(self, spec: RunSpec) -> Future[RunOutcome]:
+        self.submitted.append(spec)
+        future: Future[RunOutcome] = Future()
+        self._pending[future] = spec
+        # Track the peak before draining — the imap default submits a chunk
+        # before calling as_completed, so peak == chunk size.
+        self.peak_in_flight = max(self.peak_in_flight, len(self._pending))
+        return future
+
+    def as_completed(self, futures: Iterable[Future[RunOutcome]]) -> Iterator[RunOutcome]:
+        from datetime import datetime, timezone
+
+        for f in list(futures):
+            spec = self._pending.pop(f)
+            now = datetime.now(timezone.utc)
+            outcome = RunOutcome.ok(
+                run_id=spec.run_id,
+                output_paths={},
+                started_at=now,
+                ended_at=now,
+                duration_s=0.0,
+            )
+            f.set_result(outcome)
+            yield outcome
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _make_specs(n: int) -> list[RunSpec]:
+    from pathlib import Path
+
+    return [
+        RunSpec(
+            script_path=Path("/m.script"),
+            overrides={"x": i},
+            output_dir=Path(f"/o/run-{i}"),
+            run_id=i,
+            seed=None,
+            run_options={},
+        )
+        for i in range(n)
+    ]
+
+
+def test_imap_default_bounds_in_flight_to_four_times_max_workers() -> None:
+    """The headline #134 item 2 fix: 100 specs through a 2-worker pool must
+    never have more than ``4 * 2 = 8`` futures pending at once."""
+    pool = _RecordingPool(max_workers=2)
+    specs = _make_specs(100)
+    yielded = list(pool.imap(specs))
+    assert len(yielded) == 100
+    # 8 = chunk size; nothing materialised beyond it.
+    assert pool.peak_in_flight == 8
+    # All specs were dispatched in run_id order (each chunk submitted in order).
+    assert [s.run_id for s, _ in yielded] == list(range(100))
+
+
+def test_imap_explicit_in_flight_overrides_default() -> None:
+    pool = _RecordingPool(max_workers=2)
+    yielded = list(pool.imap(_make_specs(20), in_flight=3))
+    assert len(yielded) == 20
+    assert pool.peak_in_flight == 3
+
+
+def test_imap_yields_spec_outcome_pairs() -> None:
+    """Each yielded pair carries the originating :class:`RunSpec` so the caller
+    doesn't need to maintain a run_id -> spec side-table."""
+    pool = _RecordingPool(max_workers=1)
+    specs = _make_specs(5)
+    pairs = list(pool.imap(specs))
+    for spec, outcome in pairs:
+        assert isinstance(spec, RunSpec)
+        assert isinstance(outcome, RunOutcome)
+        assert spec.run_id == outcome.run_id
+
+
+def test_imap_rejects_non_positive_in_flight() -> None:
+    pool = _RecordingPool(max_workers=1)
+    with pytest.raises(ValueError):
+        list(pool.imap(_make_specs(1), in_flight=0))
+
+
+def test_imap_consumes_iterator_lazily() -> None:
+    """Iterator inputs are pulled only as outcomes drain — a true 10⁵-spec
+    generator never materialises in full."""
+    pool = _RecordingPool(max_workers=1)
+    counter = {"pulled": 0}
+
+    def _gen() -> Iterator[RunSpec]:
+        for i in range(1000):
+            counter["pulled"] += 1
+            from pathlib import Path
+
+            yield RunSpec(
+                script_path=Path("/m.script"),
+                overrides={"x": i},
+                output_dir=Path(f"/o/run-{i}"),
+                run_id=i,
+                seed=None,
+                run_options={},
+            )
+
+    # Pull just the first 5 outcomes and abandon the iterator.
+    it = pool.imap(_gen(), in_flight=4)
+    first_five = [next(it) for _ in range(5)]
+    assert len(first_five) == 5
+    # We've consumed 5 outcomes; the iterator should not have been fully drained
+    # (it's a 1000-spec generator). The chunked default pulls in_flight=4 at a
+    # time, so after 5 outcomes we've pulled either 4 (first chunk active) or 8
+    # (second chunk started). Either way, far less than 1000.
+    assert counter["pulled"] < 1000
+
+
+def test_default_max_workers_is_one() -> None:
+    """The base ABC fallback is 1 so unknown backends still get a sane (slow)
+    sequential default rather than 0 or a crash."""
+
+    pool = _RecordingPool()  # uses the override
+    assert pool.max_workers == 2
+
+    # Reach into _MinimalPool, which does NOT override max_workers.
+    minimal = _MinimalPool()
+    assert minimal.max_workers == 1

--- a/tests/test_backends_dask.py
+++ b/tests/test_backends_dask.py
@@ -35,7 +35,9 @@ def _make_spec(*, output_dir: Path, run_id: int = 0) -> RunSpec:
 
 def _ok_outcome(run_id: int) -> RunOutcome:
     now = datetime.now(timezone.utc)
-    return RunOutcome.ok(run_id=run_id, output_paths={}, started_at=now, ended_at=now)
+    return RunOutcome.ok(
+        run_id=run_id, output_paths={}, started_at=now, ended_at=now, duration_s=0.0
+    )
 
 
 class _StubFuture:

--- a/tests/test_backends_joblib.py
+++ b/tests/test_backends_joblib.py
@@ -175,7 +175,9 @@ def test_close_cancels_pending_futures(tmp_path: Path) -> None:
 
 def _ok_outcome(run_id: int) -> RunOutcome:
     now = datetime.now(timezone.utc)
-    return RunOutcome.ok(run_id=run_id, output_paths={}, started_at=now, ended_at=now)
+    return RunOutcome.ok(
+        run_id=run_id, output_paths={}, started_at=now, ended_at=now, duration_s=0.0
+    )
 
 
 def test_default_dispatches_run_one_directly(

--- a/tests/test_backends_mpi.py
+++ b/tests/test_backends_mpi.py
@@ -30,7 +30,9 @@ def _make_spec(*, output_dir: Path, run_id: int = 0) -> RunSpec:
 
 def _ok_outcome(run_id: int) -> RunOutcome:
     now = datetime.now(timezone.utc)
-    return RunOutcome.ok(run_id=run_id, output_paths={}, started_at=now, ended_at=now)
+    return RunOutcome.ok(
+        run_id=run_id, output_paths={}, started_at=now, ended_at=now, duration_s=0.0
+    )
 
 
 class _StubMPIPoolExecutor:

--- a/tests/test_backends_process_pool.py
+++ b/tests/test_backends_process_pool.py
@@ -52,7 +52,9 @@ def _make_spec(*, output_dir: Path, run_id: int = 0) -> RunSpec:
 
 def _ok_outcome(run_id: int) -> RunOutcome:
     now = datetime.now(timezone.utc)
-    return RunOutcome.ok(run_id=run_id, output_paths={}, started_at=now, ended_at=now)
+    return RunOutcome.ok(
+        run_id=run_id, output_paths={}, started_at=now, ended_at=now, duration_s=0.0
+    )
 
 
 @pytest.fixture

--- a/tests/test_backends_ray.py
+++ b/tests/test_backends_ray.py
@@ -36,7 +36,9 @@ def _make_spec(*, output_dir: Path, run_id: int = 0) -> RunSpec:
 
 def _ok_outcome(run_id: int) -> RunOutcome:
     now = datetime.now(timezone.utc)
-    return RunOutcome.ok(run_id=run_id, output_paths={}, started_at=now, ended_at=now)
+    return RunOutcome.ok(
+        run_id=run_id, output_paths={}, started_at=now, ended_at=now, duration_s=0.0
+    )
 
 
 class _ObjectRef:

--- a/tests/test_backends_subprocess.py
+++ b/tests/test_backends_subprocess.py
@@ -51,6 +51,7 @@ def fake_subprocess_run(monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
             output_paths={"report__R": spec.output_dir / "report__R.parquet"},
             started_at=now,
             ended_at=now,
+            duration_s=0.0,
         )
         Path(argv[outcome_idx]).write_text(json.dumps(outcome.to_dict()))
         return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
@@ -152,6 +153,96 @@ def test_non_zero_exit_returns_failed_outcome_with_stderr(
     assert outcome.stderr is not None
     assert "exited with status 3" in outcome.stderr
     assert "cannot read spec" in outcome.stderr
+
+
+def test_outcome_recovered_from_stdout_on_exit_four(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Parent must recover outcome JSON printed to stdout when child exits 4.
+
+    Issue #134 item 1 closes the work-loss path where a 30-minute GMAT run
+    succeeded but the outcome JSON couldn't land on disk. The child prints
+    the outcome to stdout before exiting 4; the parent's stdout-recovery
+    path turns it back into a real RunOutcome instead of synthesising a
+    failed one.
+    """
+    now = datetime.now(timezone.utc)
+    real_outcome = RunOutcome.ok(
+        run_id=42,
+        output_paths={"report__R": tmp_path / "run-42" / "report__R.parquet"},
+        started_at=now,
+        ended_at=now,
+        duration_s=1800.0,  # 30 min — the work-loss path
+    )
+    stdout_payload = json.dumps(real_outcome.to_dict())
+
+    def _run(argv: list[str], **_: Any) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            argv,
+            4,
+            stdout=f"some unrelated noise\n{stdout_payload}\n",
+            stderr="cannot write outcome /tmp/x.json: [Errno 28] No space left on device",
+        )
+
+    monkeypatch.setattr(subprocess, "run", _run)
+
+    outcome = _subprocess.run_spec_in_subprocess(
+        _make_spec(output_dir=tmp_path / "run-42", run_id=42)
+    )
+
+    # The actual run was recovered — not a synthetic failed outcome.
+    assert outcome.status == "ok"
+    assert outcome.run_id == 42
+    assert outcome.duration_s == 1800.0
+
+
+def test_outcome_recovery_falls_back_to_failed_when_stdout_unparseable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _run(argv: list[str], **_: Any) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            argv,
+            4,
+            stdout="not json at all",
+            stderr="cannot write outcome",
+        )
+
+    monkeypatch.setattr(subprocess, "run", _run)
+
+    outcome = _subprocess.run_spec_in_subprocess(
+        _make_spec(output_dir=tmp_path / "run-9", run_id=9)
+    )
+
+    assert outcome.status == "failed"
+    assert outcome.run_id == 9
+    assert outcome.stderr is not None
+    assert "exited with status 4" in outcome.stderr
+
+
+def test_outcome_recovery_rejects_run_id_mismatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A stdout outcome whose run_id doesn't match the spec is *not* trusted."""
+    now = datetime.now(timezone.utc)
+    wrong = RunOutcome.ok(
+        run_id=999,  # ← doesn't match the spec's run_id below
+        output_paths={},
+        started_at=now,
+        ended_at=now,
+        duration_s=0.0,
+    )
+
+    def _run(argv: list[str], **_: Any) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(argv, 4, stdout=json.dumps(wrong.to_dict()), stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _run)
+
+    outcome = _subprocess.run_spec_in_subprocess(
+        _make_spec(output_dir=tmp_path / "run-5", run_id=5)
+    )
+
+    assert outcome.status == "failed"
+    assert outcome.run_id == 5  # the synthetic outcome carries the *expected* id
 
 
 def test_timeout_returns_failed_outcome(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_failure_modes.py
+++ b/tests/test_failure_modes.py
@@ -175,13 +175,23 @@ class _SyntheticFailingPool(Pool):
 def _ok_outcome(spec: RunSpec, output_paths: dict[str, Path]) -> RunOutcome:
     now = datetime.now(timezone.utc)
     return RunOutcome.ok(
-        run_id=spec.run_id, output_paths=output_paths, started_at=now, ended_at=now
+        run_id=spec.run_id,
+        output_paths=output_paths,
+        started_at=now,
+        ended_at=now,
+        duration_s=0.0,
     )
 
 
 def _failed_outcome(spec: RunSpec, stderr: str) -> RunOutcome:
     now = datetime.now(timezone.utc)
-    return RunOutcome.failed(run_id=spec.run_id, stderr=stderr, started_at=now, ended_at=now)
+    return RunOutcome.failed(
+        run_id=spec.run_id,
+        stderr=stderr,
+        started_at=now,
+        ended_at=now,
+        duration_s=0.0,
+    )
 
 
 def _drive_synthetic_sweep(

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -17,6 +17,8 @@ from gmat_sweep.grids import (
     expand_monte_carlo_to_run_specs,
     expand_samples_to_run_specs,
     full_factorial,
+    full_factorial_size,
+    iter_grid_run_specs,
     latin_hypercube_samples,
 )
 from gmat_sweep.spec import RunSpec
@@ -565,3 +567,46 @@ def test_expand_latin_hypercube_deterministic_per_seed() -> None:
         output_dir="/o",
     )
     assert [s.overrides for s in a] == [s.overrides for s in b]
+
+
+# ---- iter_grid_run_specs / full_factorial_size (issue #133 item 6) --------
+
+
+def test_iter_grid_run_specs_yields_same_specs_as_eager_expander() -> None:
+    grid = {"a": [1, 2], "b": [10, 20, 30]}
+    eager = expand_grid_to_run_specs(grid, "/m.script", "/o")
+    streamed = list(iter_grid_run_specs(grid, "/m.script", "/o"))
+    assert eager == streamed
+
+
+def test_iter_grid_run_specs_is_lazy() -> None:
+    """The cartesian product is generated one spec at a time.
+
+    For a 10⁵-row factorial the driver should not pre-materialise the list —
+    pull the first three specs and assert the iterator hasn't exhausted.
+    """
+    grid = {"a": list(range(100)), "b": list(range(100)), "c": list(range(10))}
+    # 100 * 100 * 10 = 100_000 runs
+    it = iter_grid_run_specs(grid, "/m.script", "/o")
+    first_three = [next(it), next(it), next(it)]
+    assert [s.run_id for s in first_three] == [0, 1, 2]
+    # The iterator is still alive — consuming three of 100k doesn't exhaust it.
+    next_spec = next(it)
+    assert next_spec.run_id == 3
+
+
+def test_full_factorial_size_matches_iteration_length() -> None:
+    grid = {"a": [1, 2], "b": [10, 20, 30], "c": [100, 200]}
+    assert full_factorial_size(grid) == 2 * 3 * 2
+    assert full_factorial_size(grid) == len(list(full_factorial(grid)))
+
+
+def test_full_factorial_size_for_empty_grid_is_one() -> None:
+    assert full_factorial_size({}) == 1
+
+
+def test_full_factorial_size_validates_keys_and_values() -> None:
+    with pytest.raises(SweepConfigError):
+        full_factorial_size({"a": [1, 2], "b": []})
+    with pytest.raises(SweepConfigError):
+        full_factorial_size({1: [1, 2]})  # type: ignore[dict-item]

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -85,6 +85,7 @@ def test_manifest_entry_from_outcome_carries_overrides_and_log_path() -> None:
         output_paths={"ReportFile1": Path("/o/run-7/r1.parquet")},
         started_at=_utc(2026, 5, 4, 0, 0, 0),
         ended_at=_utc(2026, 5, 4, 0, 0, 5),
+        duration_s=5.0,
     )
     entry = ManifestEntry.from_outcome(
         outcome,
@@ -105,6 +106,7 @@ def test_manifest_entry_from_outcome_log_path_defaults_to_none() -> None:
         stderr="GMAT exploded",
         started_at=_utc(2026, 5, 4, 0, 0, 0),
         ended_at=_utc(2026, 5, 4, 0, 0, 1),
+        duration_s=1.0,
     )
     entry = ManifestEntry.from_outcome(outcome, overrides={"Sat.SMA": 7000.0})
     assert entry.log_path is None

--- a/tests/test_monte_carlo_extend.py
+++ b/tests/test_monte_carlo_extend.py
@@ -171,6 +171,10 @@ def test_extension_run_count_is_positive_after_extend(
     assert manifest.extension_run_count == 15
     # parameter_spec.n stays frozen at the original value — header is append-only.
     assert manifest.parameter_spec["n"] == 10
+    # Header run_count is stale (it reports the original size) but
+    # total_run_count reflects the live total. Issue #134 item 3.
+    assert manifest.run_count == 10
+    assert manifest.total_run_count == 25
 
 
 def test_extension_run_count_is_zero_for_grid_manifest(
@@ -346,3 +350,20 @@ def test_latin_hypercube_extend_refuses_with_clear_message(
             backend=LocalJoblibPool(max_workers=1),
             progress=False,
         )
+
+
+def test_latin_hypercube_extend_is_not_in_public_api() -> None:
+    """The typed-refusal sentinel is intentionally hidden from the top-level
+    namespace and ``__all__`` so the user-facing API doesn't advertise an
+    "extend" capability for LH sweeps. Generic wrappers that need the typed
+    refusal import it directly from :mod:`gmat_sweep.api`."""
+    import gmat_sweep
+    import gmat_sweep.api as api_mod
+
+    assert "latin_hypercube_extend" not in gmat_sweep.__all__
+    assert "latin_hypercube_extend" not in api_mod.__all__
+    # Direct import from gmat_sweep.api still works — used by typed-refusal
+    # wrappers that want the SweepConfigError rather than AttributeError.
+    from gmat_sweep.api import latin_hypercube_extend as _direct
+
+    assert _direct is not None

--- a/tests/test_repr_html.py
+++ b/tests/test_repr_html.py
@@ -153,6 +153,7 @@ def test_run_outcome_repr_html_ok() -> None:
         output_paths={"ReportFile1": Path("/o/run-7/r1.parquet")},
         started_at=_utc(2026, 5, 4, 0, 0, 0),
         ended_at=_utc(2026, 5, 4, 0, 0, 12),
+        duration_s=12.0,
     )
     html = outcome._repr_html_()
     _assert_well_formed_html(html)
@@ -171,6 +172,7 @@ def test_run_outcome_repr_html_failed_truncates_long_stderr() -> None:
         stderr=f"{long_first_line}\nsecond line not shown",
         started_at=_utc(2026, 5, 4, 0, 0, 0),
         ended_at=_utc(2026, 5, 4, 0, 0, 1),
+        duration_s=1.0,
     )
     html = outcome._repr_html_()
     _assert_well_formed_html(html)
@@ -186,6 +188,7 @@ def test_run_outcome_repr_html_escapes_html_in_stderr() -> None:
         stderr="<script>alert('boom')</script>",
         started_at=_utc(2026, 5, 4),
         ended_at=_utc(2026, 5, 4, 0, 0, 1),
+        duration_s=1.0,
     )
     html = outcome._repr_html_()
     _assert_well_formed_html(html)

--- a/tests/test_run_subprocess.py
+++ b/tests/test_run_subprocess.py
@@ -137,14 +137,62 @@ def test_spec_with_wrong_type_returns_three(tmp_path: Path) -> None:
     assert rc == 3
 
 
+def test_outcome_write_failure_after_run_prints_outcome_to_stdout(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Recovery path for #134 item 1: a post-run_one OSError on the outcome write
+    still emits the outcome to stdout so the parent backend can recover it,
+    instead of losing the run."""
+    spec_path = tmp_path / "spec.json"
+    outcome_path = tmp_path / "outcome.json"
+    _write_spec(spec_path, output_dir=tmp_path / "run-0", run_id=7)
+
+    # The writability probe passes (path doesn't exist yet, parent is writable).
+    # Inject a post-run OSError by replacing Path.open *only after* run_one has
+    # produced the outcome — monkeypatch via a counter.
+    import pathlib
+
+    real_open = pathlib.Path.open
+    call_count = {"n": 0}
+
+    def _open(self: Path, *args: Any, **kwargs: Any) -> Any:
+        # Only fail on the write-mode reopen for the outcome path. The probe
+        # uses touch() (which goes through os.open), not Path.open().
+        if self == outcome_path and args and args[0] == "w":
+            call_count["n"] += 1
+            raise OSError("simulated post-run write failure")
+        return real_open(self, *args, **kwargs)
+
+    import types
+
+    monkeypatch = pytest.MonkeyPatch()
+    try:
+        monkeypatch.setattr(pathlib.Path, "open", _open)
+        rc = _run_subprocess.main(["--spec", str(spec_path), "--outcome", str(outcome_path)])
+    finally:
+        monkeypatch.undo()
+    _ = types  # silence unused
+
+    assert rc == 4
+    assert call_count["n"] >= 1
+    captured = capsys.readouterr()
+    # The outcome JSON appears on stdout — parent can recover the run.
+    last_json_line = next(
+        line for line in reversed(captured.out.splitlines()) if line.startswith("{")
+    )
+    recovered = RunOutcome.from_dict(json.loads(last_json_line))
+    assert recovered.run_id == 7
+    assert recovered.status == "ok"
+
+
 def test_unwriteable_outcome_path_returns_four(
     tmp_path: Path, fake_gmat_run: FakeGmatRun, capsys: pytest.CaptureFixture[str]
 ) -> None:
     spec_path = tmp_path / "spec.json"
     _write_spec(spec_path, output_dir=tmp_path / "run-0")
 
-    # Pre-create the outcome path as a *directory* so write_text fails with
-    # IsADirectoryError (a subclass of OSError).
+    # Pre-create the outcome path as a *directory* so touch / write_text fails
+    # with IsADirectoryError (a subclass of OSError).
     outcome_path = tmp_path / "outcome.json"
     outcome_path.mkdir()
 
@@ -152,4 +200,9 @@ def test_unwriteable_outcome_path_returns_four(
 
     assert rc == 4
     captured = capsys.readouterr()
-    assert "cannot write outcome" in captured.err
+    # The writability probe fires before run_one, so the user-facing message
+    # is "not writable", not "cannot write outcome" — same exit code, earlier
+    # detection. Either message is acceptable surface for this test.
+    assert "outcome" in captured.err and (
+        "not writable" in captured.err or "cannot write outcome" in captured.err
+    )

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -102,6 +102,7 @@ def test_run_outcome_ok_helper_sets_status_and_clears_stderr() -> None:
         output_paths={"ReportFile1": Path("/o/run-2/r1.parquet")},
         started_at=started,
         ended_at=ended,
+        duration_s=12.0,
     )
     assert out.status == "ok"
     assert out.stderr is None
@@ -117,6 +118,7 @@ def test_run_outcome_failed_helper_captures_stderr_and_empty_outputs() -> None:
         stderr="GMAT exploded",
         started_at=started,
         ended_at=ended,
+        duration_s=5.0,
     )
     assert out.status == "failed"
     assert out.stderr == "GMAT exploded"
@@ -135,6 +137,7 @@ def test_run_outcome_ok_round_trips_paths_and_timestamps() -> None:
         },
         started_at=started,
         ended_at=ended,
+        duration_s=90.0,
     )
     restored = RunOutcome.from_dict(json.loads(json.dumps(original.to_dict())))
     assert restored == original
@@ -149,6 +152,7 @@ def test_run_outcome_failed_round_trips_with_stderr() -> None:
         stderr="GMAT exploded",
         started_at=started,
         ended_at=ended,
+        duration_s=5.0,
     )
     restored = RunOutcome.from_dict(json.loads(json.dumps(original.to_dict())))
     assert restored == original
@@ -169,3 +173,70 @@ def test_run_outcome_skipped_constructed_directly_round_trips() -> None:
     restored = RunOutcome.from_dict(json.loads(json.dumps(skipped.to_dict())))
     assert restored == skipped
     assert restored.status == "skipped"
+
+
+def test_run_outcome_from_dict_rejects_unknown_status() -> None:
+    moment = _utc(2026, 5, 4, 0, 0, 0)
+    payload = {
+        "run_id": 1,
+        "status": "banana",
+        "output_paths": {},
+        "duration_s": 0.0,
+        "stderr": None,
+        "started_at": moment.isoformat(),
+        "ended_at": moment.isoformat(),
+    }
+    with pytest.raises(ValueError, match="banana"):
+        RunOutcome.from_dict(payload)
+
+
+@pytest.mark.parametrize(
+    "field, bad_value",
+    [
+        ("script_path", 123),
+        ("output_dir", None),
+        ("run_id", "0"),
+        ("run_id", True),  # bool is an int subclass — reject explicitly
+        ("seed", "42"),
+        ("overrides", ["Sat.SMA", 7000.0]),
+        ("run_options", "overwrite"),
+    ],
+)
+def test_run_spec_from_dict_rejects_malformed_field(field: str, bad_value: object) -> None:
+    payload: dict[str, object] = {
+        "script_path": "/missions/flyby.script",
+        "overrides": {"Sat.SMA": 7000.0},
+        "output_dir": "/sweep-out/run-0",
+        "run_id": 0,
+        "seed": 42,
+        "run_options": {},
+    }
+    payload[field] = bad_value
+    with pytest.raises(ValueError, match=field):
+        RunSpec.from_dict(payload)
+
+
+def test_run_outcome_duration_unaffected_by_wall_clock_step() -> None:
+    """Wall-clock bookends can disagree with duration_s when NTP corrects mid-run.
+
+    The fix is to source duration from time.monotonic() inside the worker; this
+    test asserts the helpers accept (and preserve) a duration that contradicts
+    `ended_at - started_at`.
+    """
+    started = _utc(2026, 5, 4, 12, 0, 0)
+    # Simulate the system clock being stepped backwards by 5 seconds mid-run:
+    # ended_at is *before* started_at, but monotonic-derived duration is 3.0 s.
+    ended = _utc(2026, 5, 4, 11, 59, 55)
+    monotonic_duration = 3.0
+
+    out = RunOutcome.ok(
+        run_id=0,
+        output_paths={},
+        started_at=started,
+        ended_at=ended,
+        duration_s=monotonic_duration,
+    )
+    assert out.duration_s == monotonic_duration
+    # Sanity: the wall-clock delta is negative; the helper trusted the
+    # caller's monotonic value rather than re-deriving.
+    assert (ended - started).total_seconds() < 0

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -161,6 +161,7 @@ class _NamedSpecificPool(Pool):
                 output_paths={},
                 started_at=now,
                 ended_at=now,
+                duration_s=0.0,
             )
             f.set_result(outcome)
             yield outcome
@@ -427,6 +428,7 @@ class _InterruptingPool(Pool):
                 output_paths={},
                 started_at=now,
                 ended_at=now,
+                duration_s=0.0,
             )
         raise KeyboardInterrupt
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -260,6 +260,35 @@ def test_run_one_never_raises_for_known_failure_modes(
     assert outcome.stderr
 
 
+def test_run_one_failed_when_filehandler_init_raises(
+    tmp_path: Path, fake_gmat_run: FakeGmatRun, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A FileHandler init failure must be folded into RunOutcome.failed, not raised.
+
+    The bug fixed in #134 (item 4): mkdir succeeded but FileHandler.__init__
+    raised (permission denied, EROFS, ENOSPC), and the exception escaped
+    run_one, violating the module's "never raises" contract.
+    """
+    import logging
+
+    original = logging.FileHandler
+
+    def _exploding_filehandler(*args: Any, **kwargs: Any) -> logging.FileHandler:
+        raise PermissionError("simulated FileHandler init failure")
+
+    monkeypatch.setattr(logging, "FileHandler", _exploding_filehandler)
+    try:
+        spec = _make_spec(output_dir=tmp_path / "run-0")
+        outcome = run_one(spec)
+    finally:
+        monkeypatch.setattr(logging, "FileHandler", original)
+
+    assert outcome.status == "failed"
+    assert outcome.stderr is not None
+    assert "PermissionError" in outcome.stderr
+    assert "simulated FileHandler init failure" in outcome.stderr
+
+
 # ---- time-column synthesis ----------------------------------------------
 #
 # gmat-run's ReportFile parser names columns after the GMAT field (e.g.


### PR DESCRIPTION
## Summary

Closes the nine spec / worker / orchestration contract gaps in #134, plus the streaming `grids.full_factorial` fix #139 deferred from #133 item 6 (same underlying refactor at a different layer).

### Work-loss paths
- `_run_subprocess` probes `--outcome` writability before `run_one`, so a bad path no longer burns a 30-minute GMAT run. On a post-run write failure the outcome is printed to stdout; `backends._subprocess.run_spec_in_subprocess` recovers it before falling back to a synthetic `RunOutcome.failed`.
- `worker.run_one`'s `mkdir` / logger / `FileHandler` setup now sits inside the `try` block, so a `FileHandler` init failure folds into `RunOutcome.failed` instead of escaping the worker.

### Streaming orchestration (#134 item 2 + #133 item 6)
- New `Pool.imap(specs, *, in_flight=None)` ABC method with a chunked default bounded to `4 * max_workers`. Backends override the new `max_workers` property to expose their actual count.
- New `grids.iter_grid_run_specs` + `full_factorial_size` for lazy grid expansion. `Sweep.__init__` now accepts an `Iterable[RunSpec]` plus `expected_run_count`; `api.sweep(grid=...)` streams the cartesian product through end-to-end. A 10⁵-row factorial no longer pins 10⁵ specs + 10⁵ futures in driver memory.

### Manifest contract (#134 item 3)
- New `Manifest.total_run_count` property — live total derived from the entries (`run_count + extension_run_count`). The header's `run_count` field stays frozen on disk to preserve the documented append-only / torn-tail tolerance.
- `docs/manifest-schema.md` documents both fields and points the example at `total_run_count` for extended manifests.

### RunOutcome / RunSpec validation
- `duration_s` is now sourced from `time.monotonic()`; an NTP step mid-run can't drive duration negative.
- `RunOutcome.from_dict` validates `status in {ok, failed, skipped}`; `RunSpec.from_dict` validates field types explicitly. Both raise `ValueError` naming the bad field, which `manifest._parse_entry_line` wraps to `ManifestCorruptError` and `_run_subprocess.py` maps to `_EXIT_BAD_SPEC=3`.
- `Sweep._repr_html_`'s status counter buckets unknown statuses under "other" instead of raising `KeyError`.
- `RunSpec.to_dict` / `SweepSpec.to_dict` drop per-call `dict(...)` copies — `json.dumps` doesn't mutate.

### Public-API hygiene
- `latin_hypercube_extend` is removed from `__all__` and `docs/api.md`. The function is a typed-refusal sentinel (raises `SweepConfigError` with a substantive explanation — LH extension changes stratification of every existing sample, so there is no bit-equal slice); still importable from `gmat_sweep.api` for generic wrappers that want the typed error.

## Test plan
- [x] `uv run pytest` — 661 passed, 10 skipped (optional extras).
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy src` — no issues.
- [x] New regression tests for each item: stdout recovery on exit=4, FileHandler-init failure, monotonic-duration wall-clock immunity, banana-status rejection, RunSpec field-type guards, latin_hypercube_extend public-API removal, total_run_count after extend, Pool.imap bounded in-flight + spec/outcome pairing + lazy iterator consumption, streaming grid generator.

Closes #134