### PR TITLE
Docs: fix Sweep.from_manifest examples, refresh pool inventory, correct duration_s

### DIFF
--- a/docs/backends.md
+++ b/docs/backends.md
@@ -1,8 +1,9 @@
 # Backends
 
 Every gmat-sweep run is dispatched through a `Pool` — the abstraction that
-takes a `RunSpec`, runs it, and returns a `RunOutcome`. Five concrete
-pools ship in the box:
+takes a `RunSpec`, runs it, and returns a `RunOutcome`. Seven concrete
+pools ship in the box (six listed below; `DebugPool` is the off-spec
+single-spec backend documented [further down](#debugpool-in-process-single-run-debugger-friendly)):
 
 | Pool | Install | When to pick it |
 |---|---|---|

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -57,11 +57,15 @@ does not — it never runs anything.
 | `local` (default) | [`LocalJoblibPool`][gmat_sweep.LocalJoblibPool] over loky workers | none |
 | `dask`          | [`DaskPool`][gmat_sweep.backends.DaskPool] over a `LocalCluster` | `pip install gmat-sweep[dask]` |
 | `ray`           | [`RayPool`][gmat_sweep.backends.RayPool] over a local Ray runtime | `pip install gmat-sweep[ray]` |
+| `mpi`           | [`MPIPool`][gmat_sweep.backends.MPIPool] over `mpi4py.futures` | `pip install gmat-sweep[mpi]` (plus a system MPI install) |
 
 `--workers N` maps onto each backend in the natural way: `LocalJoblibPool`
-takes it as `workers`, `DaskPool` as `n_workers`, `RayPool` as `num_cpus`.
+takes it as `max_workers`, `DaskPool` as `n_workers`, `RayPool` as `num_cpus`.
 The default `-1` means "let the pool pick" (every available core for the
 local pool, `os.cpu_count()` for Dask, Ray's own auto-detect for Ray).
+`--workers` is not supported on `--backend mpi` — the rank count is fixed
+by the MPI launcher (`mpirun -n K`) or by `--backend-arg max_workers=N`
+under dynamic spawn; passing `--workers` there exits `2`.
 
 `--backend-arg KEY=VALUE` is an escape hatch for less-common pool
 constructor kwargs. It is repeatable, values are coerced int → float → str,
@@ -81,10 +85,10 @@ gmat-sweep run --backend ray \
 ```
 
 `--backend-arg` is rejected with `--backend local` (the local pool has no
-extra kwargs to forward). Missing extras (`[dask]` / `[ray]` not installed)
-exit with code `4` and a "pip install gmat-sweep[…]" message on stderr.
-Unknown kwargs surface the same way — they reach the pool constructor and
-are rejected there.
+extra kwargs to forward). Missing extras (`[dask]` / `[ray]` / `[mpi]` not
+installed) exit with code `4` and a "pip install gmat-sweep[…]" message
+on stderr. Unknown kwargs surface the same way — they reach the pool
+constructor and are rejected there.
 
 ## Manifest fsync cadence
 

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -108,9 +108,14 @@ To export every successful run in a sweep:
 ```python
 from pathlib import Path
 
-from gmat_sweep import Sweep
+from gmat_sweep import LocalJoblibPool, Sweep
 
-sweep = Sweep.from_manifest(Path("./sweep/manifest.jsonl"))
+with LocalJoblibPool() as pool:
+    sweep = Sweep.from_manifest(
+        Path("./sweep/manifest.jsonl"),
+        Path("./mission.script"),
+        backend=pool,
+    )
 ephem = sweep.to_ephemerides()
 
 out_dir = Path("./oem")
@@ -251,12 +256,13 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
-from gmat_sweep import Manifest, Sweep
+from gmat_sweep import LocalJoblibPool, Manifest, Sweep
 
 
 def compare_sweeps(
     tool_a_root: Path,
     tool_b_root: Path,
+    script_path: Path,
     *,
     state_columns: tuple[str, ...] = ("Sat.EarthMJ2000Eq.X",
                                       "Sat.EarthMJ2000Eq.Y",
@@ -273,8 +279,13 @@ def compare_sweeps(
             f"A: {a_manifest.script_sha256[:12]}, B: {b_manifest.script_sha256[:12]}"
         )
 
-    a_df = Sweep.from_manifest(tool_a_root / "manifest.jsonl").to_dataframe()
-    b_df = Sweep.from_manifest(tool_b_root / "manifest.jsonl").to_dataframe()
+    with LocalJoblibPool() as pool:
+        a_df = Sweep.from_manifest(
+            tool_a_root / "manifest.jsonl", script_path, backend=pool
+        ).to_dataframe()
+        b_df = Sweep.from_manifest(
+            tool_b_root / "manifest.jsonl", script_path, backend=pool
+        ).to_dataframe()
 
     a_ok = {e.run_id: e.overrides for e in a_manifest.entries if e.status == "ok"}
     b_ok = {e.run_id: e.overrides for e in b_manifest.entries if e.status == "ok"}

--- a/docs/examples/06_dask_cluster_recipe.ipynb
+++ b/docs/examples/06_dask_cluster_recipe.ipynb
@@ -398,7 +398,7 @@
     "\n",
     "On a real cluster, only the `LocalCluster(...)` line above changes — the `DaskPool(client=client)` line and everything below it stays the same.\n",
     "\n",
-    "For throughput numbers across the three backends, see the [reference benchmarks](https://astro-tools.github.io/gmat-sweep/benchmarks/)."
+    "For throughput numbers across the benchmarked backends, see the [reference benchmarks](https://astro-tools.github.io/gmat-sweep/benchmarks/)."
    ]
   }
  ],

--- a/docs/examples/07_ray_autoscaling_recipe.ipynb
+++ b/docs/examples/07_ray_autoscaling_recipe.ipynb
@@ -456,7 +456,7 @@
     "\n",
     "The [Ray autoscaling recipe](https://astro-tools.github.io/gmat-sweep/recipes/ray-autoscaling/) covers the cluster YAML, the worker image discipline, and how the autoscaler responds to sweep load. The driver code is the same as this notebook — only the `ray.init(...)` line changes from `num_cpus=4` to `address=\"ray://<head-host>:10001\"`.\n",
     "\n",
-    "For throughput numbers across the three backends, see the [reference benchmarks](https://astro-tools.github.io/gmat-sweep/benchmarks/)."
+    "For throughput numbers across the benchmarked backends, see the [reference benchmarks](https://astro-tools.github.io/gmat-sweep/benchmarks/)."
    ]
   }
  ],

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -42,11 +42,15 @@ pool constructor:
   it when you compose one Dask or Ray pool across calls that load
   different `.script` files.
 
-The contract is uniform across `LocalJoblibPool`, `DaskPool`, and
-`RayPool`. Under the default, a sweep of N runs with W workers pays
-roughly W bootstraps total, not 1 and not N — for a small sweep that's
-overhead worth knowing about; for a meaningfully large sweep it is a
-rounding error.
+The contract is uniform across every shipped pool — `LocalJoblibPool`,
+`ProcessPoolExecutorPool`, `DaskPool`, `RayPool`, `KubernetesJobPool`,
+`MPIPool`, and `DebugPool` — and the `Pool` ABC enforces it on any
+third-party subclass. Under the default, a sweep of N runs with W
+workers pays roughly W bootstraps total, not 1 and not N — for a small
+sweep that's overhead worth knowing about; for a meaningfully large
+sweep it is a rounding error. `ProcessPoolExecutorPool` is the
+exception by construction: `max_tasks_per_child=1` gives every task a
+fresh interpreter, so it pays N bootstraps regardless of mode.
 
 ## Why does `gmat-sweep` depend on `gmat-run`?
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -88,7 +88,8 @@ gmat-sweep run --grid Sat.SMA=7000:7200:3 --out ./sweep mission.script
 
 - [Parameter spec](parameter-spec.md) — what overrides are valid and how
   the cartesian product is laid out.
-- [Backends](backends.md) — `LocalJoblibPool`, `DaskPool`, `RayPool`, and
+- [Backends](backends.md) — `LocalJoblibPool`, `ProcessPoolExecutorPool`,
+  `DaskPool`, `RayPool`, `KubernetesJobPool`, `MPIPool`, `DebugPool`, and
   the `reuse_gmat_context` knob that picks how the GMAT bootstrap is
   amortised across runs.
 - [Cluster recipes](recipes/index.md) — Slurm, Kubernetes, and Ray

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,8 +54,9 @@ order-independence contracts.
   vision snippet.
 - **[Parameter spec](parameter-spec.md)** — how grids, dotted-path overrides,
   and the CLI's mini-grammar work.
-- **[Backends](backends.md)** — the three pool implementations
-  (`LocalJoblibPool`, `DaskPool`, `RayPool`), the `reuse_gmat_context`
+- **[Backends](backends.md)** — the shipped pool implementations
+  (`LocalJoblibPool`, `ProcessPoolExecutorPool`, `DaskPool`, `RayPool`,
+  `KubernetesJobPool`, `MPIPool`, `DebugPool`), the `reuse_gmat_context`
   contract, and the backend-equivalence guarantee.
 - **[Monte Carlo](monte-carlo.md)** — stochastic dispersion sweeps with
   named distributions and a determinism contract.
@@ -65,13 +66,13 @@ order-independence contracts.
   sweep writes alongside its outputs.
 - **[Supported versions](supported-versions.md)** — GMAT × Python × OS matrix.
 - **[Benchmarks](benchmarks.md)** — wall-clock and throughput numbers for the
-  three backends on a 1000-run reference sweep.
+  single-machine backends on a 1000-run reference sweep.
 - **[Cookbook](cookbook.md)** — patterns for turning a sweep's outputs into
   the inputs downstream consumers need: visualisation export (CCSDS-OEM,
   CZML), cross-tool validation, and external-tool wrapping.
 - **[Cluster recipes](recipes/index.md)** — Slurm with `srun`, Kubernetes
-  pod-per-worker, and Ray autoscaling — wiring `DaskPool` and `RayPool`
-  into shared infrastructure.
+  pod-per-worker, Kubernetes Job-per-run, and Ray autoscaling — wiring
+  `DaskPool`, `KubernetesJobPool`, and `RayPool` into shared infrastructure.
 - **[FAQ](faq.md)** — subprocess isolation, the `gmat-run` dependency, and
   where to get GMAT.
 - **[API reference](api.md)** — auto-generated from docstrings.

--- a/docs/manifest-schema.md
+++ b/docs/manifest-schema.md
@@ -135,7 +135,7 @@ hashes; same for two clones with different `core.autocrlf` settings.
 | `output_paths` | Map from the prefixed output basename (`report__<name>`, `ephemeris__<name>`, `contact__<name>`) to the per-run Parquet path. Empty `{}` for non-`ok` runs. The prefix encodes the GMAT output kind so [`lazy_multiindex`][gmat_sweep.lazy_multiindex] / [`lazy_ephemerides`][gmat_sweep.lazy_ephemerides] / [`lazy_contacts`][gmat_sweep.lazy_contacts] can dispatch without reading the file. |
 | `started_at`   | UTC `datetime` the worker began this run, ISO-8601 with tz offset.                                           |
 | `ended_at`     | UTC `datetime` the worker returned its outcome, ISO-8601.                                                    |
-| `duration_s`   | `(ended_at - started_at).total_seconds()`. Computed once on the worker side; the three timing fields cannot disagree. |
+| `duration_s`   | Run duration in seconds, measured by the worker as a `time.monotonic` delta around the run body. Not equal to `(ended_at - started_at).total_seconds()` — measuring monotonically keeps `duration_s` non-negative across mid-run wall-clock corrections (NTP step), while `started_at` / `ended_at` remain wall-clock audit timestamps. |
 | `stderr`       | `null` for successful runs. For failed runs: the formatted Python traceback, optionally followed by the captured GMAT engine log. |
 | `log_path`     | Path to the worker log file (`worker.log` under the per-run output directory), or `null`. Present whether the run succeeded or failed. |
 

--- a/docs/recipes/index.md
+++ b/docs/recipes/index.md
@@ -43,14 +43,14 @@ changes.
 
 ## When none of these fits
 
-The three orchestrators above are the ones with one-shot recipes. For
+The orchestrators above are the ones with one-shot recipes. For
 anything else — AWS Batch, GCP Batch, custom MPI launchers, in-house
 schedulers — write a custom `Pool` against the
 [`Pool`][gmat_sweep.backends.Pool] ABC. Its contract is small: accept
 [`RunSpec`][gmat_sweep.spec.RunSpec]s, route each through the per-task
 subprocess hop, and yield [`RunOutcome`][gmat_sweep.spec.RunOutcome]s as
-they complete. The three shipped pools are exactly that pattern, three
-different ways.
+they complete. The shipped pools are exactly that pattern, in different
+shapes.
 
 ## Looking for the other side?
 

--- a/docs/recipes/ray-autoscaling.md
+++ b/docs/recipes/ray-autoscaling.md
@@ -152,13 +152,16 @@ profile a small sweep first, then size for the real one.
 
 ### Subprocess hop inside each Ray task
 
-Each `gmat-sweep` task runs as a Ray actor task. Inside that task, the
-sweep still does its per-run subprocess hop — `_worker_entrypoint`
-spawns a child Python that bootstraps GMAT and exits. Ray's worker
-processes themselves are long-lived (the autoscaler manages them at
-node granularity, not per task), but the subprocess hop is per task,
-not per worker. This is by design — it's the same isolation contract
-that protects sweeps on every other backend.
+Each `gmat-sweep` task runs as a Ray actor task. Under the default
+`reuse_gmat_context=True`, the task imports `gmat_run` once per worker
+and dispatches every subsequent task through
+`gmat_sweep.worker.run_one` in the same interpreter. Under
+`reuse_gmat_context=False`, the task spawns a child Python via
+`gmat_sweep.backends._subprocess.run_spec_in_subprocess` that
+bootstraps GMAT fresh and exits — per task, not per worker. Ray's
+worker processes themselves are long-lived (the autoscaler manages them
+at node granularity, not per task); the isolation contract is the same
+one that protects sweeps on every other backend.
 
 The `reuse_gmat_context=True` default still amortises bootstrap across
 the runs assigned to a single Ray worker process, so worker-level

--- a/docs/recipes/slurm.md
+++ b/docs/recipes/slurm.md
@@ -114,12 +114,15 @@ gmat_run"` before launching the sweep.
 
 ### Subprocess isolation still applies inside each worker
 
-Each Dask worker is one Python process. The sweep's per-run subprocess
-hop runs **inside** that worker — `_worker_entrypoint` spawns a child
-Python that bootstraps GMAT, runs the script, and exits. No special
-Slurm-side configuration is needed; the per-task fresh GMAT context
-that protects sweeps on a laptop protects them on Slurm in exactly the
-same way.
+Each Dask worker is one Python process. Under
+`reuse_gmat_context=True` (the default) each worker imports `gmat_run`
+once and dispatches each task through `gmat_sweep.worker.run_one` in
+the same interpreter. Under `reuse_gmat_context=False` each task spawns
+a child Python via `gmat_sweep.backends._subprocess.run_spec_in_subprocess`
+that bootstraps GMAT fresh, runs the script, and exits. No special
+Slurm-side configuration is needed in either mode; the per-task fresh
+GMAT context that protects sweeps on a laptop protects them on Slurm
+in exactly the same way.
 
 The `reuse_gmat_context=True` default still amortises bootstrap across
 the runs assigned to a single worker, so worker-level reuse remains the


### PR DESCRIPTION
## Summary

Doc drift surfaced by walking every page against the current source and re-executing all ten example notebooks. The notebooks themselves all pass; these are markdown-only fixes plus two notebook markdown-cell touch-ups.

### Hard breakage

- **`docs/cookbook.md`** had two `Sweep.from_manifest(Path("./.../manifest.jsonl"))` examples (Pattern 1 OEM export and Pattern 2 `compare_sweeps`). `from_manifest` requires `script_path` (positional) and `backend=` (keyword-only) and raises `TypeError` as written. Rewrap both with `LocalJoblibPool` and pass the required args.

### Factually wrong against the source

- **`docs/manifest-schema.md`**: `duration_s` entry was described as `(ended_at - started_at).total_seconds()` "the three timing fields cannot disagree". The worker actually measures `duration_s` from a `time.monotonic` bookend pair (see `src/gmat_sweep/spec.py`); the wall timestamps can disagree across an NTP step. Rewritten to match.
- **`docs/recipes/slurm.md`** + **`docs/recipes/ray-autoscaling.md`** referenced a `_worker_entrypoint` function that does not exist. Real symbols are `gmat_sweep.worker.run_one` (reuse path) and `gmat_sweep.backends._subprocess.run_spec_in_subprocess` (fresh-bootstrap path); paragraphs also now mention the `reuse_gmat_context` gate.

### Stale pool inventory

Many pages still enumerated "three pool implementations (`LocalJoblibPool`, `DaskPool`, `RayPool`)" but the package ships seven:

- `docs/index.md`, `docs/getting-started.md`, `docs/faq.md`, `docs/recipes/index.md`: enumerations refreshed.
- `docs/backends.md`: "Five concrete pools" → "Seven" (six in the table; `DebugPool` documented separately further down).
- `docs/cli.md` "Choosing a backend" table was missing `mpi`; CLI accepts `--backend mpi` (the missing-extras line also omitted `[mpi]`). Also fixed the `LocalJoblibPool` workers kwarg from the deprecated `workers=` to `max_workers=`.
- `docs/index.md` + two notebook markdown cells (06, 07): "three backends" benchmark reference was stale; the benchmarks page now covers five backends.

## Validation

- All 10 example notebooks (01–10) execute end-to-end against gmat-sweep 0.3.0 + gmat-run 0.4.0 + GMAT R2026a.
- `uv run ruff check` + `uv run ruff format --check` clean.
- `uv run mkdocs build --strict` succeeds.

## Test plan

- [ ] `mkdocs serve` and click through the edited pages; confirm anchors, code blocks, and tables render as intended.
- [ ] Spot-read the rewritten cookbook examples and confirm they read cleanly as worked snippets.